### PR TITLE
Merged token and path in public list and fileinfo

### DIFF
--- a/src/publicLinkAccess.js
+++ b/src/publicLinkAccess.js
@@ -32,16 +32,16 @@ class PublicFiles {
   /**
    * Lists files in a public link as determined by the given token
    *
-   * @param {string}      token
+   * @param {string}      tokenAndPath
    * @param {string}      path
    * @param {string|null} password
    * @param {array}       properties
    * @param {string}      depth
    * @return {FileInfo[]}
    */
-  async list (token, path = null, password = null, properties = [], depth = '1') {
+  async list (tokenAndPath, password = null, properties = [], depth = '1') {
     const headers = this.helpers.buildHeaders(false)
-    const url = this.getFileUrl(token, path)
+    const url = this.getFileUrl(tokenAndPath)
 
     if (password) {
       headers.authorization = 'Basic ' + Buffer.from('public:' + password).toString('base64')
@@ -261,15 +261,14 @@ class PublicFiles {
 
   /**
    * Returns the file info for the given public resource
-   * @param {string} token public share token
-   * @param {string} path path to the resource
+   * @param {string} tokenAndPath public share token and path to the resource
    * @param {string|null} password public link's password
    * @param {Array} properties WebDAV properties
    * @returns {FileInfo} instance of class fileInfo
    * @returns {Promise.<error>} error, if exists.
    */
-  async getFileInfo (token, path, password = null, properties = []) {
-    const fileInfo = await this.list(token, path, password, properties, '0')
+  async getFileInfo (tokenAndPath, password = null, properties = []) {
+    const fileInfo = await this.list(tokenAndPath, password, properties, '0')
 
     return fileInfo[0] ? fileInfo[0] : fileInfo
   }

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -144,7 +144,7 @@ describe('oc.publicFiles', function () {
         })
 
         it('should list the folder contents', function (done) {
-          oc.publicFiles.list(testFolderShare.getToken(), null, data.passwordWhenListing).then(files => {
+          oc.publicFiles.list(testFolderShare.getToken(), data.passwordWhenListing).then(files => {
             if (data.shallGrantAccess) {
               // test length
               expect(files.length).toBe(4)
@@ -352,7 +352,6 @@ describe('oc.publicFiles', function () {
           const sharedFolder = testFolderShare.getToken()
           const folder = await oc.publicFiles.getFileInfo(
             sharedFolder,
-            null,
             data.shareParams.password
           )
 


### PR DESCRIPTION
## Motivation
In my prev PR (#437) I separated in the list method in publicAccess the token and path. However, this brings more complexity where it's being used since we might need to take care of separating those two then. By uniting them again we save effort on the client side.