### PR TITLE
Add missing groups parameter to createUser API

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Full API documentation is available at [![docs](https://img.shields.io/badge/api
 To build the jsdocs, type this command and follow the instructions on the terminal :
 
 ```
-$ yarn run docs
+$ yarn build:docs
 ```
 
 ## Unit tests

--- a/src/userManagement.js
+++ b/src/userManagement.js
@@ -42,15 +42,22 @@ class Users {
    *
    * @param      {string}  userName     username of the new user to be created
    * @param      {string}  password     password of the new user to be created
+   * @param      {string[]} groups      list of group names for user is to be added to (must already exist)
    * @returns {Promise.<status>}  boolean: true if successful
    * @returns {Promise.<error>}     string: error message, if any.
    */
-  createUser (userName, password) {
+  createUser (userName, password, groups) {
     return new Promise((resolve, reject) => {
-      this.helpers._makeOCSrequest('POST', this.helpers.OCS_SERVICE_CLOUD, 'users', {
+      const params = {
         password: password,
         userid: userName
-      }).then(data => {
+      }
+
+      if (groups && groups.length) {
+        params.groups = groups
+      }
+
+      this.helpers._makeOCSrequest('POST', this.helpers.OCS_SERVICE_CLOUD, 'users', params).then(data => {
         this.helpers._OCSuserResponseHandler(data, resolve, reject)
       }).catch(error => {
         reject(error)

--- a/tests/userTest.js
+++ b/tests/userTest.js
@@ -165,6 +165,22 @@ describe('Main: Currently testing user management,', function () {
     })
   })
 
+  it('checking method : createUser with groups', function (done) {
+    oc.users.createUser('newUserWithGroup' + timeRightNow, testUserPassword, [testGroup]).then((data) => {
+      expect(data).toEqual(true)
+      return oc.users.userIsInGroup('newUserWithGroup' + timeRightNow, testGroup)
+    }).then((status) => {
+      expect(status).toBe(true)
+      return oc.users.deleteUser('newUserWithGroup' + timeRightNow)
+    }).then((status) => {
+      expect(status).toBe(true)
+      done()
+    }).catch((error) => {
+      expect(error).toBe(null)
+      done()
+    })
+  })
+
   it('checking method : searchUsers', function (done) {
     oc.users.searchUsers('').then(data => {
       expect(typeof (data)).toEqual('object')


### PR DESCRIPTION
As discussed with @LukasHirt 
https://talk.owncloud.com/group/aarnet-tech?msg=c2wy8KRkF4tQseMh4

This SDK is missing the `groups` parameter - this enables subadmin users of a specific group to create more users in that group, which was not previously possible via this API.