### PR TITLE
Refactor and cleanup unauthorized tests

### DIFF
--- a/tests/unauthorized/capabilitiesTest.js
+++ b/tests/unauthorized/capabilitiesTest.js
@@ -1,37 +1,31 @@
 describe('Unauthorized: Currently testing getConfig, getVersion and getCapabilities', function () {
-  const OwnCloud = require('../../src')
   const config = require('../config/config.json')
+  var timeRightNow = new Date().getTime()
+
   // LIBRARY INSTANCE
   let oc
 
   // PACT setup
   const Pact = require('@pact-foundation/pact-web')
   const provider = new Pact.PactWeb()
-  const { capabilitiesGETRequestInvalidAuth } = require('../pactHelper.js')
+  const { capabilitiesGETRequestInvalidAuth, pactCleanup, createOwncloud } = require('../pactHelper.js')
 
-  beforeAll(function (done) {
-    const promises = []
-    promises.push(provider.addInteraction(capabilitiesGETRequestInvalidAuth()))
-    Promise.all(promises).then(done, done.fail)
+  beforeAll(function () {
+    return provider.addInteraction(capabilitiesGETRequestInvalidAuth())
   })
 
-  afterAll(async function (done) {
-    await provider.verify()
-    provider.removeInteractions().then(done, done.fail)
+  afterAll(function () {
+    return pactCleanup(provider)
   })
 
   beforeEach(function () {
-    oc = new OwnCloud({
-      baseUrl: config.owncloudURL,
-      auth: {
-        basic: {
-          username: config.username,
-          password: config.password + new Date().getTime()
-        }
-      }
-    })
+    oc = createOwncloud(config.username, config.password + timeRightNow)
 
-    oc.login()
+    return oc.login().then(() => {
+      fail('not expected to log in')
+    }).catch(err => {
+      expect(err).toBe('Unauthorized')
+    })
   })
 
   it('checking method : getCapabilities', function (done) {

--- a/tests/unauthorized/userTest.js
+++ b/tests/unauthorized/userTest.js
@@ -1,7 +1,6 @@
 describe('Unauthorized: Currently testing user management,', function () {
   // CURRENT TIME
   var timeRightNow = new Date().getTime()
-  var OwnCloud = require('../../src')
   var config = require('../config/config.json')
 
   // LIBRARY INSTANCE
@@ -13,7 +12,9 @@ describe('Unauthorized: Currently testing user management,', function () {
   const {
     invalidAuthHeader,
     CORSPreflightRequest,
-    capabilitiesGETRequestInvalidAuth
+    capabilitiesGETRequestInvalidAuth,
+    pactCleanup,
+    createOwncloud
   } = require('../pactHelper.js')
   const { unauthorizedXmlResponseBody, origin } = require('../pactHelper.js')
 
@@ -59,7 +60,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     generate: '/ocs/v1.php/cloud/users/' + config.testUser
   })
 
-  beforeAll(function (done) {
+  beforeAll(function () {
     const promises = []
     promises.push(provider.addInteraction(CORSPreflightRequest()))
     promises.push(provider.addInteraction(capabilitiesGETRequestInvalidAuth()))
@@ -78,29 +79,24 @@ describe('Unauthorized: Currently testing user management,', function () {
       'GET',
       subadminsUserEndpointPath
     )))
-    Promise.all(promises).then(done, done.fail)
+    return Promise.all(promises)
   })
 
-  afterAll(async function (done) {
-    await provider.verify()
-    provider.removeInteractions().then(done, done.fail)
+  afterAll(function () {
+    return pactCleanup(provider)
   })
 
   // TESTING CONFIGS
   var testUserPassword = 'password'
 
   beforeEach(function () {
-    oc = new OwnCloud({
-      baseUrl: config.owncloudURL,
-      auth: {
-        basic: {
-          username: config.username,
-          password: config.password + timeRightNow
-        }
-      }
-    })
+    oc = createOwncloud(config.username, config.password + timeRightNow)
 
-    oc.login()
+    return oc.login().then(() => {
+      fail('not expected to log in')
+    }).catch((err) => {
+      expect(err).toBe('Unauthorized')
+    })
   })
 
   it('checking method : getUser', async function (done) {


### PR DESCRIPTION
### Refactor and cleanup unauthorized tests
1. Remove callbacks from the test hook functions (beforeAll, afterAll, beforeEach, afterEach)
2. use createOwncloud() function from `pacthelper` to create new instance of owncloud sdk

Related https://github.com/owncloud/owncloud-sdk/issues/581