### PR TITLE
[Tests-Only] refactor and cleanup publicLinkTest requestOcsTest shareRecipientTest

### DIFF
--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -1,6 +1,4 @@
 describe('oc.publicFiles', function () {
-  // CURRENT TIME
-  const OwnCloud = require('../src/owncloud')
   const config = require('./config/config.json')
   const using = require('jasmine-data-provider')
 
@@ -17,7 +15,8 @@ describe('oc.publicFiles', function () {
     htmlResponseAndAccessControlCombinedHeader,
     CORSPreflightRequest,
     capabilitiesGETRequestValidAuth,
-    GETRequestToCloudUserEndpoint
+    GETRequestToCloudUserEndpoint,
+    createOwncloud
   } = require('./pactHelper.js')
   const provider = new Pact.PactWeb()
 
@@ -89,23 +88,10 @@ describe('oc.publicFiles', function () {
     }
   }
 
-  beforeEach(function (done) {
-    oc = new OwnCloud({
-      baseUrl: config.owncloudURL,
-      auth: {
-        basic: {
-          username: config.username,
-          password: config.password
-        }
-      }
-    })
+  beforeEach(function () {
+    oc = createOwncloud()
 
-    oc.login().then(() => {
-      done()
-    }).catch(error => {
-      fail(error)
-      done()
-    })
+    return oc.login()
   })
 
   afterEach(function () {
@@ -113,22 +99,22 @@ describe('oc.publicFiles', function () {
     oc = null
   })
 
-  afterAll(function (done) {
-    provider.verify().then(done, done.fail)
+  afterAll(function () {
+    return provider.verify()
   })
 
   describe('when creating file urls', function () {
-    beforeAll(function (done) {
+    beforeAll(function () {
       const promises = [
         provider.addInteraction(CORSPreflightRequest()),
         provider.addInteraction(capabilitiesGETRequestValidAuth()),
         provider.addInteraction(GETRequestToCloudUserEndpoint())
       ]
-      Promise.all(promises).then(done, done.fail)
+      return Promise.all(promises)
     })
 
-    afterAll(function (done) {
-      provider.removeInteractions().then(done, done.fail)
+    afterAll(function () {
+      return provider.removeInteractions()
     })
 
     using({
@@ -192,7 +178,7 @@ describe('oc.publicFiles', function () {
         // CREATED SHARES
         let testFolderShare = null
 
-        beforeAll(async function (done) {
+        beforeAll(function () {
           const promises = [
             provider.addInteraction(CORSPreflightRequest()),
             provider.addInteraction(capabilitiesGETRequestValidAuth()),
@@ -242,21 +228,19 @@ describe('oc.publicFiles', function () {
             }))
           }
 
-          Promise.all(promises).then(done, done.fail)
+          return Promise.all(promises)
         })
 
-        afterAll(function (done) {
-          provider.removeInteractions().then(done, done.fail)
+        afterAll(function () {
+          return provider.removeInteractions()
         })
 
-        beforeEach(async function (done) {
-          oc.shares.shareFileWithLink(config.testFolder, data.shareParams).then(share => {
+        beforeEach(function () {
+          return oc.shares.shareFileWithLink(config.testFolder, data.shareParams).then(share => {
             expect(typeof (share)).toBe('object')
             testFolderShare = share
-            done()
           }).catch(error => {
             fail(error)
-            done()
           })
         })
 
@@ -376,7 +360,7 @@ describe('oc.publicFiles', function () {
       }
     }, function (data, description) {
       describe(description, function () {
-        beforeAll(function (done) {
+        beforeAll(function () {
           const promises = [
             provider.addInteraction(CORSPreflightRequest()),
             provider.addInteraction(capabilitiesGETRequestValidAuth()),
@@ -421,11 +405,11 @@ describe('oc.publicFiles', function () {
             config.testContent
           )))
 
-          Promise.all(promises).then(done, done.fail)
+          return Promise.all(promises)
         })
 
-        afterAll(function (done) {
-          provider.removeInteractions().then(done, done.fail)
+        afterAll(function () {
+          return provider.removeInteractions()
         })
 
         it('should create a folder', function (done) {

--- a/tests/requestsOcsTest.js
+++ b/tests/requestsOcsTest.js
@@ -13,22 +13,25 @@ describe('Main: Currently testing low level OCS', function () {
     GETRequestToCloudUserEndpoint,
     validAuthHeaders,
     GETSingleUserEndpoint,
-    createOwncloud
+    createOwncloud,
+    pactCleanup
   } = require('./pactHelper.js')
 
-  beforeEach(function (done) {
+  beforeAll(function () {
     const promises = []
     promises.push(provider.addInteraction(capabilitiesGETRequestValidAuth()))
     promises.push(provider.addInteraction(GETRequestToCloudUserEndpoint()))
     promises.push(provider.addInteraction(CORSPreflightRequest()))
-    Promise.all(promises).then(done, done.fail)
+    return Promise.all(promises)
   })
 
-  afterEach(async function (done) {
+  afterEach(function () {
     oc.logout()
     oc = null
-    await provider.verify()
-    provider.removeInteractions().then(done, done.fail)
+  })
+
+  afterAll(function () {
+    return pactCleanup(provider)
   })
 
   it('checking : capabilities', async function (done) {

--- a/tests/shareRecipientTest.js
+++ b/tests/shareRecipientTest.js
@@ -1,5 +1,4 @@
 describe('Main: Currently testing share recipient,', function () {
-  var OwnCloud = require('../src/owncloud')
   var config = require('./config/config.json')
 
   // LIBRARY INSTANCE
@@ -13,36 +12,27 @@ describe('Main: Currently testing share recipient,', function () {
     origin,
     CORSPreflightRequest,
     capabilitiesGETRequestValidAuth,
-    GETRequestToCloudUserEndpoint
+    GETRequestToCloudUserEndpoint,
+    pactCleanup,
+    createOwncloud
   } = require('./pactHelper.js')
 
-  beforeAll(function (done) {
+  beforeAll(function () {
     const promises = []
     promises.push(provider.addInteraction(CORSPreflightRequest()))
     promises.push(provider.addInteraction(capabilitiesGETRequestValidAuth()))
     promises.push(provider.addInteraction(GETRequestToCloudUserEndpoint()))
-    Promise.all(promises).then(done, done.fail)
+    return Promise.all(promises)
   })
 
-  afterAll(async function (done) {
-    await provider.verify()
-    provider.removeInteractions().then(done, done.fail)
+  afterAll(function () {
+    return pactCleanup(provider)
   })
 
-  beforeEach(function (done) {
-    oc = new OwnCloud({
-      baseUrl: config.owncloudURL,
-      auth: {
-        basic: {
-          username: config.username,
-          password: config.password
-        }
-      }
-    })
+  beforeEach(function () {
+    oc = createOwncloud()
 
-    oc.login().then(() => {
-      done()
-    })
+    return oc.login()
   })
 
   it('testing behavior : invalid page', function (done) {


### PR DESCRIPTION
### Refactor and cleanup publicLinkTest requestOcsTest shareRecipientTest
1. Remove callbacks from the test hook functions (beforeAll, afterAll, beforeEach, afterEach)
2. use createOwncloud() function from `pacthelper` to create new instance of owncloud sdk

On top of #665

related #581