### PR TITLE
[Tests-Only] Refactor fileVersionTest to use pact.io

### DIFF
--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -1,34 +1,83 @@
-describe('Main: Currently testing file versions management,', function () {
-// CURRENT TIME
-  var timeRightNow = Math.random().toString(36).substr(2, 9)
-  var OwnCloud = require('../src/owncloud')
-  var config = require('./config/config.json')
+fdescribe('Main: Currently testing file versions management,', function () {
+  const OwnCloud = require('../src/owncloud')
+  const config = require('./config/config.json')
 
   // LIBRARY INSTANCE
-  var oc
+  let oc
 
   // PACT setup
   const Pact = require('@pact-foundation/pact-web')
   const provider = new Pact.PactWeb()
-  const { setGeneralInteractions } = require('./pactHelper.js')
-
-  beforeAll(function (done) {
-    Promise.all(setGeneralInteractions(provider)).then(done, done.fail)
-  })
-
-  afterAll(function (done) {
-    provider.removeInteractions().then(done, done.fail)
-  })
+  const {
+    setGeneralInteractions,
+    validAuthHeaders,
+    accessControlAllowHeaders,
+    accessControlAllowMethods,
+    applicationXmlResponseHeaders
+  } = require('./pactHelper.js')
 
   // TESTING CONFIGS
-  var testFolder = '/testFolder' + timeRightNow
-
-  var versionedFile = testFolder + '/versioned.txt'
-  var versionedFileInfo
-
-  function sleep (ms) {
-    return new Promise(resolve => setTimeout(resolve, ms))
+  const versionedFile = config.testFile
+  const fileInfo = {
+    id: 12345678,
+    versions: [
+      {
+        versionId: 98765432,
+        content: '**'
+      },
+      {
+        versionId: 87654321,
+        content: '*'
+      }
+    ]
   }
+  const propfindFileVersionsRequestData = {
+    method: 'PROPFIND',
+    path: Pact.Matchers.regex({
+      matcher: `.*\\/remote\\.php\\/dav\\/meta\\/${fileInfo.id}\\/v$`,
+      generate: `/remote.php/dav/meta/${fileInfo.id}/v`
+    }),
+    headers: validAuthHeaders,
+    body: '<?xml version="1.0"?>\n' +
+      '<d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">\n' +
+      '  <d:prop>\n' +
+      '  </d:prop>\n' +
+      '</d:propfind>'
+  }
+
+  const header = {
+    ...applicationXmlResponseHeaders,
+    'Access-Control-Allow-Headers': accessControlAllowHeaders,
+    'Access-Control-Allow-Methods': accessControlAllowMethods
+  }
+
+  const propfindFileVersionsResponse = (version, contentLength) => {
+    return '    <d:response>\n' +
+            `        <d:href>/remote.php/dav/meta/${fileInfo.id}/v/${fileInfo.versions[version].versionId}</d:href>\n` +
+            '        <d:propstat>\n' +
+            '            <d:prop>\n' +
+            '                <d:getlastmodified>Thu, 08 Oct 2020 02:28:50 GMT</d:getlastmodified>\n' +
+            `                <d:getcontentlength>${contentLength}</d:getcontentlength>\n` +
+            '                <d:resourcetype/>\n' +
+            '                <d:getetag>&quot;bc7012325dcc9899be7da7cabfdddb00&quot;</d:getetag>\n' +
+            '                <d:getcontenttype>text/plain</d:getcontenttype>\n' +
+            '            </d:prop>\n' +
+            '            <d:status>HTTP/1.1 200 OK</d:status>\n' +
+            '        </d:propstat>\n' +
+            '        <d:propstat>\n' +
+            '            <d:prop>\n' +
+            '                <d:quota-used-bytes/>\n' +
+            '                <d:quota-available-bytes/>\n' +
+            '            </d:prop>\n' +
+            '            <d:status>HTTP/1.1 404 Not Found</d:status>\n' +
+            '        </d:propstat>\n' +
+            '    </d:response>\n'
+  }
+
+  const fileVersionPath = version => Pact.Matchers.regex({
+    matcher: `.*\\/remote\\.php\\/dav\\/meta\\/${fileInfo.id}\\/v\\/${fileInfo.versions[version].versionId}$`,
+    generate: `/remote.php/dav/meta/${fileInfo.id}/v/${fileInfo.versions[version].versionId}`
+  })
 
   beforeEach(function (done) {
     oc = new OwnCloud({
@@ -43,80 +92,173 @@ describe('Main: Currently testing file versions management,', function () {
 
     oc.login().then(status => {
       expect(status).toEqual({ id: 'admin', 'display-name': 'admin', email: {} })
-
-      // create three versions
-      oc.files.createFolder(testFolder).then(status => {
-        oc.files.putFileContents(versionedFile, '*').then(status => {
-          sleep(1000).then(() => {
-            oc.files.putFileContents(versionedFile, '**', { previousEntityTag: status.ETag }).then(status => {
-              sleep(1000).then(() => {
-                oc.files.putFileContents(versionedFile, '***', { previousEntityTag: status.ETag }).then(status => {
-                  oc.files.fileInfo(versionedFile, ['{http://owncloud.org/ns}fileid']).then(fileInfo => {
-                    versionedFileInfo = fileInfo
-                    done()
-                  })
-                })
-              })
-            })
-          })
-        })
-      })
+      done()
     }).catch(error => {
       expect(error).toBe(null)
       done()
     })
   })
   afterEach(function () {
-    oc.files.delete(testFolder)
     oc.logout()
     oc = null
   })
 
-  it('checking method: getFileVersionUrl', function () {
-    const url = oc.fileVersions.getFileVersionUrl(666, 123456)
-    expect(url).toBe(config.owncloudURL + 'remote.php/dav/meta/666/v/123456')
-  })
+  describe('file versions of non existing file', () => {
+    beforeAll(done => {
+      const promises = []
+      promises.push(setGeneralInteractions(provider))
+      promises.push(provider.addInteraction({
+        uponReceiving: 'PROPFIND file versions of non existent file',
+        withRequest: propfindFileVersionsRequestData,
+        willRespondWith: {
+          status: 404,
+          headers: applicationXmlResponseHeaders,
+          body: '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">\n' +
+            '  <s:exception>Sabre\\DAV\\Exception\\NotFound</s:exception>\n' +
+            '  <s:message/>\n' +
+            '</d:error>'
+        }
+      }))
 
-  it('retrieves file versions', function (done) {
-    oc.fileVersions.listVersions(versionedFileInfo.getFileId()).then(versions => {
-      expect(versions.length).toEqual(2)
-      expect(versions[0].getSize()).toEqual(2)
-      expect(versions[1].getSize()).toEqual(1)
-      oc.fileVersions.getFileVersionContents(versionedFileInfo.getFileId(), versions[0].getName()).then(content => {
-        expect(content).toBe('**')
-        oc.fileVersions.getFileVersionContents(versionedFileInfo.getFileId(), versions[1].getName()).then(content => {
-          expect(content).toBe('*')
-          done()
-        })
+      Promise.all(promises).then(done, done.fail)
+    })
+
+    afterAll(function (done) {
+      provider.removeInteractions().then(done, done.fail)
+    })
+    it('retrieves file versions of not existing file', function (done) {
+      oc.fileVersions.listVersions(fileInfo.id).then(versions => {
+        expect(versions).toBe(null)
+        done()
+      }).catch(error => {
+        expect(error.statusCode).toBe(404)
+        expect(error.message).toBe('')
+        done()
       })
     })
   })
 
-  it('retrieves file versions of not existing file', function (done) {
-    oc.fileVersions.listVersions(12345678).then(versions => {
-      expect(versions).toBe(null)
-      done()
-    }).catch(error => {
-      expect(error.statusCode).toBe(404)
-      expect(error.message).toBe('')
-      done()
-    })
-  })
+  describe('file versions for existing files', () => {
+    beforeAll(done => {
+      const promises = []
+      promises.push(setGeneralInteractions(provider))
+      promises.push(provider.addInteraction({
+        uponReceiving: 'PROPFIND file versions of existent file',
+        withRequest: propfindFileVersionsRequestData,
+        willRespondWith: {
+          status: 207,
+          headers: header,
+          body: '<?xml version="1.0"?>\n' +
+            '<d:multistatus\n' +
+            '    xmlns:d="DAV:"\n' +
+            '    xmlns:s="http://sabredav.org/ns"\n' +
+            '    xmlns:oc="http://owncloud.org/ns">\n' +
+            '    <d:response>\n' +
+            `        <d:href>/remote.php/dav/meta/${fileInfo.id}/v/</d:href>\n` +
+            '        <d:propstat>\n' +
+            '            <d:prop>\n' +
+            '                <d:resourcetype>\n' +
+            '                    <d:collection/>\n' +
+            '                </d:resourcetype>\n' +
+            '            </d:prop>\n' +
+            '            <d:status>HTTP/1.1 200 OK</d:status>\n' +
+            '        </d:propstat>\n' +
+            '    </d:response>\n' +
+            `${propfindFileVersionsResponse(1, 2)}` +
+            `${propfindFileVersionsResponse(0, 1)}` +
+            '</d:multistatus>'
+        }
+      }))
 
-  it('restore file version', function (done) {
-    oc.fileVersions.listVersions(versionedFileInfo.getFileId()).then(versions => {
-      expect(versions.length).toEqual(2)
-      expect(versions[0].getSize()).toEqual(2)
-      expect(versions[1].getSize()).toEqual(1)
-      oc.fileVersions.restoreFileVersion(versionedFileInfo.getFileId(), versions[0].getName(), versionedFile).then(status => {
-        expect(status).toBe(true)
-        oc.files.getFileContents(versionedFile).then(content => {
-          expect(content).toBe('**')
+      for (let i = 0; i < fileInfo.versions.length; i++) {
+        promises.push(provider.addInteraction({
+          uponReceiving: 'GET file version contents',
+          withRequest: {
+            method: 'GET',
+            path: fileVersionPath(i),
+            headers: validAuthHeaders
+          },
+          willRespondWith: {
+            status: 200,
+            headers: header,
+            body: fileInfo.versions[i].content
+          }
+        }))
+      }
+
+      promises.push(provider.addInteraction({
+        uponReceiving: 'Restore file versions',
+        withRequest: {
+          method: 'COPY',
+          path: fileVersionPath(0),
+          headers: validAuthHeaders
+        },
+        willRespondWith: {
+          status: 204,
+          headers: header
+        }
+      }))
+
+      promises.push(provider.addInteraction({
+        uponReceiving: 'GET file contents',
+        withRequest: {
+          method: 'GET',
+          path: Pact.Matchers.regex({
+            matcher: `.*\\/remote\\.php\\/webdav\\/${versionedFile}`,
+            generate: `/remote.php/webdav/${versionedFile}`
+          }),
+          headers: validAuthHeaders
+        },
+        willRespondWith: {
+          status: 200,
+          headers: header,
+          body: fileInfo.versions[0].content
+        }
+      }))
+
+      Promise.all(promises).then(done, done.fail)
+    })
+
+    afterAll(function (done) {
+      provider.removeInteractions().then(done, done.fail)
+    })
+
+    it('checking method: getFileVersionUrl', function () {
+      const url = oc.fileVersions.getFileVersionUrl(666, 123456)
+      expect(url).toBe(config.owncloudURL + 'remote.php/dav/meta/666/v/123456')
+    })
+
+    it('retrieves file versions', async function (done) {
+      oc.fileVersions.listVersions(fileInfo.id).then(versions => {
+        expect(versions.length).toEqual(2)
+        expect(versions[0].getSize()).toEqual(2)
+        expect(versions[1].getSize()).toEqual(1)
+        oc.fileVersions.getFileVersionContents(fileInfo.id, fileInfo.versions[0].versionId).then(content => {
+          expect(content).toBe(fileInfo.versions[0].content)
+          oc.fileVersions.getFileVersionContents(fileInfo.id, fileInfo.versions[1].versionId).then(content => {
+            expect(content).toBe(fileInfo.versions[1].content)
+            done()
+          })
+        })
+      })
+    })
+
+    it('restore file version', function (done) {
+      oc.fileVersions.listVersions(fileInfo.id).then(versions => {
+        expect(versions.length).toEqual(2)
+        expect(versions[0].getSize()).toEqual(2)
+        expect(versions[1].getSize()).toEqual(1)
+        oc.fileVersions.restoreFileVersion(fileInfo.id, fileInfo.versions[0].versionId, versionedFile).then(status => {
+          expect(status).toBe(true)
+          oc.files.getFileContents(versionedFile).then(content => {
+            expect(content).toBe(fileInfo.versions[0].content)
+            done()
+          })
+        }).catch(reason => {
+          fail(reason)
           done()
         })
-      }).catch(reason => {
-        fail(reason)
-        done()
       })
     })
   })

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -3,7 +3,7 @@ var validUserPasswordHash = btoa(config.username + ':' + config.password)
 const Pact = require('@pact-foundation/pact-web')
 
 const accessControlAllowHeaders = 'OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With'
-const accessControlAllowMethods = 'GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT,COPY,MOVE,HEAD'
+const accessControlAllowMethods = 'GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT,COPY,MOVE,HEAD,LOCK,UNLOCK'
 const origin = 'http://localhost:9876'
 const validAuthHeaders = {
   authorization: 'Basic ' + validUserPasswordHash,


### PR DESCRIPTION
### Description
This PR refactors `fileVersionTest.js` to use pact.io and adds the interactions related to file versions into the tests/fileVersionTest.js file.

Part of https://github.com/owncloud/owncloud-sdk/issues/500