### PR TITLE
[Tests-Only] refactor and cleanup fileVersionTest and publicLinkTest

### DIFF
--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -16,7 +16,8 @@ describe('Main: Currently testing file versions management,', function () {
     CORSPreflightRequest,
     GETRequestToCloudUserEndpoint,
     capabilitiesGETRequestValidAuth,
-    createOwncloud
+    createOwncloud,
+    pactCleanup
   } = require('./pactHelper.js')
 
   // TESTING CONFIGS
@@ -82,7 +83,7 @@ describe('Main: Currently testing file versions management,', function () {
     generate: `/remote.php/dav/meta/${fileInfo.id}/v/${fileInfo.versions[version].versionId}`
   })
 
-  beforeEach(async function () {
+  beforeEach(function () {
     oc = createOwncloud()
     return oc.login()
   })
@@ -115,9 +116,8 @@ describe('Main: Currently testing file versions management,', function () {
       return Promise.all(promises)
     })
 
-    afterAll(async function () {
-      await provider.verify()
-      return provider.removeInteractions()
+    afterAll(function () {
+      return pactCleanup(provider)
     })
 
     it('retrieves file versions of not existing file', function (done) {
@@ -199,8 +199,7 @@ describe('Main: Currently testing file versions management,', function () {
     })
 
     afterAll(async function () {
-      await provider.verify()
-      return provider.removeInteractions()
+      return pactCleanup(provider)
     })
 
     it('checking method: getFileVersionUrl', function () {

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -16,7 +16,8 @@ describe('oc.publicFiles', function () {
     CORSPreflightRequest,
     capabilitiesGETRequestValidAuth,
     GETRequestToCloudUserEndpoint,
-    createOwncloud
+    createOwncloud,
+    pactCleanup
   } = require('./pactHelper.js')
   const provider = new Pact.PactWeb()
 
@@ -99,10 +100,6 @@ describe('oc.publicFiles', function () {
     oc = null
   })
 
-  afterAll(function () {
-    return provider.verify()
-  })
-
   describe('when creating file urls', function () {
     beforeAll(function () {
       const promises = [
@@ -114,7 +111,7 @@ describe('oc.publicFiles', function () {
     })
 
     afterAll(function () {
-      return provider.removeInteractions()
+      return pactCleanup(provider)
     })
 
     using({
@@ -232,7 +229,7 @@ describe('oc.publicFiles', function () {
         })
 
         afterAll(function () {
-          return provider.removeInteractions()
+          return pactCleanup(provider)
         })
 
         beforeEach(function () {
@@ -409,7 +406,7 @@ describe('oc.publicFiles', function () {
         })
 
         afterAll(function () {
-          return provider.removeInteractions()
+          return pactCleanup(provider)
         })
 
         it('should create a folder', function (done) {


### PR DESCRIPTION
### refactor and cleanup fileVersionTest and publicLinkTest
1. Remove callbacks from the test hook functions (beforeAll, afterAll, beforeEach, afterEach)
2. use createOwncloud() function from `pacthelper` to create new instance of owncloud sdk

Related https://github.com/owncloud/owncloud-sdk/issues/581