### PR TITLE
allow empty share name when updating shares

### DIFF
--- a/src/shareManagement.js
+++ b/src/shareManagement.js
@@ -354,7 +354,7 @@ class Shares {
       if (optionalParams.permissions) {
         postData.permissions = optionalParams.permissions
       }
-      if (optionalParams.name) {
+      if (optionalParams.name !== undefined) {
         postData.name = optionalParams.name
       }
       if (optionalParams.password !== undefined) {


### PR DESCRIPTION
Currently, creating a public link share with empty name is possible, but updateShare ignores name parameter when its empty. 

This pr fixes that behavior and allows updating a link share with empty name.