### PR TITLE
[Tests-Only] cleanup and refactor groupTest, loginTest and UserTest

### DIFF
--- a/tests/groupTest.js
+++ b/tests/groupTest.js
@@ -1,5 +1,4 @@
 describe('Main: Currently testing group management,', function () {
-  var OwnCloud = require('../src/owncloud')
   var config = require('./config/config.json')
 
   // LIBRARY INSTANCE
@@ -8,22 +7,13 @@ describe('Main: Currently testing group management,', function () {
   // PACT setup
   const Pact = require('@pact-foundation/pact-web')
   const provider = new Pact.PactWeb()
-  const { validAuthHeaders, xmlResponseHeaders, ocsMeta, applicationXmlResponseHeaders, CORSPreflightRequest } = require('./pactHelper.js')
+  const { validAuthHeaders, xmlResponseHeaders, ocsMeta, applicationXmlResponseHeaders, CORSPreflightRequest, pactCleanup, createOwncloud } = require('./pactHelper.js')
 
-  beforeEach(function (done) {
-    oc = new OwnCloud({
-      baseUrl: config.owncloudURL,
-      auth: {
-        basic: {
-          username: config.username,
-          password: config.password
-        }
-      }
-    })
-    done()
+  beforeEach(function () {
+    oc = createOwncloud()
   })
 
-  beforeAll(function (done) {
+  beforeAll(function () {
     const promises = []
     promises.push(provider.addInteraction(CORSPreflightRequest()))
     promises.push(provider.addInteraction({
@@ -119,12 +109,11 @@ describe('Main: Currently testing group management,', function () {
           '</ocs>'
       }
     }))
-    Promise.all(promises).then(done, done.fail)
+    return Promise.all(promises)
   })
 
-  afterAll(async function (done) {
-    await provider.verify()
-    await provider.removeInteractions().then(done, done.fail)
+  afterAll(function () {
+    return pactCleanup(provider)
   })
 
   it('checking method : getGroups', function (done) {

--- a/tests/loginTest.js
+++ b/tests/loginTest.js
@@ -16,12 +16,12 @@ describe('Main: Currently testing Login and initLibrary,', function () {
   const provider = new Pact.PactWeb()
   const { setGeneralInteractions } = require('./pactHelper.js')
 
-  beforeAll(function (done) {
-    Promise.all(setGeneralInteractions(provider)).then(done, done.fail)
+  beforeAll(function () {
+    return setGeneralInteractions(provider)
   })
 
-  afterAll(function (done) {
-    provider.removeInteractions().then(done, done.fail)
+  afterAll(function () {
+    return provider.removeInteractions()
   })
 
   beforeEach(function () {

--- a/tests/userTest.js
+++ b/tests/userTest.js
@@ -1,5 +1,4 @@
 describe('Main: Currently testing user management,', function () {
-  var OwnCloud = require('../src/owncloud')
   var config = require('./config/config.json')
 
   // LIBRARY INSTANCE
@@ -15,7 +14,9 @@ describe('Main: Currently testing user management,', function () {
     GETRequestToCloudUserEndpoint,
     createAUser,
     deleteAUser,
-    createAUserWithGroupMembership
+    createAUserWithGroupMembership,
+    pactCleanup,
+    createOwncloud
   } = require('./pactHelper.js')
   const { accessControlAllowMethods, validAuthHeaders, xmlResponseHeaders } = require('./pactHelper.js')
 
@@ -204,7 +205,7 @@ describe('Main: Currently testing user management,', function () {
     }
   }
 
-  beforeAll(function (done) {
+  beforeAll(function () {
     const promises = []
     promises.push(provider.addInteraction(CORSPreflightRequest()))
     promises.push(provider.addInteraction(capabilitiesGETRequestValidAuth()))
@@ -315,28 +316,18 @@ describe('Main: Currently testing user management,', function () {
       ' <data/>\n' +
       '</ocs>\n'
     )))
-    Promise.all(promises).then(done, done.fail)
+    return Promise.all(promises)
   })
 
-  afterAll(async function (done) {
-    await provider.verify()
-    await provider.removeInteractions().then(done, done.fail)
+  afterAll(function () {
+    return pactCleanup(provider)
   })
 
-  beforeEach(function (done) {
-    oc = new OwnCloud({
-      baseUrl: config.owncloudURL,
-      auth: {
-        basic: {
-          username: config.username,
-          password: config.password
-        }
-      }
-    })
+  beforeEach(function () {
+    oc = createOwncloud()
 
-    oc.login().then(status => {
+    return oc.login().then(status => {
       expect(status).toEqual({ id: 'admin', 'display-name': 'admin', email: {} })
-      done()
     })
   })
 


### PR DESCRIPTION
### Refactor and cleanup groupTest, loginTest and UserTest
1. Remove callbacks from the test hook functions (beforeAll, afterAll, beforeEach, afterEach)
2. use createOwncloud() function from `pacthelper` to create new instance of owncloud sdk

On top of #664

related #581