### PR TITLE
Add json format to capabilities request

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -54,6 +54,7 @@ steps:
   - "cd /var/www/owncloud"
   - php occ config:system:set trusted_domains 1 --value=owncloud
   - php occ config:system:set cors.allowed-domains 0 --value=http://localhost:9876
+  - php occ config:system:set dav.enable.tech_preview --value=true  --type=boolean
   - php occ log:manage --level 0
   - php occ config:list
   - "chown www-data * -R"
@@ -205,6 +206,7 @@ steps:
   - "cd /var/www/owncloud/sub/"
   - php occ config:system:set trusted_domains 1 --value=owncloud
   - php occ config:system:set cors.allowed-domains 0 --value=http://localhost:9876
+  - php occ config:system:set dav.enable.tech_preview --value=true --type=boolean
   - php occ log:manage --level 0
   - php occ config:list
   - "chown www-data * -R"

--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -75,7 +75,7 @@ class helpers {
    * @returns {object}    all capabilities
    */
   getCapabilities () {
-    return this._makeOCSrequest('GET', this.OCS_SERVICE_CLOUD, 'capabilities')
+    return this._makeOCSrequest('GET', this.OCS_SERVICE_CLOUD, 'capabilities?format=json')
       .then(data => {
         const body = data.data.ocs.data
         this._versionNumber = body.version.major + '.' + body.version.minor + '.' + body.version.micro

--- a/tests/capabilitiesTest.js
+++ b/tests/capabilitiesTest.js
@@ -51,7 +51,7 @@ describe('Main: Currently testing getConfig, getVersion and getCapabilities', fu
       expect(capabilities.capabilities.files).not.toBe(undefined)
 
       // Big file chunking of files app is always on
-      expect(parseInt(capabilities.capabilities.files.bigfilechunking)).toEqual(1)
+      expect(capabilities.capabilities.files.bigfilechunking).toEqual(true)
       done()
     }).catch(error => {
       fail(error)


### PR DESCRIPTION
## Motivation
When we got response in XML format the booleans were translated into string which caused desync between oc and reva.

@refs 