### PR TITLE
provider tests run in drone with oc10

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -172,6 +172,7 @@ module.exports = {
     '**/tests/fileTrashTest.js',
     '**/tests/fileVersionTest.js',
     '**/tests/filesTest.js',
+    '**/tests/providerTest.js'
   ]
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   "scripts": {
     "lint": "eslint tests/**/*.js tests/*.js src/**/*.js src/*.js --color --global requirejs --global require",
     "lint-fix": "eslint tests/**/*.js tests/*.js src/**/*.js src/*.js --color --global requirejs --global require --fix",
-    "test": "jest --runInBand",
-    "test-drone": "jest --runInBand",
+    "test-consumer": "jest --runInBand --testPathIgnorePatterns='provider.*'",
+    "test-provider": "jest --runInBand providerTest.js",
     "build:docs": "jsdoc -c jsdoc.conf.json",
     "build:system": "webpack"
   },
@@ -69,6 +69,7 @@
     "lint-staged": ">=8",
     "mocha": "^8.2.1",
     "sinon": "^9.0.2",
+    "sync-fetch": "^0.3.0",
     "webpack": "^4.30.0",
     "webpack-cli": "^3.3.2",
     "webpack-node-externals": "^1.7.2"

--- a/tests/appsTest.js
+++ b/tests/appsTest.js
@@ -63,8 +63,8 @@ describe('Main: Currently testing apps management,', function () {
           }).appendElement('data', '', (data) => {
             data.appendElement('apps', '', (apps) => {
               apps
-                .appendElement('element', '', 'workflow')
-                .appendElement('element', '', 'files')
+                .appendElement('element', '', MatchersV3.string('workflow'))
+                .appendElement('element', '', MatchersV3.string('files'))
             })
           })
         })

--- a/tests/appsTest.js
+++ b/tests/appsTest.js
@@ -9,12 +9,27 @@ describe('Main: Currently testing apps management,', function () {
     capabilitiesGETRequestValidAuth,
     GETRequestToCloudUserEndpoint,
     xmlResponseHeaders,
+    htmlResponseHeaders,
     createProvider,
     createOwncloud
   } = require('./pactHelper.js')
 
   const changeAppStatus = (provider, action) => {
-    const method = action === 'enable' ? 'POST' : 'DELETE'
+    let method = 'DELETE'
+    let responseHeader = htmlResponseHeaders
+    let body = ''
+    if (action === 'enable') {
+      method = 'POST'
+      responseHeader = xmlResponseHeaders
+      body = new XmlBuilder('1.0', '', 'ocs').build(ocs => {
+        ocs.appendElement('meta', '', (meta) => {
+          meta
+            .appendElement('status', '', 'ok')
+            .appendElement('statuscode', '', 100)
+            .appendElement('message', '', '')
+        }).appendElement('data', '', '')
+      })
+    }
     return provider
       .uponReceiving(action + ' apps')
       .withRequest({
@@ -27,15 +42,8 @@ describe('Main: Currently testing apps management,', function () {
       })
       .willRespondWith({
         status: 200,
-        headers: xmlResponseHeaders,
-        body: new XmlBuilder('1.0', '', 'ocs').build(ocs => {
-          ocs.appendElement('meta', '', (meta) => {
-            meta
-              .appendElement('status', '', 'ok')
-              .appendElement('statuscode', '', 100)
-              .appendElement('message', '', '')
-          }).appendElement('data', '', '')
-        })
+        headers: responseHeader,
+        body: body
       })
   }
 

--- a/tests/capabilitiesTest.js
+++ b/tests/capabilitiesTest.js
@@ -33,9 +33,8 @@ describe('Main: Currently testing getConfig, getVersion and getCapabilities', ()
           ocs.appendElement('meta', '', (meta) => {
             meta.appendElement('status', '', 'ok')
               .appendElement('statuscode', '', '100')
-              .appendElement('message', '', '')
           }).appendElement('data', '', (data) => {
-            data.appendElement('version', '', '1.7')
+            data.appendElement('version', '', MatchersV3.decimal(1.7))
           })
         })
       })

--- a/tests/capabilitiesTest.js
+++ b/tests/capabilitiesTest.js
@@ -9,7 +9,7 @@ describe('Main: Currently testing getConfig, getVersion and getCapabilities', ()
     capabilitiesGETRequestValidAuth,
     GETRequestToCloudUserEndpoint,
     validAuthHeaders,
-    xmlResponseHeaders
+    applicationXmlResponseHeaders
   } = require('./pactHelper.js')
 
   it('checking method : getConfig', async () => {
@@ -28,7 +28,7 @@ describe('Main: Currently testing getConfig, getVersion and getCapabilities', ()
       })
       .willRespondWith({
         status: 200,
-        headers: xmlResponseHeaders,
+        headers: applicationXmlResponseHeaders,
         body: new XmlBuilder('1.0', '', 'ocs').build(ocs => {
           ocs.appendElement('meta', '', (meta) => {
             meta.appendElement('status', '', 'ok')

--- a/tests/groupTest.js
+++ b/tests/groupTest.js
@@ -16,6 +16,7 @@ describe('Main: Currently testing group management,', function () {
 
   async function GETGroupsRequest (provider) {
     await provider
+      .given('group exists', { groupName: config.testGroup })
       .uponReceiving('a GET groups request')
       .withRequest({
         method: 'GET',
@@ -43,6 +44,14 @@ describe('Main: Currently testing group management,', function () {
   }
 
   async function DELETEGroupRequests (provider, group) {
+    if (group === config.nonExistentGroup) {
+      await provider
+        .given('group does not exist', { groupName: group })
+    } else {
+      await provider
+        .given('group exists', { groupName: group })
+    }
+
     await provider
       .uponReceiving('a DELETE request for group, ' + group)
       .withRequest({
@@ -165,6 +174,7 @@ describe('Main: Currently testing group management,', function () {
   it('checking method : createGroup', async function () {
     const headers = { ...validAuthHeaders, ...{ 'Content-Type': 'application/x-www-form-urlencoded' } }
     await provider
+      .given('group does not exist', { groupName: config.testGroup })
       .uponReceiving('a create group POST request')
       .withRequest({
         method: 'POST',

--- a/tests/groupTest.js
+++ b/tests/groupTest.js
@@ -9,7 +9,6 @@ describe('Main: Currently testing group management,', function () {
     validAuthHeaders,
     xmlResponseHeaders,
     ocsMeta,
-    applicationXmlResponseHeaders,
     capabilitiesGETRequestValidAuth,
     GETRequestToCloudUserEndpoint,
     createOwncloud
@@ -173,11 +172,12 @@ describe('Main: Currently testing group management,', function () {
           /.*\/ocs\/v1\.php\/cloud\/groups$/,
           '/ocs/v1.php/cloud/groups'
         ),
-        headers: headers
+        headers: headers,
+        body: 'groupid=' + config.testGroup
       })
       .willRespondWith({
         status: 200,
-        headers: applicationXmlResponseHeaders,
+        headers: xmlResponseHeaders,
         body: new XmlBuilder('1.0', '', 'ocs').build(ocs => {
           ocs.appendElement('meta', '', (meta) => {
             return ocsMeta(meta, 'ok', '100')

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -68,6 +68,10 @@ const xmlResponseHeaders = {
   'Content-Type': 'text/xml; charset=utf-8'
 }
 
+const htmlResponseHeaders = {
+  'Content-Type': 'text/html; charset=utf-8'
+}
+
 const getAuthHeaders = (username, password) => {
   const header = `${username}:${password}`
   const buff = Buffer.from(header)
@@ -514,6 +518,7 @@ module.exports = {
   validAuthHeaders,
   invalidAuthHeader,
   xmlResponseHeaders,
+  htmlResponseHeaders,
   applicationXmlResponseHeaders,
   applicationFormUrlEncoded,
   textPlainResponseHeaders,

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -22,6 +22,7 @@ describe('provider testing', () => {
       opts.pactBrokerUrl = 'https://jankaritech.pactflow.io'
       opts.publishVerificationResult = true
       opts.pactBrokerToken = process.env.PACTFLOW_TOKEN
+      opts.enablePending = true
       opts.consumerVersionSelectors = [
         {
           tag: process.env.DRONE_SOURCE_BRANCH,

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -1,0 +1,71 @@
+describe('provider testing', () => {
+  const { VerifierV3 } = require('@pact-foundation/pact/v3')
+  const chai = require('chai')
+  const chaiAsPromised = require('chai-as-promised')
+  const path = require('path')
+  const fetch = require('sync-fetch')
+
+  const {
+    validAuthHeaders
+  } = require('./pactHelper.js')
+
+  chai.use(chaiAsPromised)
+
+  it('verifies the provider', () => {
+    const opts = {
+      provider: 'oc-server',
+      logLevel: 'debug',
+      providerBaseUrl: process.env.PROVIDER_BASE_URL || 'http://localhost/',
+      disableSSLVerification: true
+    }
+    if (process.env.CI === 'true') {
+      opts.pactBrokerUrl = 'https://jankaritech.pactflow.io'
+      opts.publishVerificationResult = true
+      opts.pactBrokerToken = process.env.PACTFLOW_TOKEN
+      opts.consumerVersionSelectors = [
+        {
+          tag: process.env.DRONE_SOURCE_BRANCH,
+          latest: true
+        }
+      ]
+      opts.providerVersion = process.env.PROVIDER_VERSION
+    } else {
+      opts.pactUrls = [path.resolve(process.cwd(), 'tests', 'pacts', 'owncloud-sdk-oc-server.json')]
+    }
+
+    opts.stateHandlers = {
+      'group exists': (setup, parameters) => {
+        if (setup) {
+          fetch(process.env.PROVIDER_BASE_URL + '/ocs/v1.php/cloud/groups', {
+            method: 'POST',
+            body: 'groupid=' + parameters.groupName,
+            headers: {
+              ...validAuthHeaders,
+              ...{ 'Content-Type': 'application/x-www-form-urlencoded' }
+            }
+          })
+          return Promise.resolve({ description: 'group added' })
+        } else {
+          fetch(process.env.PROVIDER_BASE_URL + '/ocs/v1.php/cloud/groups/' + parameters.groupName, {
+            method: 'DELETE',
+            headers: validAuthHeaders
+          })
+          return Promise.resolve({ description: 'group deleted' })
+        }
+      },
+      'group does not exist': (setup, parameters) => {
+        fetch(process.env.PROVIDER_BASE_URL + '/ocs/v1.php/cloud/groups/' + parameters.groupName, {
+          method: 'DELETE',
+          headers: validAuthHeaders
+        })
+        return Promise.resolve({ description: 'group deleted' })
+      }
+    }
+    return new VerifierV3(opts).verifyProvider().then(output => {
+      console.log('Pact Verification Complete!')
+      console.log('Result:', output)
+    }).catch(function (error) {
+      chai.assert.fail(error.message)
+    })
+  }, 60000)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1992,7 +1992,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -2241,6 +2241,14 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+buffer@^5.7.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 buffers@~0.1.1:
   version "0.1.1"
@@ -4500,7 +4508,7 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ieee754@^1.1.4:
+ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -6287,7 +6295,7 @@ nise@^4.0.4:
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
-node-fetch@2.6.1, node-fetch@^2.2.0:
+node-fetch@2.6.1, node-fetch@^2.2.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -8134,6 +8142,14 @@ symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
+sync-fetch@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/sync-fetch/-/sync-fetch-0.3.0.tgz#77246da949389310ad978ab26790bb05f88d1335"
+  integrity sha512-dJp4qg+x4JwSEW1HibAuMi0IIrBI3wuQr2GimmqB7OXR50wmwzfdusG+p39R9w3R6aFtZ2mzvxvWKQ3Bd/vx3g==
+  dependencies:
+    buffer "^5.7.0"
+    node-fetch "^2.6.1"
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
part of #644 
fixes #647

This PR is the start to run the existing pact tests against oC10 as provider

1. adjust some tests so that they pass on the provider
2. create pact states (given ...) to setup and delete groups - because we cannot have currently async code in the state handlers I'm using the `sync-fetch` library for that
3. setup and run provider tests in drone with oc10

## run provider tests locally:
- run consumer tests: `rm tests/pacts/owncloud-sdk-oc-server.json ; yarn run test-consumer`
- run provider tests: `PROVIDER_BASE_URL=http://localhost/owncloud-core yarn test-provider`

the local test run will currently fail because there are still a lot of interaction that are not correct (e.g. CORS) and other interactions have missing given steps.

To run only a subset of tests reduce the `testMatch` in `jest.config.js`

## run in CI:
in CI the consumer tests are run and uploaded to https://jankaritech.pactflow.io/ and tagged with the current commit & branch 
then the provider tests are run against oc10 - the result is also published on pactflow
Even some provider side tests fail they will currently not fail CI, because the pact is marked as `pending` see http://blog.pact.io/2020/02/24/how-we-have-fixed-the-biggest-problem-with-the-pact-workflow/

At the beginning of the provider CI run drone will show an URL where the results are uploaded to e.g. https://jankaritech.pactflow.io/pacts/provider/oc-server/consumer/owncloud-sdk/pact-version/7e080f863d0da14797a4aea282ec06a268825dc1
sadly the result is not public, but we can add up to 10users in the current account

next job will to be fix all the interactions, so that they pass with oc10