### PR TITLE
[Tests-Only] Add interactions for the tests in sharing tests

### DIFF
--- a/tests/sharingTest.js
+++ b/tests/sharingTest.js
@@ -8,32 +8,25 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
   // PACT setup
   const Pact = require('@pact-foundation/pact-web')
   const provider = new Pact.PactWeb()
-  const { setGeneralInteractions } = require('./pactHelper.js')
-
-  beforeAll(function (done) {
-    Promise.all(setGeneralInteractions(provider)).then(done, done.fail)
-  })
-
-  afterAll(function (done) {
-    provider.removeInteractions().then(done, done.fail)
-  })
+  const { setGeneralInteractions, ocsMeta, shareResponseOcsData, applicationXmlResponseHeaders } = require('./pactHelper.js')
+  const { accessControlAllowHeaders, accessControlAllowMethods, validAuthHeaders, xmlResponseHeaders } = require('./pactHelper.js')
 
   // TESTING CONFIGS
   const testUserPassword = config.testUserPassword
-  const testContent = config.testContent
   const testUser = config.testUser
   const testGroup = config.testGroup
-  const testFolder = config.testFolder
+  const testFolder = '/' + config.testFolder
   const nonExistentFile = config.nonExistentFile
   const expirationDate = config.expirationDate
   const testFiles = config.testFiles
 
   // CREATED SHARES
-  let sharedFilesWithUser = {}
-  let sharedFilesByLink = {}
-  let sharedFilesWithGroup = {}
-  let testFolderShareID = null
-  const allShareIDs = []
+  const sharedFiles = {
+    'test space and + and #.txt': 18,
+    'test.txt': 14,
+    '文件.txt': 19
+  }
+  const testFolderShareID = 9
 
   // CONSTANTS FROM lib/public/constants.php
   const OCS_PERMISSION_READ = 1
@@ -41,13 +34,39 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
   const OCS_PERMISSION_CREATE = 4
   const OCS_PERMISSION_SHARE = 16
 
-  // Helpers
-  /**
-   * Adds specified number of dates to the date
-   * @param   {object} date Date to which the days are supposed to be added
-   * @param   {number} days Number of days to be added
-   * @returns {object}      Returns the date with added days
-   */
+  const aGetRequestForAShareWithShareName = function (name, shareType, iteration) {
+    const path = ['%2Ftest.txt', '%2Ftest%20space%20and%20%2B%20and%20%23.txt', '%2F%E6%96%87%E4%BB%B6.txt']
+    return {
+      uponReceiving: 'a GET request for a ' + name + path[iteration],
+      withRequest: {
+        method: 'GET',
+        path: Pact.Matchers.term({
+          matcher: '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares$',
+          generate: '/ocs/v1.php/apps/files_sharing/api/v1/shares'
+        }),
+        query: 'path=' + path[iteration],
+        headers: validAuthHeaders
+      },
+      willRespondWith: {
+        status: 200,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers': accessControlAllowHeaders,
+          'Access-Control-Allow-Methods': accessControlAllowMethods
+        },
+        body: '<?xml version="1.0"?>\n' +
+          '<ocs>\n' +
+          ocsMeta('ok', '100') +
+          ' <data>\n' +
+          '  <element>\n' +
+           shareResponseOcsData(shareType, config.testFilesId[iteration], 1, config.testFiles[iteration]) +
+          '   <token>' + config.testFilesToken[iteration] + '</token>\n' +
+          '  </element>\n' +
+          ' </data>\n' +
+          '</ocs>'
+      }
+    }
+  }
 
   describe('Currently testing folder sharing,', function () {
     beforeEach(function (done) {
@@ -62,70 +81,61 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
       })
 
       oc.login().then(() => {
-        oc.files.createFolder(testFolder).then(status => {
-          expect(status).toBe(true)
-          done()
-        }).catch(error => {
-          expect(error).toBe(null)
-          done()
-        })
+        done()
       })
     })
 
-    afterEach(function (done) {
-      oc.files.delete(testFolder).then(status => {
-        expect(status).toBe(true)
-        done()
-      }).catch(error => {
-        expect(error).toBe(null)
-        done()
-      })
+    afterEach(function () {
       oc.logout()
       oc = null
     })
 
+    const aGetRequestForPublicLinkShare = function (name, permissions, additionalBodyElem) {
+      return {
+        uponReceiving: 'a GET request for a public link share' + name,
+        withRequest: {
+          method: 'GET',
+          path: Pact.Matchers.term({
+            matcher: '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares\\/\\d+$',
+            generate: '/ocs/v1.php/apps/files_sharing/api/v1/shares/9'
+          }),
+          headers: validAuthHeaders
+        },
+        willRespondWith: {
+          status: 200,
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Headers': accessControlAllowHeaders,
+            'Access-Control-Allow-Methods': accessControlAllowMethods
+          },
+          body: '<?xml version="1.0"?>\n' +
+           '<ocs>\n' +
+           ocsMeta('ok', '100') +
+           ' <data>\n' +
+           '  <element>\n' +
+           shareResponseOcsData(3, 17, permissions, testFolder) +
+           additionalBodyElem +
+           '  <name>Öffentlicher Link</name>\n' +
+           '  </element>\n' +
+           ' </data>\n' +
+           '</ocs>'
+        }
+      }
+    }
     describe('sharedFolder,', function () {
-      beforeEach(function (done) {
-        const testLinkName = 'Öffentlicher Link'
-        oc.shares.shareFileWithLink(testFolder, { name: testLinkName }).then(share => {
-          expect(typeof (share)).toBe('object')
-          expect(share.getName()).toBe(testLinkName)
-          expect(share.getPath()).toBe('/' + testFolder)
-          testFolderShareID = share.getId()
-          allShareIDs.push(testFolderShareID)
-          done()
-        }).catch(error => {
-          expect(error).toBe(null)
-          done()
-        })
-      })
-
-      afterEach(function (done) {
-        oc.shares.deleteShare(testFolderShareID).then(status => {
-          expect(status).toBe(true)
-          done()
-        }).catch(error => {
-          expect(error).toBe(null)
-          done()
-        })
-      })
-
       // needs to be double checked ...
       describe('updating share permissions,', function () {
-        beforeEach(function (done) {
-          oc.shares.updateShare(testFolderShareID, { permissions: 31 }) // max-permissions
-            .then(updatedShare => {
-              expect(updatedShare.getId()).toBe(testFolderShareID)
-              expect(updatedShare.getPermissions()).toBe(31)
-              done()
-            }).catch(error => {
-              let check = 'can\'t change permissions for public share links'
-              if (error === 'can\'t change permission for public link share') {
-                check = 'can\'t change permission for public link share'
-              }
-              expect(error.toLowerCase()).toBe(check)
-              done()
-            })
+        beforeAll(async function (done) {
+          const promises = []
+          promises.push(setGeneralInteractions(provider))
+          promises.push(provider.addInteraction(
+            aGetRequestForPublicLinkShare('to confirm the permissions is not changed', 1, ''))
+          )
+          Promise.all(promises).then(done, done.fail)
+        })
+
+        afterAll(function (done) {
+          provider.removeInteractions().then(done, done.fail)
         })
 
         it('confirms not changed permissions', function (done) {
@@ -142,19 +152,21 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
 
       // needs to be double checked
       describe('making publicUpload true,', function () {
-        beforeEach(function (done) {
-          oc.shares.updateShare(testFolderShareID, { publicUpload: true }).then(updatedShare => {
-            expect(updatedShare.getId()).toBe(testFolderShareID)
-            expect(updatedShare.getPermissions() & OCS_PERMISSION_CREATE).toBeGreaterThan(0)
-            expect(updatedShare.getPermissions() & OCS_PERMISSION_UPDATE).toBeGreaterThan(0)
-            done()
-          }).catch(error => {
-            expect(error).toBe(null)
-            done()
-          })
+        beforeAll(async function (done) {
+          const promises = []
+          promises.push(setGeneralInteractions(provider))
+          promises.push(provider.addInteraction(
+            aGetRequestForPublicLinkShare('after making publicupload true', 15, ''))
+          )
+
+          Promise.all(promises).then(done, done.fail)
         })
 
-        xit('confirms publicUpload true', function (done) {
+        afterAll(function (done) {
+          provider.removeInteractions().then(done, done.fail)
+        })
+
+        it('confirms publicUpload true', function (done) {
           oc.shares.getShare(testFolderShareID).then(share => {
             expect(share.getPermissions() & OCS_PERMISSION_CREATE).toBeGreaterThan(0)
             expect(share.getPermissions() & OCS_PERMISSION_UPDATE).toBeGreaterThan(0)
@@ -168,16 +180,20 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
 
       // needs to be double checked
       describe('adding password,', function () {
-        beforeEach(function (done) {
-          oc.shares.updateShare(testFolderShareID, { password: testUserPassword }).then(updatedShare => {
-            expect(updatedShare.getId()).toBe(testFolderShareID)
-            expect(typeof (updatedShare.getShareWith())).toEqual('string')
-            expect(typeof (updatedShare.getShareWithDisplayName())).toEqual('string')
-            done()
-          }).catch(error => {
-            expect(error).toBe(null)
-            done()
-          })
+        beforeAll(async function (done) {
+          const additionalBodyElement = '  <share_with>***redacted***</share_with>\n' +
+                  '  <share_with_displayname>***redacted***</share_with_displayname>\n'
+
+          const promises = []
+          promises.push(setGeneralInteractions(provider))
+          promises.push(provider.addInteraction(
+            aGetRequestForPublicLinkShare('after password is added', 1, additionalBodyElement))
+          )
+          Promise.all(promises).then(done, done.fail)
+        })
+
+        afterAll(function (done) {
+          provider.removeInteractions().then(done, done.fail)
         })
 
         it('confirms added password', function (done) {
@@ -196,6 +212,234 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
 
   describe('Currently testing file sharing,', function () {
     beforeEach(function (done) {
+      const promises = []
+      promises.push(setGeneralInteractions(provider))
+      promises.push(provider.addInteraction({
+        uponReceiving: 'a link share POST request with a non-existent file',
+        withRequest: {
+          method: 'POST',
+          path: Pact.Matchers.term({
+            matcher: '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares$',
+            generate: '/ocs/v1.php/apps/files_sharing/api/v1/shares'
+          }),
+          headers: validAuthHeaders,
+          body: 'shareType=3' + '&path=%2F' + config.nonExistentFile + '&password=' + config.testUserPassword
+        },
+        willRespondWith: {
+          status: 200,
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Headers': accessControlAllowHeaders,
+            'Access-Control-Allow-Methods': accessControlAllowMethods
+          },
+          body: '<?xml version="1.0"?>\n' +
+            '<ocs>\n' +
+            ocsMeta('failure', 404, 'Wrong path, file/folder doesn\'t exist') +
+            ' <data/>\n' +
+            '</ocs>'
+        }
+      }))
+      promises.push(provider.addInteraction({
+        uponReceiving: 'a group share POST request with valid auth but non-existent file',
+        withRequest: {
+          method: 'POST',
+          path: Pact.Matchers.term({
+            matcher: '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares$',
+            generate: '/ocs/v1.php/apps/files_sharing/api/v1/shares'
+          }),
+          headers: validAuthHeaders,
+          body: 'shareType=1&shareWith=' + config.testGroup + '&path=%2F' + config.nonExistentFile + '&permissions=19'
+        },
+        willRespondWith: {
+          status: 200,
+          headers: applicationXmlResponseHeaders,
+          body: '<?xml version="1.0"?>\n' +
+            '<ocs>\n' +
+            ocsMeta('failure', 404, 'Wrong path, file/folder doesn\'t exist') +
+            ' <data/>\n' +
+            '</ocs>'
+        }
+      }))
+      promises.push(provider.addInteraction({
+        uponReceiving: 'a GET request for a share with non-existent file',
+        withRequest: {
+          method: 'GET',
+          path: Pact.Matchers.term({
+            matcher: '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares$',
+            generate: '/ocs/v1.php/apps/files_sharing/api/v1/shares'
+          }),
+          query: 'path=%2F' + config.nonExistentFile,
+          headers: validAuthHeaders
+        },
+        willRespondWith: {
+          status: 200,
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Headers': accessControlAllowHeaders,
+            'Access-Control-Allow-Methods': accessControlAllowMethods
+          },
+          body: '<?xml version="1.0"?>\n' +
+              '<ocs>\n' +
+              ocsMeta('failure', 404, 'Wrong path, file/folder doesn\'t exist') +
+              ' <data/>\n' +
+              '</ocs>'
+        }
+      })
+      )
+      promises.push(provider.addInteraction({
+        uponReceiving: 'a GET request for an existent but non-shared file',
+        withRequest: {
+          method: 'GET',
+          path: Pact.Matchers.term({
+            matcher: '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares$',
+            generate: '/ocs/v1.php/apps/files_sharing/api/v1/shares'
+          }),
+          query: 'path=%2FnewFileCreated123',
+          headers: validAuthHeaders
+        },
+        willRespondWith: {
+          status: 200,
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Headers': accessControlAllowHeaders,
+            'Access-Control-Allow-Methods': accessControlAllowMethods
+          },
+          body: '<?xml version="1.0"?>\n' +
+              '<ocs>\n' +
+              ocsMeta('ok', '100') +
+              ' <data/>\n' +
+              '</ocs>'
+        }
+      })
+      )
+      promises.push(provider.addInteraction({
+        uponReceiving: 'a GET request for a non-existent share',
+        withRequest: {
+          method: 'GET',
+          path: Pact.Matchers.term({
+            matcher: '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares\\/-1$',
+            generate: '/ocs/v1.php/apps/files_sharing/api/v1/shares/-1'
+          }),
+          headers: validAuthHeaders
+        },
+        willRespondWith: {
+          status: 200,
+          headers: xmlResponseHeaders,
+          body: '<?xml version="1.0"?>\n' +
+              '<ocs>\n' +
+              ocsMeta('failure', 404, 'Wrong share ID, share doesn\'t exist') +
+              ' <data/>\n' +
+              '</ocs>'
+        }
+      })
+      )
+      promises.push(provider.addInteraction({
+        uponReceiving: 'Put file contents as empty content in files specified',
+        withRequest: {
+          method: 'PUT',
+          path: Pact.Matchers.regex({
+            matcher: '.*\\/remote\\.php\\/webdav\\/newFileCreated123$',
+            generate: '/remote.php/webdav/newFileCreated123'
+          }),
+          headers: validAuthHeaders
+        },
+        willRespondWith: {
+          status: 200,
+          headers: {
+            'Access-Control-Allow-Origin': origin
+          }
+        }
+      })
+      )
+      for (let i = 0; i < config.testFiles.length; i++) {
+        promises.push(provider.addInteraction({
+          uponReceiving: 'a GET request for an existent share with id ' + config.testFilesId[i],
+          withRequest: {
+            method: 'GET',
+            path: Pact.Matchers.term({
+              matcher: '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares\\/' + config.testFilesId[i] + '$',
+              generate: '/ocs/v1.php/apps/files_sharing/api/v1/shares/' + config.testFilesId[i]
+            }),
+            headers: validAuthHeaders
+          },
+          willRespondWith: {
+            status: 200,
+            headers: xmlResponseHeaders,
+            body: '<?xml version="1.0"?>\n' +
+              '<ocs>\n' +
+              ocsMeta('ok', '100') +
+              ' <data>\n' +
+              '  <element>\n' +
+              shareResponseOcsData(0, config.testFilesId[i], 19, config.testFiles[i]) +
+              '  </element>\n' +
+              ' </data>\n' +
+              '</ocs>'
+          }
+        }))
+      }
+
+      const requests = ['PUT', 'DELETE']
+      for (let i = 0; i < requests.length; i++) {
+        promises.push(provider.addInteraction({
+          uponReceiving: 'a ' + requests[i] + ' request to update/delete a non-existent share',
+          withRequest: {
+            method: requests[i],
+            path: Pact.Matchers.regex({
+              matcher: '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares\\/-1$',
+              generate: '/ocs/v1.php/apps/files_sharing/api/v1/shares/-1'
+            }),
+            headers: validAuthHeaders
+          },
+          willRespondWith: {
+            status: 200,
+            headers: {
+              'Access-Control-Allow-Origin': origin
+            },
+            body: '<?xml version="1.0"?>\n' +
+              '<ocs>\n' +
+              ocsMeta('failure', 404, 'Wrong share ID, share doesn\'t exist') +
+              ' <data/>\n' +
+              '</ocs>'
+          }
+        }))
+      }
+
+      for (let i = 0; i < config.testFiles.length; i++) {
+        promises.push(provider.addInteraction({
+          uponReceiving: 'a user share POST request with valid auth and expiration date set to path ' + config.testFilesPath[i],
+          withRequest: {
+            method: 'POST',
+            path: Pact.Matchers.term({
+              matcher: '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares$',
+              generate: '/ocs/v1.php/apps/files_sharing/api/v1/shares'
+            }),
+            headers: validAuthHeaders,
+            body: 'shareType=0&shareWith=' + config.testUser + '&path=' + config.testFilesPath[i] + '&expireDate=' + config.expirationDate
+          },
+          willRespondWith: {
+            status: 200,
+            headers: applicationXmlResponseHeaders,
+            body: '<?xml version="1.0"?>\n' +
+                '<ocs>\n' +
+                ocsMeta('ok', '100') +
+                ' <data>\n' +
+                shareResponseOcsData(0, config.testFilesId[i], 19, config.testFiles[i]) +
+                '  <expiration>' + config.expirationDate + '</expiration>\n' +
+                ' </data>\n' +
+                '</ocs>'
+          }
+        })
+        )
+      }
+
+      Promise.all(promises).then(done, done.fail)
+    })
+
+    afterEach(function (done) {
+      provider.removeInteractions().then(done, done.fail)
+    })
+
+    beforeEach(function (done) {
       oc = new OwnCloud({
         baseUrl: config.owncloudURL,
         auth: {
@@ -205,111 +449,28 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
           }
         }
       })
-
       oc.login().then(() => {
-        // CREATING TEST USER
-        oc.users.createUser(testUser, testUserPassword).then(status => {
-          expect(status).toBe(true)
-          // CREATING TEST GROUP
-          return oc.groups.createGroup(testGroup)
-        }).then(status => {
-          expect(status).toBe(true)
-          let count = 0
-          for (let i = 0; i < testFiles.length; i++) {
-            // CREATING TEST FILES
-            oc.files.putFileContents(testFiles[i], testContent).then(status => {
-              expect(typeof status).toBe('object')
-              count++
-              if (count === testFiles.length) {
-                done()
-              }
-            }).catch(error => {
-              expect(error).toBe(null)
-              done()
-            })
-          }
-        }).catch(error => {
-          expect(error).toBe(null)
-          done()
-        })
-      })
-    })
-
-    afterEach(function (done) {
-      oc.users.deleteUser(testUser).then(status => {
-        expect(status).toBe(true)
-        return oc.groups.deleteGroup(testGroup)
-      }).then(status2 => {
-        expect(status2).toBe(true)
-
-        let count = 0
-        for (let i = 0; i < testFiles.length; i++) {
-          // DELETING TEST FILES
-          oc.files.delete(testFiles[i]).then(status => {
-            expect(status).toBe(true)
-            count++
-            if (count === testFiles.length) {
-              done()
-            }
-          }).catch(error => {
-            expect(error).toBe(null)
-            done()
-          })
-        }
-      }).catch(error => {
-        expect(error).toBe(null)
         done()
       })
     })
 
     describe('sharedFilesByLink,', function () {
-      beforeEach(function (done) {
-        let count = 0
-        for (let i = 0; i < testFiles.length; i++) {
-          oc.shares.shareFileWithLink(testFiles[i]).then(async share => {
-            expect(share).not.toBe(null)
-            expect(typeof (share)).toBe('object')
-            console.log(await share.getPath())
-            expect(testFiles.indexOf(share.getPath())).toBeGreaterThan(-1)
-            expect(typeof (share.getId())).toBe('number')
-            expect(typeof (share.getLink())).toBe('string')
-            expect(typeof (share.getToken())).toBe('string')
-            sharedFilesByLink[share.getPath()] = share.getId()
-            allShareIDs.push(share.getId())
-            count++
-            if (count === testFiles.length) {
-              done()
-            }
-          }).catch(error => {
-            expect(error).toBe(null)
-            done()
-          })
+      beforeEach(async function (done) {
+        const promises = []
+        for (let i = 0; i < config.testFiles.length; i++) {
+          promises.push(provider.addInteraction(aGetRequestForAShareWithShareName('public link share',
+            3, i)))
         }
+        Promise.all(promises).then(done, done.fail)
       })
 
       afterEach(function (done) {
-        let count = 0
-        const numShares = Object.keys(sharedFilesByLink).length
-
-        for (const file in sharedFilesByLink) {
-          oc.shares.deleteShare(sharedFilesByLink[file]).then(status => {
-            expect(status).toBe(true)
-            count++
-            if (count === numShares) {
-              sharedFilesByLink = {}
-              done()
-            }
-          }).catch(error => {
-            expect(error).toBe(null)
-            done()
-          })
-        }
+        provider.removeInteractions().then(done, done.fail)
       })
 
       describe('checking the shared files,', function () {
         it('checking method : isShared with shared file', function (done) {
           let count = 0
-
           for (let i = 0; i < testFiles.length; i++) {
             oc.shares.isShared(testFiles[i]).then(status => {
               expect(status).toEqual(true)
@@ -326,13 +487,12 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
 
         it('checking method : getShare with existent share', function (done) {
           let count = 0
-
-          for (const file in sharedFilesByLink) {
-            oc.shares.getShare(sharedFilesByLink[file]).then(share => {
+          for (const file in sharedFiles) {
+            oc.shares.getShare(sharedFiles[file]).then(share => {
               expect(typeof (share)).toBe('object')
-              expect(Object.prototype.hasOwnProperty.call(sharedFilesWithUser, share.getId())).toBeGreaterThan(-1)
+              expect(Object.prototype.hasOwnProperty.call(sharedFiles, share.getId())).toBeGreaterThan(-1)
               count++
-              if (count === Object.keys(sharedFilesByLink).length) {
+              if (count === Object.keys(sharedFiles).length) {
                 done()
               }
             }).catch(error => {
@@ -345,8 +505,8 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
         it('checking method : getShares for shared file', function (done) {
           let count = 0
           const allIDs = []
-          for (const file in sharedFilesByLink) {
-            allIDs.push(sharedFilesByLink[file])
+          for (const file in sharedFiles) {
+            allIDs.push(sharedFiles[file])
           }
 
           for (let i = 0; i < testFiles.length; i++) {
@@ -374,73 +534,33 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
     })
 
     describe('sharedFilesWithUser,', function () {
-      beforeEach(function (done) {
-        let count = 0
-
-        for (let i = 0; i < testFiles.length; i++) {
-          oc.shares.shareFileWithUser(testFiles[i], testUser).then(share => {
-            expect(share).not.toBe(null)
-            expect(typeof (share)).toBe('object')
-            expect(typeof (share.getId())).toBe('number')
-            sharedFilesWithUser[share.getPath()] = share.getId()
-            allShareIDs.push(share.getId())
-            count++
-            if (count === testFiles.length) {
-              done()
-            }
-          }).catch(error => {
-            expect(error).toBe(null)
-            done()
-          })
+      beforeEach(async function (done) {
+        const promises = []
+        for (let i = 0; i < config.testFiles.length; i++) {
+          promises.push(provider.addInteraction(aGetRequestForAShareWithShareName(
+            'user share ', 0, i)))
         }
+        Promise.all(promises).then(done, done.fail)
       })
 
       afterEach(function (done) {
-        let count = 0
-
-        for (const file in sharedFilesWithUser) {
-          oc.shares.deleteShare(sharedFilesWithUser[file]).then(status => {
-            expect(status).toBe(true)
-            count++
-            if (count === testFiles.length) {
-              sharedFilesWithUser = {}
-              done()
-            }
-          }).catch(error => {
-            expect(error).toBe(null)
-            done()
-          })
-        }
+        provider.removeInteractions().then(done, done.fail)
       })
 
       describe('updating permissions', function () {
-        beforeEach(function (done) {
-          const maxPerms = OCS_PERMISSION_READ + OCS_PERMISSION_UPDATE + OCS_PERMISSION_SHARE
-          let count = 0
-
-          for (const file in sharedFilesWithUser) {
-            oc.shares.updateShare(sharedFilesWithUser[file], { permissions: maxPerms }).then(updatedShare => {
-              expect(updatedShare.getPermissions()).toBe(maxPerms)
-              count++
-              if (count === Object.keys(sharedFilesWithUser).length) {
-                done()
-              }
-            }).catch(error => {
-              expect(error).toBe(null)
-              done()
-            })
-          }
+        afterEach(function (done) {
+          provider.removeInteractions().then(done, done.fail)
         })
 
         it('confirms updated permissions', function (done) {
           const maxPerms = OCS_PERMISSION_READ + OCS_PERMISSION_UPDATE + OCS_PERMISSION_SHARE
           let count = 0
 
-          for (const file in sharedFilesWithUser) {
-            oc.shares.getShare(sharedFilesWithUser[file]).then(share => {
+          for (const file in sharedFiles) {
+            oc.shares.getShare(sharedFiles[file]).then(share => {
               expect(share.getPermissions()).toEqual(maxPerms)
               count++
-              if (count === Object.keys(sharedFilesWithUser).length) {
+              if (count === Object.keys(sharedFiles).length) {
                 done()
               }
             }).catch(error => {
@@ -454,11 +574,11 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
       it('checking method : isShared with shared file', function (done) {
         let count = 0
 
-        for (const file in sharedFilesWithUser) {
+        for (const file in sharedFiles) {
           oc.shares.isShared(file).then(status => {
             expect(status).toEqual(true)
             count++
-            if (count === Object.keys(sharedFilesWithUser).length) {
+            if (count === Object.keys(sharedFiles).length) {
               done()
             }
           }).catch(error => {
@@ -471,12 +591,12 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
       it('checking method : getShare with existent share', function (done) {
         let count = 0
 
-        for (const file in sharedFilesWithUser) {
-          oc.shares.getShare(sharedFilesWithUser[file]).then(share => {
+        for (const file in sharedFiles) {
+          oc.shares.getShare(sharedFiles[file]).then(share => {
             expect(typeof (share)).toBe('object')
-            expect(Object.prototype.hasOwnProperty.call(sharedFilesWithUser, share.getId())).toBeGreaterThan(-1)
+            expect(Object.prototype.hasOwnProperty.call(sharedFiles, share.getId())).toBeGreaterThan(-1)
             count++
-            if (count === Object.keys(sharedFilesWithUser).length) {
+            if (count === Object.keys(sharedFiles).length) {
               done()
             }
           }).catch(error => {
@@ -489,11 +609,11 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
       it('checking method : getShares for shared file', function (done) {
         let count = 0
         const allIDs = []
-        for (var file in sharedFilesWithUser) {
-          allIDs.push(sharedFilesWithUser[file])
+        for (var file in sharedFiles) {
+          allIDs.push(sharedFiles[file])
         }
 
-        for (file in sharedFilesWithUser) {
+        for (file in sharedFiles) {
           oc.shares.getShares(file).then(shares => {
             expect(shares.constructor).toBe(Array)
             let flag = 0
@@ -505,7 +625,7 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
             }
             expect(flag).toEqual(1)
             count++
-            if (count === Object.keys(sharedFilesWithUser).length) {
+            if (count === Object.keys(sharedFiles).length) {
               done()
             }
           }).catch(error => {
@@ -517,52 +637,26 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
     })
 
     describe('sharedFilesWithGroup,', function () {
-      beforeEach(function (done) {
-        let count = 0
-
-        for (let i = 0; i < testFiles.length; i++) {
-          oc.shares.shareFileWithGroup(testFiles[i], testGroup, { permissions: 19 }).then(share => {
-            expect(typeof (share)).toEqual('object')
-            expect(share.getPermissions()).toEqual(19)
-            sharedFilesWithGroup[share.getPath()] = share.getId()
-            allShareIDs.push(share.getId())
-            count++
-            if (count === testFiles.length) {
-              done()
-            }
-          }).catch(error => {
-            expect(error).toBe(null)
-            done()
-          })
+      beforeEach(async function (done) {
+        const promises = []
+        for (let i = 0; i < config.testFiles.length; i++) {
+          promises.push(provider.addInteraction(aGetRequestForAShareWithShareName(
+            'group share ', 1, i)))
         }
+        Promise.all(promises).then(done, done.fail)
       })
 
       afterEach(function (done) {
-        let count = 0
-
-        for (const file in sharedFilesWithGroup) {
-          oc.shares.deleteShare(sharedFilesWithGroup[file]).then(status => {
-            expect(status).toEqual(true)
-            count++
-            if (count === testFiles.length) {
-              sharedFilesWithGroup = {}
-              done()
-            }
-          }).catch(error => {
-            expect(error).toBe(null)
-            done()
-          })
-        }
+        provider.removeInteractions().then(done, done.fail)
       })
 
       it('checking method : isShared with shared file', function (done) {
         let count = 0
-
-        for (const file in sharedFilesWithGroup) {
+        for (const file in sharedFiles) {
           oc.shares.isShared(file).then(status => {
             expect(status).toEqual(true)
             count++
-            if (count === Object.keys(sharedFilesWithGroup).length) {
+            if (count === Object.keys(sharedFiles).length) {
               done()
             }
           }).catch(error => {
@@ -575,12 +669,12 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
       it('checking method : getShare with existent share', function (done) {
         let count = 0
 
-        for (const file in sharedFilesWithGroup) {
-          oc.shares.getShare(sharedFilesWithGroup[file]).then(share => {
+        for (const file in sharedFiles) {
+          oc.shares.getShare(sharedFiles[file]).then(share => {
             expect(typeof (share)).toBe('object')
-            expect(Object.prototype.hasOwnProperty.call(sharedFilesWithGroup, share.getId())).toBeGreaterThan(-1)
+            expect(Object.prototype.hasOwnProperty.call(sharedFiles, share.getId())).toBeGreaterThan(-1)
             count++
-            if (count === Object.keys(sharedFilesWithGroup).length) {
+            if (count === Object.keys(sharedFiles).length) {
               done()
             }
           }).catch(error => {
@@ -593,11 +687,11 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
       it('checking method : getShares for shared file', function (done) {
         let count = 0
         const allIDs = []
-        for (var file in sharedFilesWithGroup) {
-          allIDs.push(sharedFilesWithGroup[file])
+        for (var file in sharedFiles) {
+          allIDs.push(sharedFiles[file])
         }
 
-        for (file in sharedFilesWithGroup) {
+        for (file in sharedFiles) {
           oc.shares.getShares(file).then(shares => {
             expect(shares.constructor).toBe(Array)
             let flag = 0
@@ -609,7 +703,7 @@ fdescribe('Main: Currently testing file/folder sharing,', function () {
             }
             expect(flag).toEqual(1)
             count++
-            if (count === Object.keys(sharedFilesWithGroup).length) {
+            if (count === Object.keys(sharedFiles).length) {
               done()
             }
           }).catch(error => {


### PR DESCRIPTION
## Description:
New interactions and the interactions previously added in the pactHelper related to authorized sharing are added in the sharing tests file.

## Related Issue:
- https://github.com/owncloud/owncloud-sdk/issues/500#issuecomment-701138139