### PR TITLE
update pact.js & fix tests that were skipped because of a pact bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
     "@babel/runtime": "^7.4.4",
-    "@pact-foundation/pact": "10.0.0-beta.26",
+    "@pact-foundation/pact": "10.0.0-beta.29",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.0.5",
     "chai": "^4.2.0",

--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -377,9 +377,7 @@ describe('Main: Currently testing files management,', function () {
         await oc.login()
         for (let i = 0; i < testSubFiles.length; i++) {
           await oc.files.getFileContents(testSubFiles[i], { resolveWithResponseObject: true }).then((resp) => {
-            // TODO uncomment this line once the PR is available in release
-            // https://github.com/pact-foundation/pact-js/pull/590
-            // expect(resp.body).toEqual(testContent)
+            expect(resp.body).toEqual(testContent)
             expect(resp.headers.ETag).toBeDefined()
           }).catch(error => {
             expect(error).toBe(null)

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -155,10 +155,8 @@ const getContentsOfFile = (provider, file) => {
       headers: validAuthHeaders
     }).willRespondWith(file !== config.nonExistentFile ? {
       status: 200,
-      headers: textPlainResponseHeaders
-      // TODO uncomment this line once the PR is available in release
-      // https://github.com/pact-foundation/pact-js/pull/590
-      // body: config.testContent
+      headers: textPlainResponseHeaders,
+      body: config.testContent
     } : {
       status: 404,
       headers: xmlResponseAndAccessControlCombinedHeader,

--- a/tests/signedUrlIntegrationTest.js
+++ b/tests/signedUrlIntegrationTest.js
@@ -70,11 +70,8 @@ describe('Signed urls', function () {
           'Access-Control-Allow-Methods': accessControlAllowMethods,
           'Content-Type': 'text/plain; charset=utf-8',
           'Access-Control-Allow-Origin': origin
-        }
-        // TODO: uncomment this line once this PR is merged and a new version of pact-js is published
-        // https://github.com/pact-foundation/pact-js/pull/590
-
-        // body: config.testContent
+        },
+        body: config.testContent
       })
   }
 
@@ -93,11 +90,8 @@ describe('Signed urls', function () {
       const signedUrl = await oc.signUrl(url)
       const response = await fetch(signedUrl)
       expect(response.ok).toEqual(true)
-      // TODO: uncomment this line once this PR is merged and a new version of pact-js is published
-      // https://github.com/pact-foundation/pact-js/pull/590
-
-      // const txt = await response.text()
-      // expect(txt).toEqual(config.testContent)
+      const txt = await response.text()
+      expect(txt).toEqual(config.testContent)
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1069,10 +1069,10 @@
     unzipper "^0.10.10"
     url-join "^4.0.0"
 
-"@pact-foundation/pact@10.0.0-beta.26":
-  version "10.0.0-beta.26"
-  resolved "https://registry.yarnpkg.com/@pact-foundation/pact/-/pact-10.0.0-beta.26.tgz#db1076c7c1f4d39a716899f54111111c21011d87"
-  integrity sha512-rufOZLxsIYlkt51FYi5xPxjgR7WRKwPm/4oE8K/wKAbnTvkXHv0vwQjNgf6puzVT1vpZww+lB/5zXOH4JeoeQw==
+"@pact-foundation/pact@10.0.0-beta.29":
+  version "10.0.0-beta.29"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact/-/pact-10.0.0-beta.29.tgz#3637afdbf7d54470125d09206436319c1f2ac6ec"
+  integrity sha512-fSjPyWu9aGplY2fAbPBvEyXnhV2Qt+3vBnM38HXCCS2c7shws6r2PO/0tjZKTcgxn9d1/tLxwhMG/hnjmsNsGA==
   dependencies:
     "@pact-foundation/pact-node" "^10.10.1"
     "@types/bluebird" "^3.5.20"


### PR DESCRIPTION
these checks were skipped because of a bug in pact-js (https://github.com/pact-foundation/pact-js/pull/590)
after the bug got fixed and a new version released we can enable them again
