### PR TITLE
updateShare accepts empty password and expireDate

### DIFF
--- a/src/shareManagement.js
+++ b/src/shareManagement.js
@@ -346,13 +346,13 @@ class Shares {
       if (optionalParams.permissions) {
         postData.permissions = optionalParams.permissions
       }
-      if (optionalParams.password) {
-        postData.password = optionalParams.password
-      }
       if (optionalParams.name) {
         postData.name = optionalParams.name
       }
-      if (optionalParams.expireDate) {
+      if (optionalParams.password !== undefined) {
+        postData.password = optionalParams.password
+      }
+      if (optionalParams.expireDate !== undefined) {
         postData.expireDate = optionalParams.expireDate
       }
       if (optionalParams.publicUpload && typeof (optionalParams.publicUpload) === 'boolean') {


### PR DESCRIPTION
`updateShare()` now accepts empty strings as valid input, to be able to remove set values from a share.