### PR TITLE
Add X-Requested-With header - this is used by the server to determine…

### DIFF
--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -119,7 +119,8 @@ class helpers {
 
   buildHeaders (withAuthHeader = true) {
     let headers = {
-      'OCS-APIREQUEST': true
+      'OCS-APIREQUEST': true,
+      'X-Requested-With': 'XMLHttpRequest'
     }
     if (withAuthHeader) {
       headers['authorization'] = this._authHeader


### PR DESCRIPTION
… if the request is made by the user or via an ajax call

see http://www.checkheaders.com/headers/X-Requested-With/
see https://github.com/owncloud/core/blob/3bff5c2aca12499972f285e0cf2ea467a473c6b5/apps/dav/lib/Connector/Sabre/Auth.php#L240-L245