### PR TITLE
[tests-only] fix tests that use x-www-form-urlencoded body

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
     "@babel/runtime": "^7.4.4",
-    "@pact-foundation/pact": "beta",
+    "@pact-foundation/pact": "10.0.0-beta.26",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.0.5",
     "chai": "^4.2.0",

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -347,11 +347,8 @@ const createAUser = function (provider) {
       headers: {
         ...validAuthHeaders,
         ...applicationFormUrlEncoded
-      }
-      // TODO: uncomment this line once the issue is fixed
-      // https://github.com/pact-foundation/pact-js/issues/577
-
-    // body: `password=${config.testUserPassword}&userid=${config.testUser}`
+      },
+      body: `password=${config.testUserPassword}&userid=${config.testUser}`
     }).willRespondWith({
       status: 200,
       headers: {
@@ -369,11 +366,11 @@ const createAUserWithGroupMembership = function (provider) {
         '.*\\/ocs\\/v1\\.php\\/cloud\\/users',
         '/ocs/v1.php/cloud/users'
       ),
-      headers: validAuthHeaders
-      // TODO: uncomment this line once the issue is fixed
-      // https://github.com/pact-foundation/pact-js/issues/577
-
-      // body: 'password=' + config.testUserPassword + '&userid=' + config.testUser + '&groups%5B0%5D=' + config.testGroup
+      headers: {
+        ...validAuthHeaders,
+        ...applicationFormUrlEncoded
+      },
+      body: 'password=' + config.testUserPassword + '&userid=' + config.testUser + '&groups%5B0%5D=' + config.testGroup
     })
     .willRespondWith({
       status: 200,
@@ -509,6 +506,7 @@ module.exports = {
   invalidAuthHeader,
   xmlResponseHeaders,
   applicationXmlResponseHeaders,
+  applicationFormUrlEncoded,
   accessControlAllowHeaders,
   accessControlAllowMethods,
   unauthorizedXmlResponseBody,

--- a/tests/sharingTest.js
+++ b/tests/sharingTest.js
@@ -19,6 +19,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
 
   const {
     applicationXmlResponseHeaders,
+    applicationFormUrlEncoded,
     accessControlAllowHeaders,
     accessControlAllowMethods,
     validAuthHeaders,
@@ -489,10 +490,11 @@ describe('Main: Currently testing file/folder sharing,', function () {
               '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares$',
               '/ocs/v1.php/apps/files_sharing/api/v1/shares'
             ),
-            headers: validAuthHeaders
-          // TODO: uncomment this line once the issue is fixed
-          // https://github.com/pact-foundation/pact-js/issues/577
-          // body: 'shareType=3' + '&path=%2F' + config.nonExistentFile + '&password=' + config.testUserPassword
+            headers: {
+              ...validAuthHeaders,
+              ...applicationFormUrlEncoded
+            },
+            body: 'shareType=3' + '&path=%2F' + config.nonExistentFile + '&password=' + config.testUserPassword
           }).willRespondWith({
             status: 200,
             headers: {
@@ -516,10 +518,11 @@ describe('Main: Currently testing file/folder sharing,', function () {
               '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares$',
               '/ocs/v1.php/apps/files_sharing/api/v1/shares'
             ),
-            headers: validAuthHeaders
-          // TODO: uncomment this line once the issue is fixed
-          // https://github.com/pact-foundation/pact-js/issues/577
-          // body: 'shareType=1&shareWith=' + config.testGroup + '&path=%2F' + config.nonExistentFile + '&permissions=19'
+            headers: {
+              ...validAuthHeaders,
+              ...applicationFormUrlEncoded
+            },
+            body: 'shareType=1&shareWith=' + config.testGroup + '&path=%2F' + config.nonExistentFile + '&permissions=19'
           }).willRespondWith({
             status: 200,
             headers: applicationXmlResponseHeaders,
@@ -627,10 +630,11 @@ describe('Main: Currently testing file/folder sharing,', function () {
               '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares$',
               '/ocs/v1.php/apps/files_sharing/api/v1/shares'
             ),
-            headers: validAuthHeaders
-            // TODO: uncomment this line once the issue is fixed
-            // https://github.com/pact-foundation/pact-js/issues/577
-            // body: 'shareType=0&shareWith=' + config.testUser + '&path=' + config.testFilesPath[i] + '&expireDate=' + config.expirationDate
+            headers: {
+              ...validAuthHeaders,
+              ...applicationFormUrlEncoded
+            },
+            body: 'shareType=0&shareWith=' + config.testUser + '&path=' + file + '&expireDate=' + config.expirationDate
           })
           .willRespondWith({
             status: 200,
@@ -848,12 +852,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
         await capabilitiesGETRequestValidAuth(provider)
         await GETRequestToCloudUserEndpoint(provider)
 
-        // TODO: uncomment this line once the issue is fixed
-        // https://github.com/pact-foundation/pact-js/issues/577
-        // await Promise.all(testFiles.map(file => sharePOSTRequestWithExpirationDateSet(provider, file)))
-
-        await sharePOSTRequestWithExpirationDateSet(provider, testFiles[0])
-
+        await Promise.all(config.testFilesPath.map(file => sharePOSTRequestWithExpirationDateSet(provider, file)))
         return provider.executeTest(async () => {
           const oc = createOwncloud()
           await oc.login()

--- a/tests/sharingWithAttributesTest.js
+++ b/tests/sharingWithAttributesTest.js
@@ -6,6 +6,7 @@ describe('oc.shares', function () {
   const {
     validAuthHeaders,
     applicationXmlResponseHeaders,
+    applicationFormUrlEncoded,
     ocsMeta,
     shareResponseOcsData,
     capabilitiesGETRequestValidAuth,
@@ -44,11 +45,11 @@ describe('oc.shares', function () {
           '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares$',
           '/ocs/v1.php/apps/files_sharing/api/v1/shares'
         ),
-        headers: validAuthHeaders
-        // TODO: uncomment this line once the issue is fixed
-        // https://github.com/pact-foundation/pact-js/issues/577
-
-        // body: `shareType=0&shareWith=${testUser}&path=%2F${testFile}&attributes%5B0%5D%5Bscope%5D=${shareAttributes.attributes[0].scope}&attributes%5B0%5D%5Bkey%5D=${shareAttributes.attributes[0].key}&attributes%5B0%5D%5Bvalue%5D=${shareAttributes.attributes[0].value}&attributes%5B1%5D%5Bscope%5D=${shareAttributes.attributes[1].scope}&attributes%5B1%5D%5Bkey%5D=${shareAttributes.attributes[1].key}&attributes%5B1%5D%5Bvalue%5D=${shareAttributes.attributes[1].value}`
+        headers: {
+          ...validAuthHeaders,
+          ...applicationFormUrlEncoded
+        },
+        body: `shareType=0&shareWith=${testUser}&path=%2F${testFile}&attributes%5B0%5D%5Bscope%5D=${shareAttributes.attributes[0].scope}&attributes%5B0%5D%5Bkey%5D=${shareAttributes.attributes[0].key}&attributes%5B0%5D%5Bvalue%5D=${shareAttributes.attributes[0].value}&attributes%5B1%5D%5Bscope%5D=${shareAttributes.attributes[1].scope}&attributes%5B1%5D%5Bkey%5D=${shareAttributes.attributes[1].key}&attributes%5B1%5D%5Bvalue%5D=${shareAttributes.attributes[1].value}`
       })
       .willRespondWith({
         status: 200,

--- a/tests/userTest.js
+++ b/tests/userTest.js
@@ -14,7 +14,7 @@ describe('Main: Currently testing user management,', function () {
     createOwncloud,
     createProvider
   } = require('./pactHelper.js')
-  const { validAuthHeaders, xmlResponseHeaders } = require('./pactHelper.js')
+  const { validAuthHeaders, xmlResponseHeaders, applicationFormUrlEncoded } = require('./pactHelper.js')
 
   const aRequestToGetUserInformation = function (provider, requestName, username, responseBody) {
     return provider
@@ -66,11 +66,11 @@ describe('Main: Currently testing user management,', function () {
           '.*\\/ocs\\/v(1|2)\\.php\\/cloud\\/users\\/' + username,
           '/ocs/v1.php/cloud/users/' + username
         ),
-        headers: validAuthHeaders
-        // TODO: uncomment this line once the issue is fixed
-        // https://github.com/pact-foundation/pact-js/issues/577
-
-        // body: requestBody
+        headers: {
+          ...validAuthHeaders,
+          ...applicationFormUrlEncoded
+        },
+        body: requestBody
       })
       .willRespondWith({
         status: 200,
@@ -94,11 +94,12 @@ describe('Main: Currently testing user management,', function () {
           '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + username + '\\/groups$',
           '/ocs/v1.php/cloud/users/' + username + '/groups'
         ),
-        headers: validAuthHeaders
-        // TODO: uncomment this line once the issue is fixed
-        // https://github.com/pact-foundation/pact-js/issues/577
-
-        // body: 'groupid=' + group
+        headers:
+          {
+            ...validAuthHeaders,
+            ...applicationFormUrlEncoded
+          },
+        body: 'groupid=' + group
       })
       .willRespondWith({
         status: 200,
@@ -141,11 +142,12 @@ describe('Main: Currently testing user management,', function () {
           '.*\\/ocs\\/v(1|2)\\.php\\/cloud\\/users\\/' + username + '\\/groups$',
           '/ocs/v1.php/cloud/users/' + username + '/groups'
         ),
-        headers: validAuthHeaders
-        // TODO: uncomment this line once the issue is fixed
-        // https://github.com/pact-foundation/pact-js/issues/577
-
-        // body: 'groupid=' + group
+        headers:
+          {
+            ...validAuthHeaders,
+            ...applicationFormUrlEncoded
+          },
+        body: 'groupid=' + group
       })
       .willRespondWith({
         status: 200,
@@ -170,11 +172,12 @@ describe('Main: Currently testing user management,', function () {
           '.*\\/ocs\\/v(1|2)\\.php\\/cloud\\/users\\/' + username + '\\/subadmins$',
           '/ocs/v1.php/cloud/users/' + username + '/subadmins'
         ),
-        headers: validAuthHeaders
-        // TODO: uncomment this line once the issue is fixed
-        // https://github.com/pact-foundation/pact-js/issues/577
-
-        // body: 'groupid=' + group
+        headers:
+          {
+            ...validAuthHeaders,
+            ...applicationFormUrlEncoded
+          },
+        body: 'groupid=' + group
       })
       .willRespondWith({
         status: 200,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1069,10 +1069,10 @@
     unzipper "^0.10.10"
     url-join "^4.0.0"
 
-"@pact-foundation/pact@beta":
-  version "10.0.0-beta.22"
-  resolved "https://registry.yarnpkg.com/@pact-foundation/pact/-/pact-10.0.0-beta.22.tgz#387e25927b15e2a5704c8b59ef7b5edad4a13b74"
-  integrity sha512-AgldVSXqS2nYOWjlhIBUdHxx5cGCQAFsAhluT9YJcR+KmwgLkK9mRwkmhX1gge8VVsWxgpxaqSIysadQsmSFEw==
+"@pact-foundation/pact@10.0.0-beta.26":
+  version "10.0.0-beta.26"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact/-/pact-10.0.0-beta.26.tgz#db1076c7c1f4d39a716899f54111111c21011d87"
+  integrity sha512-rufOZLxsIYlkt51FYi5xPxjgR7WRKwPm/4oE8K/wKAbnTvkXHv0vwQjNgf6puzVT1vpZww+lB/5zXOH4JeoeQw==
   dependencies:
     "@pact-foundation/pact-node" "^10.10.1"
     "@types/bluebird" "^3.5.20"


### PR DESCRIPTION
these tests have been incomplete and the body part was ignored because of a bug in pact-js see https://github.com/pact-foundation/pact-js/issues/577
as the bug is fixed now, we can bring back these bodies

note: the issue in `signedUrlIntegrationTest.js` seems to be an other one, looking into that now

