### PR TITLE
Adapt request to settings service to new API endpoint params

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,5 @@ codecov:
   ci:
     - drone.owncloud.com
     - !appveyor
+  ignore:
+    - "vendor/settingsClient.js"

--- a/src/settings.js
+++ b/src/settings.js
@@ -35,7 +35,7 @@ class SettingsValues {
         }
       })
       if (response.status === 201) {
-        return Promise.resolve(response.data.settingsValues || [])
+        return Promise.resolve(response.data.values || [])
       }
     } catch (error) {
       // fail on anything except settings service being unavailable

--- a/src/settings.js
+++ b/src/settings.js
@@ -2,9 +2,9 @@ const SettingsClient = require('../vendor/settingsClient')
 const Promise = require('promise')
 
 /**
- * @class SettingsValues
+ * @class Settings
  * @classdesc
- * <b><i> The SettingsValues class provides access to all settings values of the (most of the time authenticated) user.</i></b>
+ * <b><i> The Settings class provides access to all settings values of the (most of the time authenticated) user.</i></b>
  *
  * @author Benedikt Kulmann
  * @version 1.0.0
@@ -28,7 +28,7 @@ class SettingsValues {
   async getSettingsValues (accountUuid = 'me') {
     try {
       const baseUrl = this.helpers.getInstance().replace(/\/$/, '')
-      const response = await SettingsClient.ValueService_ListSettingsValues({
+      const response = await SettingsClient.ValueService_ListValues({
         $domain: baseUrl,
         body: {
           account_uuid: accountUuid

--- a/src/settings.js
+++ b/src/settings.js
@@ -31,9 +31,7 @@ class SettingsValues {
       const response = await SettingsClient.ValueService_ListSettingsValues({
         $domain: baseUrl,
         body: {
-          identifier: {
-            account_uuid: accountUuid
-          }
+          account_uuid: accountUuid
         }
       })
       if (response.status === 201) {
@@ -41,7 +39,7 @@ class SettingsValues {
       }
     } catch (error) {
       // fail on anything except settings service being unavailable
-      if (error.response.status !== 502 && error.response.status !== 404) {
+      if (error.response && error.response.status !== 502 && error.response.status !== 404) {
         return Promise.reject(error)
       }
     }

--- a/vendor/settingsClient.js
+++ b/vendor/settingsClient.js
@@ -30,13 +30,151 @@ export const request = (method, url, body, queryParameters, form, config) => {
  ==========================================================*/
 /**
  *
- * request: BundleService_GetSettingsBundle
- * url: BundleService_GetSettingsBundleURL
- * method: BundleService_GetSettingsBundle_TYPE
- * raw_url: BundleService_GetSettingsBundle_RAW_URL
+ * request: RoleService_AssignRoleToUser
+ * url: RoleService_AssignRoleToUserURL
+ * method: RoleService_AssignRoleToUser_TYPE
+ * raw_url: RoleService_AssignRoleToUser_RAW_URL
  * @param body -
  */
-export const BundleService_GetSettingsBundle = function(parameters = {}) {
+export const RoleService_AssignRoleToUser = function(parameters = {}) {
+  const domain = parameters.$domain ? parameters.$domain : getDomain()
+  const config = parameters.$config
+  let path = '/api/v0/settings/assignments-add'
+  let body
+  let queryParameters = {}
+  let form = {}
+  if (parameters['body'] !== undefined) {
+    body = parameters['body']
+  }
+  if (parameters['body'] === undefined) {
+    return Promise.reject(new Error('Missing required  parameter: body'))
+  }
+  if (parameters.$queryParameters) {
+    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
+    });
+  }
+  return request('post', domain + path, body, queryParameters, form, config)
+}
+export const RoleService_AssignRoleToUser_RAW_URL = function() {
+  return '/api/v0/settings/assignments-add'
+}
+export const RoleService_AssignRoleToUser_TYPE = function() {
+  return 'post'
+}
+export const RoleService_AssignRoleToUserURL = function(parameters = {}) {
+  let queryParameters = {}
+  const domain = parameters.$domain ? parameters.$domain : getDomain()
+  let path = '/api/v0/settings/assignments-add'
+  if (parameters.$queryParameters) {
+    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
+    })
+  }
+  let keys = Object.keys(queryParameters)
+  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
+}
+/**
+ *
+ * request: RoleService_ListRoleAssignments
+ * url: RoleService_ListRoleAssignmentsURL
+ * method: RoleService_ListRoleAssignments_TYPE
+ * raw_url: RoleService_ListRoleAssignments_RAW_URL
+ * @param body -
+ */
+export const RoleService_ListRoleAssignments = function(parameters = {}) {
+  const domain = parameters.$domain ? parameters.$domain : getDomain()
+  const config = parameters.$config
+  let path = '/api/v0/settings/assignments-list'
+  let body
+  let queryParameters = {}
+  let form = {}
+  if (parameters['body'] !== undefined) {
+    body = parameters['body']
+  }
+  if (parameters['body'] === undefined) {
+    return Promise.reject(new Error('Missing required  parameter: body'))
+  }
+  if (parameters.$queryParameters) {
+    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
+    });
+  }
+  return request('post', domain + path, body, queryParameters, form, config)
+}
+export const RoleService_ListRoleAssignments_RAW_URL = function() {
+  return '/api/v0/settings/assignments-list'
+}
+export const RoleService_ListRoleAssignments_TYPE = function() {
+  return 'post'
+}
+export const RoleService_ListRoleAssignmentsURL = function(parameters = {}) {
+  let queryParameters = {}
+  const domain = parameters.$domain ? parameters.$domain : getDomain()
+  let path = '/api/v0/settings/assignments-list'
+  if (parameters.$queryParameters) {
+    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
+    })
+  }
+  let keys = Object.keys(queryParameters)
+  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
+}
+/**
+ *
+ * request: RoleService_RemoveRoleFromUser
+ * url: RoleService_RemoveRoleFromUserURL
+ * method: RoleService_RemoveRoleFromUser_TYPE
+ * raw_url: RoleService_RemoveRoleFromUser_RAW_URL
+ * @param body -
+ */
+export const RoleService_RemoveRoleFromUser = function(parameters = {}) {
+  const domain = parameters.$domain ? parameters.$domain : getDomain()
+  const config = parameters.$config
+  let path = '/api/v0/settings/assignments-remove'
+  let body
+  let queryParameters = {}
+  let form = {}
+  if (parameters['body'] !== undefined) {
+    body = parameters['body']
+  }
+  if (parameters['body'] === undefined) {
+    return Promise.reject(new Error('Missing required  parameter: body'))
+  }
+  if (parameters.$queryParameters) {
+    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
+    });
+  }
+  return request('post', domain + path, body, queryParameters, form, config)
+}
+export const RoleService_RemoveRoleFromUser_RAW_URL = function() {
+  return '/api/v0/settings/assignments-remove'
+}
+export const RoleService_RemoveRoleFromUser_TYPE = function() {
+  return 'post'
+}
+export const RoleService_RemoveRoleFromUserURL = function(parameters = {}) {
+  let queryParameters = {}
+  const domain = parameters.$domain ? parameters.$domain : getDomain()
+  let path = '/api/v0/settings/assignments-remove'
+  if (parameters.$queryParameters) {
+    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
+    })
+  }
+  let keys = Object.keys(queryParameters)
+  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
+}
+/**
+ *
+ * request: BundleService_GetBundle
+ * url: BundleService_GetBundleURL
+ * method: BundleService_GetBundle_TYPE
+ * raw_url: BundleService_GetBundle_RAW_URL
+ * @param body -
+ */
+export const BundleService_GetBundle = function(parameters = {}) {
   const domain = parameters.$domain ? parameters.$domain : getDomain()
   const config = parameters.$config
   let path = '/api/v0/settings/bundle-get'
@@ -56,13 +194,13 @@ export const BundleService_GetSettingsBundle = function(parameters = {}) {
   }
   return request('post', domain + path, body, queryParameters, form, config)
 }
-export const BundleService_GetSettingsBundle_RAW_URL = function() {
+export const BundleService_GetBundle_RAW_URL = function() {
   return '/api/v0/settings/bundle-get'
 }
-export const BundleService_GetSettingsBundle_TYPE = function() {
+export const BundleService_GetBundle_TYPE = function() {
   return 'post'
 }
-export const BundleService_GetSettingsBundleURL = function(parameters = {}) {
+export const BundleService_GetBundleURL = function(parameters = {}) {
   let queryParameters = {}
   const domain = parameters.$domain ? parameters.$domain : getDomain()
   let path = '/api/v0/settings/bundle-get'
@@ -76,13 +214,13 @@ export const BundleService_GetSettingsBundleURL = function(parameters = {}) {
 }
 /**
  *
- * request: BundleService_SaveSettingsBundle
- * url: BundleService_SaveSettingsBundleURL
- * method: BundleService_SaveSettingsBundle_TYPE
- * raw_url: BundleService_SaveSettingsBundle_RAW_URL
+ * request: BundleService_SaveBundle
+ * url: BundleService_SaveBundleURL
+ * method: BundleService_SaveBundle_TYPE
+ * raw_url: BundleService_SaveBundle_RAW_URL
  * @param body -
  */
-export const BundleService_SaveSettingsBundle = function(parameters = {}) {
+export const BundleService_SaveBundle = function(parameters = {}) {
   const domain = parameters.$domain ? parameters.$domain : getDomain()
   const config = parameters.$config
   let path = '/api/v0/settings/bundle-save'
@@ -102,13 +240,13 @@ export const BundleService_SaveSettingsBundle = function(parameters = {}) {
   }
   return request('post', domain + path, body, queryParameters, form, config)
 }
-export const BundleService_SaveSettingsBundle_RAW_URL = function() {
+export const BundleService_SaveBundle_RAW_URL = function() {
   return '/api/v0/settings/bundle-save'
 }
-export const BundleService_SaveSettingsBundle_TYPE = function() {
+export const BundleService_SaveBundle_TYPE = function() {
   return 'post'
 }
-export const BundleService_SaveSettingsBundleURL = function(parameters = {}) {
+export const BundleService_SaveBundleURL = function(parameters = {}) {
   let queryParameters = {}
   const domain = parameters.$domain ? parameters.$domain : getDomain()
   let path = '/api/v0/settings/bundle-save'
@@ -122,13 +260,59 @@ export const BundleService_SaveSettingsBundleURL = function(parameters = {}) {
 }
 /**
  *
- * request: BundleService_ListSettingsBundles
- * url: BundleService_ListSettingsBundlesURL
- * method: BundleService_ListSettingsBundles_TYPE
- * raw_url: BundleService_ListSettingsBundles_RAW_URL
+ * request: BundleService_AddSettingToBundle
+ * url: BundleService_AddSettingToBundleURL
+ * method: BundleService_AddSettingToBundle_TYPE
+ * raw_url: BundleService_AddSettingToBundle_RAW_URL
  * @param body -
  */
-export const BundleService_ListSettingsBundles = function(parameters = {}) {
+export const BundleService_AddSettingToBundle = function(parameters = {}) {
+  const domain = parameters.$domain ? parameters.$domain : getDomain()
+  const config = parameters.$config
+  let path = '/api/v0/settings/bundles-add-setting'
+  let body
+  let queryParameters = {}
+  let form = {}
+  if (parameters['body'] !== undefined) {
+    body = parameters['body']
+  }
+  if (parameters['body'] === undefined) {
+    return Promise.reject(new Error('Missing required  parameter: body'))
+  }
+  if (parameters.$queryParameters) {
+    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
+    });
+  }
+  return request('post', domain + path, body, queryParameters, form, config)
+}
+export const BundleService_AddSettingToBundle_RAW_URL = function() {
+  return '/api/v0/settings/bundles-add-setting'
+}
+export const BundleService_AddSettingToBundle_TYPE = function() {
+  return 'post'
+}
+export const BundleService_AddSettingToBundleURL = function(parameters = {}) {
+  let queryParameters = {}
+  const domain = parameters.$domain ? parameters.$domain : getDomain()
+  let path = '/api/v0/settings/bundles-add-setting'
+  if (parameters.$queryParameters) {
+    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
+    })
+  }
+  let keys = Object.keys(queryParameters)
+  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
+}
+/**
+ *
+ * request: BundleService_ListBundles
+ * url: BundleService_ListBundlesURL
+ * method: BundleService_ListBundles_TYPE
+ * raw_url: BundleService_ListBundles_RAW_URL
+ * @param body -
+ */
+export const BundleService_ListBundles = function(parameters = {}) {
   const domain = parameters.$domain ? parameters.$domain : getDomain()
   const config = parameters.$config
   let path = '/api/v0/settings/bundles-list'
@@ -148,13 +332,13 @@ export const BundleService_ListSettingsBundles = function(parameters = {}) {
   }
   return request('post', domain + path, body, queryParameters, form, config)
 }
-export const BundleService_ListSettingsBundles_RAW_URL = function() {
+export const BundleService_ListBundles_RAW_URL = function() {
   return '/api/v0/settings/bundles-list'
 }
-export const BundleService_ListSettingsBundles_TYPE = function() {
+export const BundleService_ListBundles_TYPE = function() {
   return 'post'
 }
-export const BundleService_ListSettingsBundlesURL = function(parameters = {}) {
+export const BundleService_ListBundlesURL = function(parameters = {}) {
   let queryParameters = {}
   const domain = parameters.$domain ? parameters.$domain : getDomain()
   let path = '/api/v0/settings/bundles-list'
@@ -168,16 +352,16 @@ export const BundleService_ListSettingsBundlesURL = function(parameters = {}) {
 }
 /**
  *
- * request: ValueService_GetSettingsValue
- * url: ValueService_GetSettingsValueURL
- * method: ValueService_GetSettingsValue_TYPE
- * raw_url: ValueService_GetSettingsValue_RAW_URL
+ * request: BundleService_RemoveSettingFromBundle
+ * url: BundleService_RemoveSettingFromBundleURL
+ * method: BundleService_RemoveSettingFromBundle_TYPE
+ * raw_url: BundleService_RemoveSettingFromBundle_RAW_URL
  * @param body -
  */
-export const ValueService_GetSettingsValue = function(parameters = {}) {
+export const BundleService_RemoveSettingFromBundle = function(parameters = {}) {
   const domain = parameters.$domain ? parameters.$domain : getDomain()
   const config = parameters.$config
-  let path = '/api/v0/settings/value-get'
+  let path = '/api/v0/settings/bundles-remove-setting'
   let body
   let queryParameters = {}
   let form = {}
@@ -194,16 +378,16 @@ export const ValueService_GetSettingsValue = function(parameters = {}) {
   }
   return request('post', domain + path, body, queryParameters, form, config)
 }
-export const ValueService_GetSettingsValue_RAW_URL = function() {
-  return '/api/v0/settings/value-get'
+export const BundleService_RemoveSettingFromBundle_RAW_URL = function() {
+  return '/api/v0/settings/bundles-remove-setting'
 }
-export const ValueService_GetSettingsValue_TYPE = function() {
+export const BundleService_RemoveSettingFromBundle_TYPE = function() {
   return 'post'
 }
-export const ValueService_GetSettingsValueURL = function(parameters = {}) {
+export const BundleService_RemoveSettingFromBundleURL = function(parameters = {}) {
   let queryParameters = {}
   const domain = parameters.$domain ? parameters.$domain : getDomain()
-  let path = '/api/v0/settings/value-get'
+  let path = '/api/v0/settings/bundles-remove-setting'
   if (parameters.$queryParameters) {
     Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
       queryParameters[parameterName] = parameters.$queryParameters[parameterName]
@@ -214,16 +398,16 @@ export const ValueService_GetSettingsValueURL = function(parameters = {}) {
 }
 /**
  *
- * request: ValueService_SaveSettingsValue
- * url: ValueService_SaveSettingsValueURL
- * method: ValueService_SaveSettingsValue_TYPE
- * raw_url: ValueService_SaveSettingsValue_RAW_URL
+ * request: RoleService_ListRoles
+ * url: RoleService_ListRolesURL
+ * method: RoleService_ListRoles_TYPE
+ * raw_url: RoleService_ListRoles_RAW_URL
  * @param body -
  */
-export const ValueService_SaveSettingsValue = function(parameters = {}) {
+export const RoleService_ListRoles = function(parameters = {}) {
   const domain = parameters.$domain ? parameters.$domain : getDomain()
   const config = parameters.$config
-  let path = '/api/v0/settings/value-save'
+  let path = '/api/v0/settings/roles-list'
   let body
   let queryParameters = {}
   let form = {}
@@ -240,16 +424,16 @@ export const ValueService_SaveSettingsValue = function(parameters = {}) {
   }
   return request('post', domain + path, body, queryParameters, form, config)
 }
-export const ValueService_SaveSettingsValue_RAW_URL = function() {
-  return '/api/v0/settings/value-save'
+export const RoleService_ListRoles_RAW_URL = function() {
+  return '/api/v0/settings/roles-list'
 }
-export const ValueService_SaveSettingsValue_TYPE = function() {
+export const RoleService_ListRoles_TYPE = function() {
   return 'post'
 }
-export const ValueService_SaveSettingsValueURL = function(parameters = {}) {
+export const RoleService_ListRolesURL = function(parameters = {}) {
   let queryParameters = {}
   const domain = parameters.$domain ? parameters.$domain : getDomain()
-  let path = '/api/v0/settings/value-save'
+  let path = '/api/v0/settings/roles-list'
   if (parameters.$queryParameters) {
     Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
       queryParameters[parameterName] = parameters.$queryParameters[parameterName]
@@ -260,13 +444,59 @@ export const ValueService_SaveSettingsValueURL = function(parameters = {}) {
 }
 /**
  *
- * request: ValueService_ListSettingsValues
- * url: ValueService_ListSettingsValuesURL
- * method: ValueService_ListSettingsValues_TYPE
- * raw_url: ValueService_ListSettingsValues_RAW_URL
+ * request: ValueService_GetValue
+ * url: ValueService_GetValueURL
+ * method: ValueService_GetValue_TYPE
+ * raw_url: ValueService_GetValue_RAW_URL
  * @param body -
  */
-export const ValueService_ListSettingsValues = function(parameters = {}) {
+export const ValueService_GetValue = function(parameters = {}) {
+  const domain = parameters.$domain ? parameters.$domain : getDomain()
+  const config = parameters.$config
+  let path = '/api/v0/settings/values-get'
+  let body
+  let queryParameters = {}
+  let form = {}
+  if (parameters['body'] !== undefined) {
+    body = parameters['body']
+  }
+  if (parameters['body'] === undefined) {
+    return Promise.reject(new Error('Missing required  parameter: body'))
+  }
+  if (parameters.$queryParameters) {
+    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
+    });
+  }
+  return request('post', domain + path, body, queryParameters, form, config)
+}
+export const ValueService_GetValue_RAW_URL = function() {
+  return '/api/v0/settings/values-get'
+}
+export const ValueService_GetValue_TYPE = function() {
+  return 'post'
+}
+export const ValueService_GetValueURL = function(parameters = {}) {
+  let queryParameters = {}
+  const domain = parameters.$domain ? parameters.$domain : getDomain()
+  let path = '/api/v0/settings/values-get'
+  if (parameters.$queryParameters) {
+    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
+    })
+  }
+  let keys = Object.keys(queryParameters)
+  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
+}
+/**
+ *
+ * request: ValueService_ListValues
+ * url: ValueService_ListValuesURL
+ * method: ValueService_ListValues_TYPE
+ * raw_url: ValueService_ListValues_RAW_URL
+ * @param body -
+ */
+export const ValueService_ListValues = function(parameters = {}) {
   const domain = parameters.$domain ? parameters.$domain : getDomain()
   const config = parameters.$config
   let path = '/api/v0/settings/values-list'
@@ -286,16 +516,62 @@ export const ValueService_ListSettingsValues = function(parameters = {}) {
   }
   return request('post', domain + path, body, queryParameters, form, config)
 }
-export const ValueService_ListSettingsValues_RAW_URL = function() {
+export const ValueService_ListValues_RAW_URL = function() {
   return '/api/v0/settings/values-list'
 }
-export const ValueService_ListSettingsValues_TYPE = function() {
+export const ValueService_ListValues_TYPE = function() {
   return 'post'
 }
-export const ValueService_ListSettingsValuesURL = function(parameters = {}) {
+export const ValueService_ListValuesURL = function(parameters = {}) {
   let queryParameters = {}
   const domain = parameters.$domain ? parameters.$domain : getDomain()
   let path = '/api/v0/settings/values-list'
+  if (parameters.$queryParameters) {
+    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
+    })
+  }
+  let keys = Object.keys(queryParameters)
+  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
+}
+/**
+ *
+ * request: ValueService_SaveValue
+ * url: ValueService_SaveValueURL
+ * method: ValueService_SaveValue_TYPE
+ * raw_url: ValueService_SaveValue_RAW_URL
+ * @param body -
+ */
+export const ValueService_SaveValue = function(parameters = {}) {
+  const domain = parameters.$domain ? parameters.$domain : getDomain()
+  const config = parameters.$config
+  let path = '/api/v0/settings/values-save'
+  let body
+  let queryParameters = {}
+  let form = {}
+  if (parameters['body'] !== undefined) {
+    body = parameters['body']
+  }
+  if (parameters['body'] === undefined) {
+    return Promise.reject(new Error('Missing required  parameter: body'))
+  }
+  if (parameters.$queryParameters) {
+    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
+    });
+  }
+  return request('post', domain + path, body, queryParameters, form, config)
+}
+export const ValueService_SaveValue_RAW_URL = function() {
+  return '/api/v0/settings/values-save'
+}
+export const ValueService_SaveValue_TYPE = function() {
+  return 'post'
+}
+export const ValueService_SaveValueURL = function(parameters = {}) {
+  let queryParameters = {}
+  const domain = parameters.$domain ? parameters.$domain : getDomain()
+  let path = '/api/v0/settings/values-save'
   if (parameters.$queryParameters) {
     Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
       queryParameters[parameterName] = parameters.$queryParameters[parameterName]


### PR DESCRIPTION
When [this ocis-settings PR](https://github.com/owncloud/ocis-settings/pull/46) gets merged the api call for listing settings values will require a different param nesting (`identifier` doesn't exist anymore, `account_uuid` is on highest level now).
Since the settings are not in production anywhere just yet, we can already merge this, so that a PR in phoenix can be prepared.

Also, there was a nasty bug when the settings service is not available: `error.response.status` was not accessible and threw an error. Fixed this by checking first if a response exists at all.