### PR TITLE
Integrate owncloud-sign-url

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,7 +39,7 @@ steps:
   pull: always
   image: owncloudci/core
   settings:
-    GIT_REFERENCE: "master"
+    GIT_REFERENCE: "feature/pre-signed-url"
     core_path: "/var/www/owncloud"
     db_host: "sqlite"
     db_name: "sqlite"
@@ -191,7 +191,7 @@ steps:
   pull: always
   image: owncloudci/core
   settings:
-    GIT_REFERENCE: "master"
+    GIT_REFERENCE: "feature/pre-signed-url"
     core_path: "/var/www/owncloud/sub/"
     db_host: "sqlite"
     db_name: "sqlite"

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "axios": "^0.19.2",
     "browser-request": "^0.3.3",
     "davclient.js": "https://github.com/owncloud/davclient.js.git",
+    "owncloud-sign-url": "^1.0.0",
     "promise": "^8.0.3",
     "request": "^2.88.0",
     "utf8": "^3.0.0",

--- a/src/owncloud.js
+++ b/src/owncloud.js
@@ -58,6 +58,9 @@ class ownCloud {
     if (options.userInfo) {
       helpers.setCurrentUser(options.userInfo)
     }
+    if (options.signingKey) {
+      helpers.setSigningKey(options.signingKey)
+    }
     if (options.headers) {
       helpers.setHeaders(options.headers)
     }
@@ -125,6 +128,18 @@ class ownCloud {
    */
   getCurrentUser () {
     return this.helpers.getCurrentUserAsync()
+  }
+
+  /**
+   *
+   * @param {string} url
+   * @param {number} ttl
+   * @param {string} httpMethod
+   *
+   * @returns {Promise}
+   */
+  signUrl (url, ttl = 1200, httpMethod = 'get') {
+    return this.helpers.signUrl(url, ttl, httpMethod)
   }
 }
 

--- a/tests/signedUrlIntegrationTest.js
+++ b/tests/signedUrlIntegrationTest.js
@@ -1,0 +1,46 @@
+describe('Signed urls', function () {
+  var OwnCloud = require('../src/owncloud')
+  var config = require('./config/config.json')
+
+  // LIBRARY INSTANCE
+  var oc
+
+  beforeEach(function (done) {
+    oc = new OwnCloud({
+      baseUrl: config.owncloudURL,
+      auth: {
+        basic: {
+          username: config.username,
+          password: config.password
+        }
+      }
+    })
+
+    oc.login().then(status => {
+      expect(status).toEqual({ id: 'admin', 'display-name': 'admin', email: {} })
+      done()
+    }).catch(error => {
+      expect(error).toBe(null)
+      done()
+    })
+  })
+
+  afterEach(function () {
+    oc.logout()
+    oc = null
+  })
+
+  it('should allow file download with a signUrl', async function (done) {
+    const newFolder = 'test-folder-' + Math.random().toString(36).substr(2, 9)
+    await oc.files.createFolder(newFolder)
+    await oc.files.putFileContents(newFolder + '/file.txt', '123456')
+    const url = oc.files.getFileUrlV2(newFolder + '/file.txt')
+    const signedUrl = await oc.signUrl(url)
+    const response = await fetch(signedUrl)
+    expect(response.ok).toEqual(true)
+    const txt = await response.text()
+    expect(txt).toEqual('123456')
+
+    done()
+  })
+})

--- a/tests/signedUrlTest.js
+++ b/tests/signedUrlTest.js
@@ -1,0 +1,55 @@
+describe('Main: Currently testing url signing,', function () {
+  var OwnCloud = require('../src/owncloud')
+  var config = require('./config/config.json')
+
+  // LIBRARY INSTANCE
+  var oc
+  // saved date object
+  var realDate
+
+  beforeEach(function () {
+    oc = null
+
+    // Setup
+    const currentDate = new Date('2019-05-14T11:01:58.135Z')
+    realDate = Date
+    global.Date = class extends Date {
+      constructor (date) {
+        if (date) {
+          return super(date) // eslint-disable-line constructor-super
+        }
+
+        return currentDate
+      }
+    }
+  })
+
+  afterEach(function () {
+    // Cleanup
+    global.Date = realDate
+  })
+
+  it('checking method : signUrl', function (done) {
+    oc = new OwnCloud({
+      baseUrl: config.owncloudURL,
+      auth: {
+        basic: {
+          username: config.username,
+          password: config.password
+        }
+      },
+      signingKey: '1234567890',
+      userInfo: {
+        id: 'alice'
+      }
+    })
+
+    oc.signUrl('http://cloud.example.net').then(signedUrl => {
+      expect(signedUrl).toEqual('http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6')
+      done()
+    }).catch(error => {
+      fail(error)
+      done()
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4951,6 +4951,11 @@ os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
+owncloud-sign-url@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/owncloud-sign-url/-/owncloud-sign-url-1.0.0.tgz#10254817043c2c66d58952f3fd7979538b86fd44"
+  integrity sha512-5sEMnsfTcnlOuhWIu834Z1LK4V4BTdGhtnGk8viiY97zqSLSvlZyfi9oFvWFx6COrJARJqOvlVLoaaKJCSzrgw==
+
 p-defer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"


### PR DESCRIPTION
This introduces url signing for owncloud - starting to be shipped as of 10.6(?)

```javascript
    // get an absolute url to a file - will work with webdav v1 as well
    const url = oc.files.getFileUrlV2('/file.txt')
    // sign the url - optional parameters are ttl and httpMethod
    const signedUrl = await oc.signUrl(url)
    // a simple fetch without additional headers can be done using the signed url
    const response = await fetch(signedUrl)
    expect(response.ok).toEqual(true)
    const txt = await response.text()