### PR TITLE
Return empty array when listing of settings values is empty

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -37,7 +37,7 @@ class SettingsValues {
         }
       })
       if (response.status === 201) {
-        return Promise.resolve(response.data.settingsValues)
+        return Promise.resolve(response.data.settingsValues || [])
       }
     } catch (error) {
       // fail on anything except settings service being unavailable


### PR DESCRIPTION
For technical reasons the api response is `undefined` instead of
an empty array when there are no settings values for the given user.
We want to provide an empty array instead, so that consumers of the
SDK can rely on dealing with a valid list (which is empty).