### PR TITLE
fix typos

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 workspace:
   base: /var/www/owncloud
-  path: onwcloud-sdk
+  path: owncloud-sdk
 
 steps:
 - name: increment-version
@@ -160,7 +160,7 @@ platform:
 
 workspace:
   base: /var/www/owncloud
-  path: onwcloud-sdk
+  path: owncloud-sdk
 
 steps:
 - name: increment-version

--- a/src/fileInfo.js
+++ b/src/fileInfo.js
@@ -99,7 +99,7 @@ class FileInfo {
   }
 
   /**
-   * Checks wether the information is for a folder
+   * Checks whether the information is for a folder
    * @returns {boolean}   true if folder
    */
   isDir () {

--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -394,7 +394,7 @@ class helpers {
 
   /**
    * converts all of object's "true" or "false" entries to booleans
-   * @param   {object}    object  object to be typcasted
+   * @param   {object}    object  object to be typecasted
    * @return  {object}            typecasted object
    */
   _convertObjectToBool (object) {
@@ -415,7 +415,7 @@ class helpers {
   }
 
   /**
-   * Handles Provisionging API boolean response
+   * Handles Provisioning API boolean response
    */
   _OCSuserResponseHandler (data, resolve, reject) {
     const statuscode = parseInt(this._checkOCSstatusCode(data.data))

--- a/src/owncloud.js
+++ b/src/owncloud.js
@@ -110,7 +110,7 @@ class ownCloud {
   /**
    * Gets the ownCloud app capabilities
    * @returns {Promise.<capabilities>}    string: ownCloud version
-   * @returns {Promise.<reject>}             object: capabilites
+   * @returns {Promise.<reject>}             object: capabilities
    */
   getCapabilities () {
     return this.helpers.getCapabilities()

--- a/src/shareInfo.js
+++ b/src/shareInfo.js
@@ -150,7 +150,7 @@ class ShareInfo {
   /**
    * Typecasts to integer
    * @param   {string}    [key]   Corresponding key element to be typecasted to an integer
-   * @returns {number}           typcasted integer
+   * @returns {number}           typecasted integer
    */
   _getInt (key) {
     return parseInt(this.shareInfo[key])

--- a/src/systemTags.js
+++ b/src/systemTags.js
@@ -59,7 +59,7 @@ class SystemTags {
   }
 
   /**
-   * Assing a tag to a file/folder
+   * Assign a tag to a file/folder
    * @param   {number}   fileId            id of the file/folder
    * @param   {number}   tagId             id of the tag
    * @returns {Promise}                    resolves if successful

--- a/src/userManagement.js
+++ b/src/userManagement.js
@@ -38,7 +38,7 @@ class Users {
   /**
    * Creates user via the provisioning API<br>
    * If user already exists, an error is given back : "User already exists"<br>
-   * If provisoning API has been disabled, an error is given back saying the same.
+   * If provisioning API has been disabled, an error is given back saying the same.
    *
    * @param      {string}  userName     username of the new user to be created
    * @param      {string}  password     password of the new user to be created

--- a/tests/requestsOcsTest.js
+++ b/tests/requestsOcsTest.js
@@ -75,7 +75,7 @@ describe('Main: Currently testing low level OCS', function () {
   })
 
   it('checking : PUT email', function (done) {
-    const testUser = 'testuer' + new Date().getTime()
+    const testUser = 'testuser' + new Date().getTime()
     oc.users.createUser(testUser, testUser).then(() => {
       return oc.requests.ocs({
         method: 'PUT',


### PR DESCRIPTION
I noticed the `.drone.yml` typo in a chat screenshot. Thought I may as well run the spell-checker over the code.