### PR TITLE
Get file as binary data

### DIFF
--- a/owncloud/helperFunctions.js
+++ b/owncloud/helperFunctions.js
@@ -350,7 +350,8 @@ helpers.prototype._get = function(url) {
     var options = {
         url: url,
         method: 'GET',
-        headers: headers
+        headers: headers,
+        encoding: null
     };
 
     return new Promise((resolve, reject) => {

--- a/owncloud/test/test.js
+++ b/owncloud/test/test.js
@@ -1676,7 +1676,7 @@ describe("Currently testing files management,", function () {
 
 		for (var i=0;i<testSubFiles.length;i++) {
 			oc.files.getFileContents(testSubFiles[i]).then(content => {
-				expect(content).toEqual(testContent);
+				expect(content.toString('utf8')).toEqual(testContent);
 				count++;
 				if (count === testSubFiles.length) {
 					done();
@@ -1705,7 +1705,7 @@ describe("Currently testing files management,", function () {
 			expect(status).toBe(true);
 			return oc.files.getFileContents(newFile);
 		}).then(content => {
-			expect(content).toEqual(testContent);
+			expect(content.toString('utf8')).toEqual(testContent);
 			return oc.files.delete(newFile);
 		}).then(status2 => {
 			expect(status2).toEqual(true);
@@ -1860,7 +1860,7 @@ describe("Currently testing files management,", function () {
 			expect(status).toBe(true);
 			return oc.files.getFileContents('file' + timeRightNow + '.txt');
 		}).then(content => {
-			expect(content).toEqual(testContent);
+			expect(content.toString('utf8')).toEqual(testContent);
             return oc.files.delete('file' + timeRightNow + '.txt');
 		}).then(status => {
             expect(status).toBe(true);


### PR DESCRIPTION
## Description

Default encoding setting of [requests library](https://github.com/request/request) is `utf-8`. If we download `pdf` or `mp4` file, file will be corrupted.

> encoding - encoding to be used on setEncoding of response data. If null, the body is returned as a Buffer. Anything else (including the default value of undefined) will be passed as the encoding parameter to toString() (meaning this is effectively utf8 by default). (Note: if you expect binary data, you should set encoding: null.)

-> Set encoding to `null` will solve this problem

I don't know why there are 2 failed test cases. Please give me some clues to fix it.

## Relevant issues:
- https://github.com/owncloud/js-owncloud-client/issues/45
- https://stackoverflow.com/q/50546704/2303610