### PR TITLE
[Tests-Only] Convert fdescribe to describe

### DIFF
--- a/tests/appsTest.js
+++ b/tests/appsTest.js
@@ -1,4 +1,4 @@
-fdescribe('Main: Currently testing apps management,', function () {
+describe('Main: Currently testing apps management,', function () {
   const OwnCloud = require('../src/owncloud')
   const utf8 = require('utf8')
   const config = require('./config/config.json')

--- a/tests/capabilitiesTest.js
+++ b/tests/capabilitiesTest.js
@@ -1,4 +1,4 @@
-fdescribe('Main: Currently testing getConfig, getVersion and getCapabilities', function () {
+describe('Main: Currently testing getConfig, getVersion and getCapabilities', function () {
   const OwnCloud = require('../src/owncloud')
   const config = require('./config/config.json')
 

--- a/tests/fileTrashTest.js
+++ b/tests/fileTrashTest.js
@@ -1,4 +1,4 @@
-fdescribe('oc.fileTrash', function () {
+describe('oc.fileTrash', function () {
   const OwnCloud = require('../src/owncloud')
   const config = require('./config/config.json')
 

--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -1,4 +1,4 @@
-fdescribe('Main: Currently testing file versions management,', function () {
+describe('Main: Currently testing file versions management,', function () {
   const OwnCloud = require('../src/owncloud')
   const config = require('./config/config.json')
 

--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -1,4 +1,4 @@
-fdescribe('Main: Currently testing files management,', function () {
+describe('Main: Currently testing files management,', function () {
   const FileInfo = require('../src/fileInfo')
   const OwnCloud = require('../src/owncloud')
   const config = require('./config/config.json')

--- a/tests/groupTest.js
+++ b/tests/groupTest.js
@@ -1,4 +1,4 @@
-fdescribe('Main: Currently testing group management,', function () {
+describe('Main: Currently testing group management,', function () {
   var OwnCloud = require('../src/owncloud')
   var config = require('./config/config.json')
 

--- a/tests/loginTest.js
+++ b/tests/loginTest.js
@@ -1,4 +1,4 @@
-fdescribe('Main: Currently testing Login and initLibrary,', function () {
+describe('Main: Currently testing Login and initLibrary,', function () {
   var OwnCloud = require('../src/owncloud')
   var config = require('./config/config.json')
 

--- a/tests/owncloud-sign-url/signUrlTest.js
+++ b/tests/owncloud-sign-url/signUrlTest.js
@@ -6,7 +6,7 @@ const HTTP_GET_METHOD = 'get'
 const HTTP_POST_METHOD = 'post'
 const TEST_PORT = 33001
 
-fdescribe('SignUrl tests', () => {
+describe('SignUrl tests', () => {
   let signUrl
 
   beforeAll(async () => {

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -1,4 +1,4 @@
-fdescribe('oc.publicFiles', function () {
+describe('oc.publicFiles', function () {
   // CURRENT TIME
   const OwnCloud = require('../src/owncloud')
   const config = require('./config/config.json')

--- a/tests/requestsOcsTest.js
+++ b/tests/requestsOcsTest.js
@@ -1,4 +1,4 @@
-fdescribe('Main: Currently testing low level OCS', function () {
+describe('Main: Currently testing low level OCS', function () {
   var OwnCloud = require('../src/owncloud')
   var config = require('./config/config.json')
 

--- a/tests/shareRecipientTest.js
+++ b/tests/shareRecipientTest.js
@@ -1,4 +1,4 @@
-fdescribe('Main: Currently testing share recipient,', function () {
+describe('Main: Currently testing share recipient,', function () {
   var OwnCloud = require('../src/owncloud')
   var config = require('./config/config.json')
 

--- a/tests/sharingTest.js
+++ b/tests/sharingTest.js
@@ -1,4 +1,4 @@
-fdescribe('Main: Currently testing file/folder sharing,', function () {
+describe('Main: Currently testing file/folder sharing,', function () {
   const OwnCloud = require('../src/owncloud')
   const config = require('./config/config.json')
 

--- a/tests/sharingWithAttributesTest.js
+++ b/tests/sharingWithAttributesTest.js
@@ -1,4 +1,4 @@
-fdescribe('oc.shares', function () {
+describe('oc.shares', function () {
   const OwnCloud = require('../src/owncloud')
   const config = require('./config/config.json')
 

--- a/tests/signedUrlIntegrationTest.js
+++ b/tests/signedUrlIntegrationTest.js
@@ -1,4 +1,4 @@
-fdescribe('Signed urls', function () {
+describe('Signed urls', function () {
   var OwnCloud = require('../src/owncloud')
   var config = require('./config/config.json')
 

--- a/tests/signedUrlTest.js
+++ b/tests/signedUrlTest.js
@@ -1,4 +1,4 @@
-fdescribe('Main: Currently testing url signing,', function () {
+describe('Main: Currently testing url signing,', function () {
   var OwnCloud = require('../src/owncloud')
   var config = require('./config/config.json')
 

--- a/tests/unauthorized/appsTest.js
+++ b/tests/unauthorized/appsTest.js
@@ -1,4 +1,4 @@
-fdescribe('Unauthorized: Currently testing apps management,', function () {
+describe('Unauthorized: Currently testing apps management,', function () {
   // CURRENT TIME
   const timeRightNow = new Date().getTime()
   const OwnCloud = require('../../src')

--- a/tests/unauthorized/capabilitiesTest.js
+++ b/tests/unauthorized/capabilitiesTest.js
@@ -1,4 +1,4 @@
-fdescribe('Unauthorized: Currently testing getConfig, getVersion and getCapabilities', function () {
+describe('Unauthorized: Currently testing getConfig, getVersion and getCapabilities', function () {
   const OwnCloud = require('../../src')
   const config = require('../config/config.json')
   // LIBRARY INSTANCE

--- a/tests/unauthorized/filesTest.js
+++ b/tests/unauthorized/filesTest.js
@@ -1,4 +1,4 @@
-fdescribe('Unauthorized: Currently testing files management,', function () {
+describe('Unauthorized: Currently testing files management,', function () {
   const OwnCloud = require('../../src')
   const config = require('../config/config.json')
 

--- a/tests/unauthorized/groupTest.js
+++ b/tests/unauthorized/groupTest.js
@@ -1,4 +1,4 @@
-fdescribe('Unauthorized: Currently testing group management,', function () {
+describe('Unauthorized: Currently testing group management,', function () {
   var OwnCloud = require('../../src')
   var config = require('../config/config.json')
 

--- a/tests/unauthorized/sharingTest.js
+++ b/tests/unauthorized/sharingTest.js
@@ -1,4 +1,4 @@
-fdescribe('Unauthorized: Currently testing file/folder sharing,', function () {
+describe('Unauthorized: Currently testing file/folder sharing,', function () {
   const OwnCloud = require('../../src')
   const config = require('../config/config.json')
 

--- a/tests/unauthorized/userTest.js
+++ b/tests/unauthorized/userTest.js
@@ -1,4 +1,4 @@
-fdescribe('Unauthorized: Currently testing user management,', function () {
+describe('Unauthorized: Currently testing user management,', function () {
   // CURRENT TIME
   var timeRightNow = new Date().getTime()
   var OwnCloud = require('../../src')

--- a/tests/userTest.js
+++ b/tests/userTest.js
@@ -1,4 +1,4 @@
-fdescribe('Main: Currently testing user management,', function () {
+describe('Main: Currently testing user management,', function () {
   var OwnCloud = require('../src/owncloud')
   var config = require('./config/config.json')
 


### PR DESCRIPTION
### Description
Since we have converted all the tests to pact.io, there's no need for a focused describe `fdescribe`. So, this PR converts all the `fdescribe`s to `describe`

### Related Issue
#500