### PR TITLE
Add enable/disable user api

### DIFF
--- a/src/userManagement.js
+++ b/src/userManagement.js
@@ -10,6 +10,8 @@ const Promise = require('promise')
  *      <ul>
  *          <li>createUser</li>
  *          <li>deleteUser</li>
+ *          <li>disableUser</li>
+ *          <li>enableUser</li>
  *          <li>searchUsers</li>
  *          <li>userExists</li>
  *          <li>getUsers</li>
@@ -73,7 +75,41 @@ class Users {
    */
   deleteUser (userName) {
     return new Promise((resolve, reject) => {
-      this.helpers._makeOCSrequest('DELETE', this.helpers.OCS_SERVICE_CLOUD, 'users/' + userName)
+      this.helpers._makeOCSrequest('DELETE', this.helpers.OCS_SERVICE_CLOUD, 'users/' + encodeURIComponent(userName))
+        .then(data => {
+          this.helpers._OCSuserResponseHandler(data, resolve, reject)
+        }).catch(error => {
+          reject(error)
+        })
+    })
+  }
+
+  /**
+   * Enable a user via provisioning API
+   * @param   {string}  userName    name of user to be enabled
+   * @returns {Promise.<status>}    boolean: true if successful
+   * @returns {Promise.<error>}     string: error message, if any.
+   */
+  enableUser (userName) {
+    return new Promise((resolve, reject) => {
+      this.helpers._makeOCSrequest('PUT', this.helpers.OCS_SERVICE_CLOUD, 'users/' + encodeURIComponent(userName) + '/enable', {})
+        .then(data => {
+          this.helpers._OCSuserResponseHandler(data, resolve, reject)
+        }).catch(error => {
+          reject(error)
+        })
+    })
+  }
+
+  /**
+   * Disable a user via provisioning API
+   * @param   {string}  userName    name of user to be disabled
+   * @returns {Promise.<status>}    boolean: true if successful
+   * @returns {Promise.<error>}     string: error message, if any.
+   */
+  disableUser (userName) {
+    return new Promise((resolve, reject) => {
+      this.helpers._makeOCSrequest('PUT', this.helpers.OCS_SERVICE_CLOUD, 'users/' + encodeURIComponent(userName) + '/disable', {})
         .then(data => {
           this.helpers._OCSuserResponseHandler(data, resolve, reject)
         }).catch(error => {

--- a/tests/userTest.js
+++ b/tests/userTest.js
@@ -15,7 +15,6 @@ describe('Main: Currently testing user management,', function () {
     createProvider
   } = require('./pactHelper.js')
   const { validAdminAuthHeaders, xmlResponseHeaders, applicationFormUrlEncoded } = require('./pactHelper.js')
-
   const getUserInformationInteraction = async function (provider, requestName, username, responseBody) {
     if (username !== config.adminUsername && username !== config.nonExistentUser) {
       await provider
@@ -51,6 +50,7 @@ describe('Main: Currently testing user management,', function () {
         query: query,
         headers: validAdminAuthHeaders
       })
+
       .willRespondWith({
         status: 200,
         headers: xmlResponseHeaders,
@@ -588,6 +588,136 @@ describe('Main: Currently testing user management,', function () {
         expect(status).toBe(false)
       }).catch(error => {
         expect(error).toBe(null)
+      })
+    })
+  })
+
+  it('checking method : enableUser with an existing user', async function () {
+    const provider = createProvider()
+
+    await provider.uponReceiving('enable an existing user')
+      .withRequest({
+        method: 'PUT',
+        path: MatchersV3.regex(
+          '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + config.testUser + '\\/enable',
+          '/ocs/v1.php/cloud/users/' + config.testUser + '/enable'
+        )
+      }).willRespondWith({
+        status: 200,
+        headers: xmlResponseHeaders,
+        body: new XmlBuilder('1.0', '', 'ocs')
+          .build(ocs => {
+            ocs.appendElement('meta', '', (meta) => {
+              return ocsMeta(meta, 'ok', '100')
+            })
+          })
+      })
+
+    return provider.executeTest(async () => {
+      const oc = createOwncloud()
+
+      return oc.users.enableUser(config.testUser).then((status) => {
+        expect(status).toBe(true)
+      }).catch(error => {
+        expect(error).toBe(null)
+      })
+    })
+  })
+
+  it('checking method : disableUser with an existing user', async function () {
+    const provider = createProvider()
+
+    await provider.uponReceiving('disable an existing user')
+      .withRequest({
+        method: 'PUT',
+        path: MatchersV3.regex(
+          '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + config.testUser + '\\/disable',
+          '/ocs/v1.php/cloud/users/' + config.testUser + '/disable'
+        )
+      }).willRespondWith({
+        status: 200,
+        headers: xmlResponseHeaders,
+        body: new XmlBuilder('1.0', '', 'ocs')
+          .build(ocs => {
+            ocs.appendElement('meta', '', (meta) => {
+              return ocsMeta(meta, 'ok', '100')
+            })
+          })
+      })
+
+    return provider.executeTest(async () => {
+      const oc = createOwncloud()
+
+      return oc.users.disableUser(config.testUser).then((status) => {
+        expect(status).toBe(true)
+      }).catch(error => {
+        expect(error).toBe(null)
+      })
+    })
+  })
+
+  it('checking method : enableUser with a non-existing user', async function () {
+    const provider = createProvider()
+
+    await provider.uponReceiving('enable a non-existing user')
+      .withRequest({
+        method: 'PUT',
+        path: MatchersV3.regex(
+          '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + config.nonExistentUser + '\\/enable',
+          '/ocs/v1.php/cloud/users/' + config.nonExistentUser + '/enable'
+        )
+      }).willRespondWith({
+        status: 200,
+        headers: xmlResponseHeaders,
+        body: new XmlBuilder('1.0', '', 'ocs')
+          .build(ocs => {
+            ocs.appendElement('meta', '', (meta) => {
+              return ocsMeta(meta, 'failure', '101')
+            })
+          })
+      })
+
+    return provider.executeTest(async () => {
+      const oc = createOwncloud()
+
+      return oc.users.enableUser(config.nonExistentUser).then((status) => {
+        expect(status).toBe(null)
+      }).catch(error => {
+        expect(typeof (error)).toBe('object')
+        expect(error.ocs.meta.statuscode).toEqual('101')
+      })
+    })
+  })
+
+  it('checking method : disableUser with a non-existing user', async function () {
+    const provider = createProvider()
+
+    await provider.uponReceiving('disable a non-existing user')
+      .withRequest({
+        method: 'PUT',
+        path: MatchersV3.regex(
+          '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + config.nonExistentUser + '\\/disable',
+          '/ocs/v1.php/cloud/users/' + config.nonExistentUser + '/disable'
+        )
+      }).willRespondWith({
+        status: 200,
+        headers: xmlResponseHeaders,
+        body: new XmlBuilder('1.0', '', 'ocs')
+          .build(ocs => {
+            ocs.appendElement('meta', '', (meta) => {
+              return ocsMeta(meta, 'failure', '101')
+            })
+          })
+      })
+
+    return provider.executeTest(async () => {
+      const oc = createOwncloud()
+
+      return oc.users.disableUser(config.nonExistentUser).then((status) => {
+        expect(status).toBe(null)
+      }).catch(error => {
+        expect(typeof (error)).toBe('object')
+        expect(error.ocs.meta.statuscode).toEqual('101')
       })
     })
   })


### PR DESCRIPTION
I have added `enable` and `disable` user API endpoints, these were missing and needed for some functionality I am currently working on.  I have written the tests without regard to your pact.io work in `tests/userTest.js` which tests both methods in succession.