### PR TITLE
move from browser-request to cross-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "axios": "^0.19.2",
-    "browser-request": "^0.3.3",
+    "cross-fetch": "^3.0.6",
     "davclient.js": "https://github.com/owncloud/davclient.js.git",
     "promise": "^8.0.3",
     "request": "^2.88.0",

--- a/src/fileManagement.js
+++ b/src/fileManagement.js
@@ -87,8 +87,8 @@ class Files {
         return Promise.resolve({
           body: body,
           headers: {
-            ETag: response.getResponseHeader('etag'),
-            'OC-FileId': response.getResponseHeader('oc-fileid')
+            ETag: response.headers.get('etag'),
+            'OC-FileId': response.headers.get('oc-fileid')
           }
         })
       }

--- a/tests/loginTest.js
+++ b/tests/loginTest.js
@@ -64,7 +64,7 @@ describe('Main: Currently testing Login and initLibrary,', function () {
       fail()
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -84,7 +84,7 @@ describe('Main: Currently testing Login and initLibrary,', function () {
       fail()
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })

--- a/tests/unauthorized/appsTest.js
+++ b/tests/unauthorized/appsTest.js
@@ -85,7 +85,7 @@ describe('Unauthorized: Currently testing apps management,', function () {
       expect(apps).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -98,7 +98,7 @@ describe('Unauthorized: Currently testing apps management,', function () {
         expect(status).toBe(null)
         done()
       }).catch(error => {
-        expect(error).toMatch('Unauthorised')
+        expect(error).toMatch('Unauthorized')
         count++
         if (count === key.length) {
           done()
@@ -115,7 +115,7 @@ describe('Unauthorized: Currently testing apps management,', function () {
         expect(data).toBe(null)
         done()
       }).catch(error => {
-        expect(error).toMatch('Unauthorised')
+        expect(error).toMatch('Unauthorized')
         count++
         if (count === key.length) {
           done()
@@ -132,7 +132,7 @@ describe('Unauthorized: Currently testing apps management,', function () {
         expect(status).toBe(null)
         done()
       }).catch(error => {
-        expect(error).toMatch('Unauthorised')
+        expect(error).toMatch('Unauthorized')
         count++
         if (count === key.length) {
           done()
@@ -146,7 +146,7 @@ describe('Unauthorized: Currently testing apps management,', function () {
       expect(status).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -156,7 +156,7 @@ describe('Unauthorized: Currently testing apps management,', function () {
       expect(status).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })

--- a/tests/unauthorized/capabilitiesTest.js
+++ b/tests/unauthorized/capabilitiesTest.js
@@ -36,7 +36,7 @@ describe('Unauthorized: Currently testing getConfig, getVersion and getCapabilit
       expect(capabilities).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })

--- a/tests/unauthorized/groupTest.js
+++ b/tests/unauthorized/groupTest.js
@@ -67,7 +67,7 @@ describe('Unauthorized: Currently testing group management,', function () {
       expect(status).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -77,7 +77,7 @@ describe('Unauthorized: Currently testing group management,', function () {
       expect(data).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -87,7 +87,7 @@ describe('Unauthorized: Currently testing group management,', function () {
       expect(status).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -97,7 +97,7 @@ describe('Unauthorized: Currently testing group management,', function () {
       expect(data).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -107,7 +107,7 @@ describe('Unauthorized: Currently testing group management,', function () {
       expect(status).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })

--- a/tests/unauthorized/sharingTest.js
+++ b/tests/unauthorized/sharingTest.js
@@ -86,7 +86,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
       expect(share).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -96,7 +96,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
       expect(share).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -108,7 +108,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
       expect(share).toEqual(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -118,7 +118,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
       expect(status).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -128,7 +128,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
       expect(share).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -138,7 +138,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
       expect(shares).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -148,7 +148,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
       expect(share).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -158,7 +158,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
       expect(status).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })

--- a/tests/unauthorized/userTest.js
+++ b/tests/unauthorized/userTest.js
@@ -110,7 +110,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       expect(data).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -125,7 +125,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       expect(data).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -135,7 +135,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       expect(data).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -145,7 +145,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       expect(status).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -160,7 +160,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       expect(data).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -175,7 +175,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       expect(status).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -185,7 +185,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       expect(data).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -195,7 +195,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       expect(status).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -210,7 +210,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       expect(data).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -225,7 +225,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       expect(status).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -240,7 +240,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       expect(status).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -250,7 +250,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       expect(data).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -260,7 +260,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       expect(status).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })
@@ -278,7 +278,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       expect(status).toBe(null)
       done()
     }).catch(error => {
-      expect(error).toMatch('Unauthorised')
+      expect(error).toMatch('Unauthorized')
       done()
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1765,11 +1765,6 @@ brorand@^1.0.1:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
-browser-request@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/browser-request/-/browser-request-0.3.3.tgz#9ece5b5aca89a29932242e18bf933def9876cc17"
-  integrity sha1-ns5bWsqJopkyJC4Yv5M975h2zBc=
-
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
@@ -2392,6 +2387,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+cross-fetch@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
+  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
+  dependencies:
+    node-fetch "2.6.1"
 
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -5131,7 +5133,7 @@ node-addon-api@^1.7.1:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
 
-node-fetch@^2.2.0:
+node-fetch@2.6.1, node-fetch@^2.2.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
move from https://github.com/iriscouch/browser-request to https://github.com/lquixada/cross-fetch
reasons:
1. browser-request seems not to be maintained anymore
2. to be able to switch the tests to jest, to run jest with pact-io we need to run it in node mode and `browser-request` does not support that

`Unauthorised` vs. `Unauthorized`
the HTTP response text for `401` is `Unauthorized` (`browser-request` seem to have returned
`Unauthorised`) but the OCS status response is `Unauthorised`, so in the tests we have mixed expectations

```
curl http://localhost/owncloud-core/ocs/v1.php/cloud/apps -v
*   Trying 127.0.0.1:80...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 80 (#0)
> GET /owncloud-core/ocs/v1.php/cloud/apps HTTP/1.1
> Host: localhost
> User-Agent: curl/7.68.0
> Accept: */*

< HTTP/1.1 401 Unauthorized
< Date: Mon, 28 Dec 2020 09:51:59 GMT
< Server: Apache/2.4.43 (Ubuntu)
...
< Content-Length: 153
< Content-Type: text/xml; charset=UTF-8
< 
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>failure</status>
  <statuscode>997</statuscode>
  <message>Unauthorised</message>
 </meta>
 <data/>
</ocs>
```