### PR TITLE
Use plugins/codecov:latest

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -91,7 +91,7 @@ steps:
 
 - name: codecov
   pull: always
-  image: plugins/codecov:2
+  image: plugins/codecov:latest
   settings:
     files:
       - "*.info"
@@ -243,7 +243,7 @@ steps:
 
 - name: codecov
   pull: always
-  image: plugins/codecov:2
+  image: plugins/codecov:latest
   settings:
     files:
       - "*.info"


### PR DESCRIPTION
The older docker image has out-of-date codecov upload scripts.

Similar to https://github.com/owncloud/core/pull/37416