### PR TITLE
Refactor appsTests and capabilitiesTest

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -51,6 +51,19 @@ def buildSystem():
             ],
     }]
 
+def pactLog():
+    return [{
+            'name': 'pact logs',
+            'image': 'owncloudci/nodejs:12',
+            'pull': 'always',
+            'detach': True,
+            'commands': [
+                'mkdir -p /var/www/owncloud/owncloud-sdk/tests/log',
+                'touch /var/www/owncloud/owncloud-sdk/tests/log/pact.log',
+                'tail -f /var/www/owncloud/owncloud-sdk/tests/log/pact.log'
+            ],
+    }]
+
 def prepareTestConfig(subFolderPath = '/'):
     return [{
         'name': 'prepare-test-config',
@@ -141,6 +154,7 @@ def fullBuild():
             buildDocs() +
             buildSystem() +
             prepareTestConfig() +
+            pactLog() +
             test()
     }
 
@@ -163,6 +177,7 @@ def testWithinSubFolder():
             buildDocs() +
             buildSystem() +
             prepareTestConfig('/sub/') +
+            pactLog() +
             test()
     }
 

--- a/tests/appsTest.js
+++ b/tests/appsTest.js
@@ -1,5 +1,4 @@
 describe('Main: Currently testing apps management,', function () {
-  const OwnCloud = require('../src/owncloud')
   const utf8 = require('utf8')
   const config = require('./config/config.json')
 
@@ -18,7 +17,9 @@ describe('Main: Currently testing apps management,', function () {
     capabilitiesGETRequestValidAuth,
     GETRequestToCloudUserEndpoint,
     ocsMeta,
-    xmlResponseHeaders
+    xmlResponseHeaders,
+    pactCleanup,
+    createOwncloud
   } = require('./pactHelper.js')
 
   const responseBody = function (data) {
@@ -29,12 +30,11 @@ describe('Main: Currently testing apps management,', function () {
     '</ocs>'
   }
 
-  beforeAll(function (done) {
+  beforeAll(function () {
     const promises = []
     promises.push(provider.addInteraction(CORSPreflightRequest()))
     promises.push(provider.addInteraction(capabilitiesGETRequestValidAuth()))
     promises.push(provider.addInteraction(GETRequestToCloudUserEndpoint()))
-    Promise.all(promises).then(done, done.fail)
     // a request to GET attributes of an app
     const attributes = {
       attr1: {
@@ -131,35 +131,16 @@ describe('Main: Currently testing apps management,', function () {
       }))
     }
 
-    Promise.all(promises).then(done, done.fail)
+    return Promise.all(promises)
   })
 
-  afterAll(function (done) {
-    provider.removeInteractions().then(done, done.fail)
+  afterAll(function () {
+    return pactCleanup(provider)
   })
 
-  afterAll(function (done) {
-    provider.verify().then(done, done.fail)
-  })
-
-  beforeEach(function (done) {
-    oc = new OwnCloud({
-      baseUrl: config.owncloudURL,
-      auth: {
-        basic: {
-          username: config.username,
-          password: config.password
-        }
-      }
-    })
-
-    oc.login().then(status => {
-      expect(status).toEqual({ id: 'admin', 'display-name': 'admin', email: {} })
-      done()
-    }).catch(error => {
-      expect(error).toBe(null)
-      done()
-    })
+  beforeEach(function () {
+    oc = createOwncloud()
+    return oc.login()
   })
 
   afterEach(function () {

--- a/tests/capabilitiesTest.js
+++ b/tests/capabilitiesTest.js
@@ -10,31 +10,33 @@ describe('Main: Currently testing getConfig, getVersion and getCapabilities', fu
     validAuthHeaders,
     xmlResponseHeaders,
     ocsMeta,
-    createOwncloud
+    createOwncloud,
+    pactCleanup
   } = require('./pactHelper.js')
 
-  beforeAll(function (done) {
+  beforeAll(function () {
     const promises = []
     promises.push(provider.addInteraction(CORSPreflightRequest()))
-    Promise.all(promises).then(done, done.fail)
-  })
-
-  beforeEach(function (done) {
-    const promises = []
     promises.push(provider.addInteraction(capabilitiesGETRequestValidAuth()))
     promises.push(provider.addInteraction(GETRequestToCloudUserEndpoint()))
-    Promise.all(promises).then(done, done.fail)
+    return Promise.all(promises)
   })
 
-  afterEach(async function (done) {
+  afterEach(function () {
     oc.logout()
     oc = null
-    await provider.verify()
-    provider.removeInteractions().then(done, done.fail)
+  })
+
+  beforeEach(function () {
+    oc = createOwncloud()
+    return oc.login()
+  })
+
+  afterAll(function () {
+    return pactCleanup(provider)
   })
 
   it('checking method : getConfig', async function (done) {
-    oc = await createOwncloud()
     await provider.addInteraction({
       uponReceiving: 'GET config request',
       withRequest: {
@@ -72,7 +74,6 @@ describe('Main: Currently testing getConfig, getVersion and getCapabilities', fu
   })
 
   it('checking method : getCapabilities', async function (done) {
-    oc = await createOwncloud()
     oc.getCapabilities().then(capabilities => {
       expect(capabilities).not.toBe(null)
       expect(typeof (capabilities)).toBe('object')

--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -83,7 +83,8 @@ describe('Main: Currently testing file versions management,', function () {
   })
 
   beforeEach(async function () {
-    oc = await createOwncloud()
+    oc = createOwncloud()
+    return oc.login()
   })
 
   afterEach(async function () {

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -113,17 +113,16 @@ const webdavPath = resource => Pact.Matchers.regex({
   generate: `/remote.php/webdav/${resource}`
 })
 
-const createOwncloud = async function () {
+const createOwncloud = function (username = config.username, password = config.password) {
   const oc = new OwnCloud({
     baseUrl: config.owncloudURL,
     auth: {
       basic: {
-        username: config.username,
-        password: config.password
+        username,
+        password
       }
     }
   })
-  await oc.login()
   return oc
 }
 
@@ -513,6 +512,11 @@ function setGeneralInteractions (provider) {
   return promises
 }
 
+function pactCleanup (provider) {
+  return provider.verify()
+    .then(() => provider.removeInteractions())
+}
+
 module.exports = {
   setGeneralInteractions,
   getContentsOfFile,
@@ -545,5 +549,6 @@ module.exports = {
   createAUserWithGroupMembership,
   deleteAUser,
   createAFolder,
-  updateFile
+  updateFile,
+  pactCleanup
 }

--- a/tests/requestsOcsTest.js
+++ b/tests/requestsOcsTest.js
@@ -32,7 +32,8 @@ describe('Main: Currently testing low level OCS', function () {
   })
 
   it('checking : capabilities', async function (done) {
-    oc = await createOwncloud()
+    oc = createOwncloud()
+    await oc.login()
     oc.requests.ocs({
       service: 'cloud',
       action: 'capabilities'
@@ -58,7 +59,8 @@ describe('Main: Currently testing low level OCS', function () {
   })
 
   it('checking : error behavior', async function (done) {
-    oc = await createOwncloud()
+    oc = createOwncloud()
+    await oc.login()
     await provider.addInteraction({
       uponReceiving: 'an update request for an unknown user',
       withRequest: {
@@ -104,7 +106,8 @@ describe('Main: Currently testing low level OCS', function () {
   })
 
   it('checking : PUT email', async function (done) {
-    oc = await createOwncloud()
+    oc = createOwncloud()
+    await oc.login()
     await provider.addInteraction({
       uponReceiving: 'an update user request that sets email',
       given (providerState) {


### PR DESCRIPTION
### Refactor appsTests and capabilitiesTest
1. Add pactLog step in CI for showing pactio log files
2. Remove callbacks from the test hook functions (beforeAll, afterAll, beforeEach, afterEach)
3. use createOwncloud() function from `pacthelper` to create new instance of owncloud sdk

Related https://github.com/owncloud/owncloud-sdk/issues/581