### PR TITLE
[tests-only] some fixes to make more files tests pass in the provider

### DIFF
--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -16,15 +16,14 @@ describe('Main: Currently testing files management,', function () {
     uriEncodedTestSubFiles,
     testSubFiles,
     validAuthHeaders,
-    xmlResponseAndAccessControlCombinedHeader,
+    applicationXmlResponseHeaders,
+    htmlResponseHeaders,
     GETRequestToCloudUserEndpoint,
     capabilitiesGETRequestValidAuth,
     createAFolder,
     updateFile,
     createOwncloud,
-    createProvider,
-    applicationXmlResponseHeaders,
-    origin
+    createProvider
   } = require('./pactHelper.js')
 
   // TESTING CONFIGS
@@ -46,13 +45,13 @@ describe('Main: Currently testing files management,', function () {
     if (name.includes('non existing')) {
       response = {
         status: 404,
-        headers: xmlResponseAndAccessControlCombinedHeader,
+        headers: applicationXmlResponseHeaders,
         body: webdavExceptionResponseBody('NotFound', resourceNotFoundExceptionMessage(parentFolder))
       }
     } else {
       response = {
         status: 207,
-        headers: xmlResponseAndAccessControlCombinedHeader,
+        headers: applicationXmlResponseHeaders,
         body: new XmlBuilder('1.0', 'utf-8', 'd:multistatus').build(dMultistatus => {
           dMultistatus.setAttributes({ 'xmlns:d': 'DAV:' })
           dMultistatus
@@ -140,10 +139,7 @@ describe('Main: Currently testing files management,', function () {
         })
       }).willRespondWith({
         status: 207,
-        headers: {
-          ...xmlResponseAndAccessControlCombinedHeader,
-          'Access-Control-Expose-Headers': 'Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,Vary,Webdav-Location,X-Sabre-Status'
-        },
+        headers: applicationXmlResponseHeaders,
         body: new XmlBuilder('1.0', 'utf-8', 'd:multistatus').build(dMultistatus => {
           dMultistatus.setAttributes({ 'xmlns:d': 'DAV:', 'xmlns:s': 'http://sabredav.org/ns', 'xmlns:oc': 'http://owncloud.org/ns' })
           dMultistatus
@@ -174,7 +170,7 @@ describe('Main: Currently testing files management,', function () {
         })
       }).willRespondWith({
         status: 207,
-        headers: xmlResponseAndAccessControlCombinedHeader,
+        headers: applicationXmlResponseHeaders,
         body: new XmlBuilder('1.0', 'utf-8', 'd:multistatus').build(dMultistatus => {
           dMultistatus.setAttributes({ 'xmlns:d': 'DAV:', 'xmlns:s': 'http://sabredav.org/ns', 'xmlns:oc': 'http://owncloud.org/ns' })
           dMultistatus
@@ -499,10 +495,7 @@ describe('Main: Currently testing files management,', function () {
         })
         .willRespondWith({
           status: 409,
-          headers: {
-            'Content-Type': 'text/html; charset=utf-8',
-            'Access-Control-Allow-Origin': origin
-          },
+          headers: htmlResponseHeaders,
           body: webdavExceptionResponseBody('Conflict', 'Parent node does not exist')
         })
 
@@ -566,7 +559,7 @@ describe('Main: Currently testing files management,', function () {
         },
         {
           status: 403,
-          headers: xmlResponseAndAccessControlCombinedHeader,
+          headers: applicationXmlResponseHeaders,
           body: webdavExceptionResponseBody('Forbidden', 'Source and destination uri are identical.')
         })
       return provider.executeTest(async () => {
@@ -596,7 +589,7 @@ describe('Main: Currently testing files management,', function () {
         })
         .willRespondWith({
           status: 201,
-          headers: xmlResponseAndAccessControlCombinedHeader
+          headers: applicationXmlResponseHeaders
         })
       return provider.executeTest(async () => {
         const oc = createOwncloud()
@@ -625,7 +618,7 @@ describe('Main: Currently testing files management,', function () {
         })
         .willRespondWith({
           status: 404,
-          headers: xmlResponseAndAccessControlCombinedHeader,
+          headers: applicationXmlResponseHeaders,
           body: webdavExceptionResponseBody('NotFound', resourceNotFoundExceptionMessage(nonExistentFile))
         })
 
@@ -656,7 +649,7 @@ describe('Main: Currently testing files management,', function () {
         })
         .willRespondWith({
           status: 403,
-          headers: xmlResponseAndAccessControlCombinedHeader,
+          headers: applicationXmlResponseHeaders,
           body: webdavExceptionResponseBody('Forbidden', 'Source and destination uri are identical.')
         })
 
@@ -687,7 +680,7 @@ describe('Main: Currently testing files management,', function () {
         })
         .willRespondWith({
           status: 404,
-          headers: xmlResponseAndAccessControlCombinedHeader,
+          headers: applicationXmlResponseHeaders,
           body: webdavExceptionResponseBody('NotFound', resourceNotFoundExceptionMessage(nonExistentFile))
         })
       return provider.executeTest(async () => {
@@ -723,7 +716,7 @@ describe('Main: Currently testing files management,', function () {
         })
         .willRespondWith({
           status: 207,
-          headers: xmlResponseAndAccessControlCombinedHeader,
+          headers: applicationXmlResponseHeaders,
           body: new XmlBuilder('1.0', '', 'd:multistatus').build(dMultistatus => {
             dMultistatus.setAttributes({
               'xmlns:d': 'DAV:',
@@ -757,7 +750,7 @@ describe('Main: Currently testing files management,', function () {
         })
         .willRespondWith({
           status: 207,
-          headers: xmlResponseAndAccessControlCombinedHeader,
+          headers: applicationXmlResponseHeaders,
           body: new XmlBuilder('1.0', '', 'd:multistatus').build(dMultistatus => {
             dMultistatus.setAttributes({
               'xmlns:d': 'DAV:',
@@ -795,7 +788,7 @@ describe('Main: Currently testing files management,', function () {
 
   describe.skip('TUS detection', function () {
     const tusSupportRequest = (provider, enabled = true) => {
-      let respHeaders = xmlResponseAndAccessControlCombinedHeader
+      let respHeaders = applicationXmlResponseHeaders
       if (enabled) {
         respHeaders = {
           ...respHeaders,
@@ -918,7 +911,7 @@ describe('Main: Currently testing files management,', function () {
         },
         {
           status: 201,
-          headers: xmlResponseAndAccessControlCombinedHeader
+          headers: applicationXmlResponseHeaders
         })
 
       return provider.executeTest(async () => {
@@ -950,7 +943,7 @@ describe('Main: Currently testing files management,', function () {
         })
         .willRespondWith({
           status: 201,
-          headers: xmlResponseAndAccessControlCombinedHeader
+          headers: applicationXmlResponseHeaders
         })
 
       return provider.executeTest(async () => {
@@ -980,7 +973,7 @@ describe('Main: Currently testing files management,', function () {
         })
         .willRespondWith({
           status: 201,
-          headers: xmlResponseAndAccessControlCombinedHeader
+          headers: applicationXmlResponseHeaders
         })
 
       return provider.executeTest(async () => {
@@ -1069,7 +1062,7 @@ describe('Main: Currently testing files management,', function () {
         })
         .willRespondWith({
           status: 207,
-          headers: xmlResponseAndAccessControlCombinedHeader,
+          headers: applicationXmlResponseHeaders,
           body: new XmlBuilder('1.0', '', 'd:multistatus').build(dMultistatus => {
             dMultistatus.setAttributes({
               'xmlns:d': 'DAV:',
@@ -1142,7 +1135,7 @@ describe('Main: Currently testing files management,', function () {
         })
         .willRespondWith({
           status: 207,
-          headers: xmlResponseAndAccessControlCombinedHeader,
+          headers: applicationXmlResponseHeaders,
           body: new XmlBuilder('1.0', '', 'd:multistatus').build(dMultistatus => {
             dMultistatus.setAttributes({
               'xmlns:d': 'DAV:',
@@ -1187,7 +1180,7 @@ describe('Main: Currently testing files management,', function () {
       const getFileInfoBy = data => {
         return {
           status: 207,
-          headers: xmlResponseAndAccessControlCombinedHeader,
+          headers: applicationXmlResponseHeaders,
           body: new XmlBuilder('1.0', '', 'd:multistatus').build(dMultistatus => {
             dMultistatus.setAttributes({
               'xmlns:d': 'DAV:',
@@ -1226,7 +1219,7 @@ describe('Main: Currently testing files management,', function () {
         .willRespondWith({
           status: 201,
           headers: {
-            ...xmlResponseAndAccessControlCombinedHeader,
+            ...applicationXmlResponseHeaders,
             'Access-Control-Expose-Headers': 'Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,Vary,Webdav-Location,X-Sabre-Status',
             'Content-Location': `/remote.php/dav/systemtags/${tagId}`
           }
@@ -1258,7 +1251,7 @@ describe('Main: Currently testing files management,', function () {
         })
         .willRespondWith({
           status: 201,
-          headers: xmlResponseAndAccessControlCombinedHeader
+          headers: applicationXmlResponseHeaders
         })
 
       await provider

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -420,6 +420,7 @@ const createAFolder = function (provider, folderName) {
 }
 
 const updateFile = function (provider, file) {
+  const etagMatcher = MatchersV3.regex(/^"[a-f0-9:.]{1,32}"$/, config.testFileEtag)
   return provider.uponReceiving('Put file contents to file ' + file)
     .withRequest({
       method: 'PUT',
@@ -438,9 +439,9 @@ const updateFile = function (provider, file) {
     } : {
       status: 201,
       headers: {
-        'OC-FileId': config.testFileOcFileId,
-        ETag: config.testFileEtag,
-        'OC-ETag': config.testFileEtag
+        'OC-FileId': MatchersV3.like(config.testFileOcFileId),
+        ETag: etagMatcher,
+        'OC-ETag': etagMatcher
       }
     })
 }

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -136,6 +136,7 @@ const createOwncloud = function (username = config.username, password = config.p
 
 const getContentsOfFile = (provider, file) => {
   return provider
+    .given('file exists', { fileName: file })
     .uponReceiving('GET contents of file ' + file)
     .withRequest({
       method: 'GET',

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -165,6 +165,7 @@ const deleteResource = (provider, resource, type = 'folder') => {
       body: webdavExceptionResponseBody('NotFound', resourceNotFoundExceptionMessage(config.nonExistentDir))
     }
   } else if (type === 'file') {
+    provider.given('file exists', { fileName: resource })
     response = {
       status: 200,
       headers: xmlResponseHeaders,
@@ -175,6 +176,7 @@ const deleteResource = (provider, resource, type = 'folder') => {
       })
     }
   } else {
+    provider.given('folder exists', { folderName: resource })
     response = {
       status: 204
     }

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -436,7 +436,7 @@ const updateFile = function (provider, file) {
       headers: applicationXmlResponseHeaders,
       body: webdavExceptionResponseBody('NotFound', resourceNotFoundExceptionMessage(config.nonExistentDir))
     } : {
-      status: 200,
+      status: 201,
       headers: {
         'OC-FileId': config.testFileOcFileId,
         ETag: config.testFileEtag,

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -87,18 +87,6 @@ const unauthorizedXmlResponseBody = new XmlBuilder('1.0', '', 'ocs').build(ocs =
     .appendElement('data', '', '')
 })
 
-const xmlResponseAndAccessControlCombinedHeader = {
-  ...applicationXmlResponseHeaders,
-  'Access-Control-Allow-Headers': accessControlAllowHeaders,
-  'Access-Control-Allow-Methods': accessControlAllowMethods
-}
-
-const htmlResponseAndAccessControlCombinedHeader = {
-  'Content-Type': 'text/html; charset=utf-8',
-  'Access-Control-Allow-Headers': accessControlAllowHeaders,
-  'Access-Control-Allow-Methods': accessControlAllowMethods
-}
-
 const resourceNotFoundExceptionMessage = resource => `File with name ${resource} could not be located`
 
 const webdavMatcherForResource = resource => {
@@ -159,7 +147,7 @@ const getContentsOfFile = (provider, file) => {
       body: config.testContent
     } : {
       status: 404,
-      headers: xmlResponseAndAccessControlCombinedHeader,
+      headers: applicationXmlResponseHeaders,
       body: webdavExceptionResponseBody('NotFound', resourceNotFoundExceptionMessage(config.nonExistentFile))
     })
 }
@@ -169,7 +157,7 @@ const deleteResource = (provider, resource, type = 'folder') => {
   if (resource.includes('nonExistent')) {
     response = {
       status: 404,
-      headers: xmlResponseAndAccessControlCombinedHeader,
+      headers: applicationXmlResponseHeaders,
       body: webdavExceptionResponseBody('NotFound', resourceNotFoundExceptionMessage(config.nonExistentDir))
     }
   } else if (type === 'file') {
@@ -184,10 +172,7 @@ const deleteResource = (provider, resource, type = 'folder') => {
     }
   } else {
     response = {
-      status: 204,
-      headers: {
-        'Access-Control-Allow-Origin': origin
-      }
+      status: 204
     }
   }
   return provider.uponReceiving(`a request to delete a ${type},  ${resource}`)
@@ -296,8 +281,7 @@ const GETSingleUserEndpoint = function (provider) {
     .willRespondWith({
       status: 200,
       headers: {
-        'Content-Type': 'application/json; charset=utf-8',
-        'Access-Control-Allow-Origin': origin
+        'Content-Type': 'application/json; charset=utf-8'
       },
       body: {
         ocs: {
@@ -426,7 +410,7 @@ const createAFolder = function (provider, folderName) {
       headers: validAuthHeaders
     }).willRespondWith({
       status: 201,
-      headers: htmlResponseAndAccessControlCombinedHeader
+      headers: htmlResponseHeaders
     })
 }
 
@@ -444,15 +428,11 @@ const updateFile = function (provider, file) {
       // body: config.testContent
     }).willRespondWith(file.includes('nonExistent') ? {
       status: 404,
-      headers: {
-        'Access-Control-Allow-Origin': origin,
-        ...applicationXmlResponseHeaders
-      },
+      headers: applicationXmlResponseHeaders,
       body: webdavExceptionResponseBody('NotFound', resourceNotFoundExceptionMessage(config.nonExistentDir))
     } : {
       status: 200,
       headers: {
-        'Access-Control-Allow-Origin': origin,
         'OC-FileId': config.testFileOcFileId,
         ETag: config.testFileEtag,
         'OC-ETag': config.testFileEtag
@@ -516,16 +496,14 @@ module.exports = {
   invalidAuthHeader,
   xmlResponseHeaders,
   htmlResponseHeaders,
-  applicationXmlResponseHeaders,
   applicationFormUrlEncoded,
   textPlainResponseHeaders,
   accessControlAllowHeaders,
   accessControlAllowMethods,
   unauthorizedXmlResponseBody,
-  xmlResponseAndAccessControlCombinedHeader,
+  applicationXmlResponseHeaders,
   testSubFiles,
   uriEncodedTestSubFiles,
-  htmlResponseAndAccessControlCombinedHeader,
   capabilitiesGETRequestValidAuth,
   GETRequestToCloudUserEndpoint,
   GETSingleUserEndpoint,

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -135,8 +135,11 @@ const createOwncloud = function (username = config.username, password = config.p
 }
 
 const getContentsOfFile = (provider, file) => {
+  if (file !== config.nonExistentFile) {
+    provider
+      .given('file exists', { fileName: file })
+  }
   return provider
-    .given('file exists', { fileName: file })
     .uponReceiving('GET contents of file ' + file)
     .withRequest({
       method: 'GET',
@@ -400,7 +403,8 @@ const deleteAUser = function (provider) {
 }
 
 const createAFolder = function (provider, folderName) {
-  return provider.uponReceiving('successfully create a folder ' + folderName)
+  return provider
+    .uponReceiving('successfully create a folder ' + folderName)
     .withRequest({
       method: 'MKCOL',
       path: MatchersV3.regex(

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -71,10 +71,7 @@ describe('provider testing', () => {
       },
       'folder exists': (setup, parameters) => {
         if (setup) {
-          const results = createFolderRecrusive(config.username, parameters.folderName)
-          chai.assert.isBelow(
-            results[0].status, 300, `creating folder '${parameters.folderName}' failed`
-          )
+          createFolderRecrusive(config.username, parameters.folderName)
         }
         return Promise.resolve({ description: 'folder created' })
       },
@@ -82,17 +79,9 @@ describe('provider testing', () => {
         const dirname = path.dirname(parameters.fileName)
         if (setup) {
           if (dirname !== '' && dirname !== '/') {
-            const results = createFolderRecrusive(config.username, dirname)
-            for (let i = 0; i < results.length; i++) {
-              chai.assert.isBelow(
-                results[i].status, 300, `creating folder '${dirname}' failed'`
-              )
-            }
+            createFolderRecrusive(config.username, dirname)
           }
-          const result = createFile(config.username, parameters.fileName, config.testContent)
-          chai.assert.isBelow(
-            result.status, 300, `creating file '${parameters.fileName}' failed`
-          )
+          createFile(config.username, parameters.fileName, config.testContent)
         } else {
           let itemToDelete
           if (dirname !== '' && dirname !== '/') {
@@ -101,10 +90,7 @@ describe('provider testing', () => {
           } else {
             itemToDelete = parameters.fileName
           }
-          const result = deleteItem(config.username, itemToDelete)
-          chai.assert.strictEqual(
-            result.status, 204, `deleting '${itemToDelete}' failed`
-          )
+          deleteItem(config.username, itemToDelete)
         }
         return Promise.resolve({ description: 'file created' })
       }

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -71,7 +71,10 @@ describe('provider testing', () => {
       },
       'folder exists': (setup, parameters) => {
         if (setup) {
-          createFolderRecrusive(config.username, parameters.folderName)
+          const results = createFolderRecrusive(config.username, parameters.folderName)
+          chai.assert.isBelow(
+            results[0].status, 300, `creating folder '${parameters.folderName}' failed`
+          )
         }
         return Promise.resolve({ description: 'folder created' })
       },
@@ -82,13 +85,13 @@ describe('provider testing', () => {
             const results = createFolderRecrusive(config.username, dirname)
             for (let i = 0; i < results.length; i++) {
               chai.assert.isBelow(
-                results[i].status, 300, `creating folder '${dirname} failed'`
+                results[i].status, 300, `creating folder '${dirname}' failed'`
               )
             }
           }
           const result = createFile(config.username, parameters.fileName, config.testContent)
           chai.assert.isBelow(
-            result.status, 300, `creating file '${dirname} failed'`
+            result.status, 300, `creating file '${parameters.fileName}' failed`
           )
         } else {
           let itemToDelete
@@ -100,7 +103,7 @@ describe('provider testing', () => {
           }
           const result = deleteItem(config.username, itemToDelete)
           chai.assert.strictEqual(
-            result.status, 204, `deleting '${itemToDelete} failed'`
+            result.status, 204, `deleting '${itemToDelete}' failed`
           )
         }
         return Promise.resolve({ description: 'file created' })

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -1,3 +1,5 @@
+const config = require('./config/config.json')
+
 describe('provider testing', () => {
   const { VerifierV3 } = require('@pact-foundation/pact/v3')
   const chai = require('chai')
@@ -8,6 +10,12 @@ describe('provider testing', () => {
   const {
     validAuthHeaders
   } = require('./pactHelper.js')
+
+  const {
+    createFolderRecrusive,
+    createFile,
+    deleteItem
+  } = require('./webdavHelper.js')
 
   chai.use(chaiAsPromised)
 
@@ -60,6 +68,42 @@ describe('provider testing', () => {
           headers: validAuthHeaders
         })
         return Promise.resolve({ description: 'group deleted' })
+      },
+      'folder exists': (setup, parameters) => {
+        if (setup) {
+          createFolderRecrusive(config.username, parameters.folderName)
+        }
+        return Promise.resolve({ description: 'folder created' })
+      },
+      'file exists': (setup, parameters) => {
+        const dirname = path.dirname(parameters.fileName)
+        if (setup) {
+          if (dirname !== '' && dirname !== '/') {
+            const results = createFolderRecrusive(config.username, dirname)
+            for (let i = 0; i < results.length; i++) {
+              chai.assert.isBelow(
+                results[i].status, 300, `creating folder '${dirname} failed'`
+              )
+            }
+          }
+          const result = createFile(config.username, parameters.fileName, config.testContent)
+          chai.assert.isBelow(
+            result.status, 300, `creating file '${dirname} failed'`
+          )
+        } else {
+          let itemToDelete
+          if (dirname !== '' && dirname !== '/') {
+            const folders = dirname.split(path.sep)
+            itemToDelete = folders[0]
+          } else {
+            itemToDelete = parameters.fileName
+          }
+          const result = deleteItem(config.username, itemToDelete)
+          chai.assert.strictEqual(
+            result.status, 204, `deleting '${itemToDelete} failed'`
+          )
+        }
+        return Promise.resolve({ description: 'file created' })
       }
     }
     return new VerifierV3(opts).verifyProvider().then(output => {

--- a/tests/webdavHelper.js
+++ b/tests/webdavHelper.js
@@ -14,6 +14,17 @@ const createDavPath = function (userId, element) {
 }
 
 /**
+ * returns the full and sanitized URL of the dav resource
+ * @param {string} userId
+ * @param {string} resource
+ * @returns {string}
+ */
+const createFullDavUrl = function (userId, resource) {
+  return (process.env.PROVIDER_BASE_URL + createDavPath(userId, resource))
+    .replace(/([^:])\/{2,}/g, '$1/')
+}
+
+/**
  * Create a folder using webDAV api.
  *
  * @param {string} user
@@ -28,8 +39,7 @@ const createFolderRecrusive = function (user, folderName) {
     for (let j = 0; j <= i; j++) {
       recrusivePath += path.sep + folders[j]
     }
-    const davPath = createDavPath(user, recrusivePath)
-    results[i] = fetch(process.env.PROVIDER_BASE_URL + davPath, {
+    results[i] = fetch(createFullDavUrl(user, recrusivePath), {
       method: 'MKCOL',
       headers: validAuthHeaders
     })
@@ -46,8 +56,7 @@ const createFolderRecrusive = function (user, folderName) {
  * @returns {*} result of the fetch request
  */
 const createFile = function (user, fileName, contents = '') {
-  const davPath = createDavPath(user, fileName)
-  return fetch(process.env.PROVIDER_BASE_URL + davPath, {
+  return fetch(createFullDavUrl(user, fileName), {
     method: 'PUT',
     headers: validAuthHeaders,
     body: contents
@@ -62,8 +71,7 @@ const createFile = function (user, fileName, contents = '') {
  * @returns {*} result of the fetch request
  */
 const deleteItem = function (user, itemName) {
-  const davPath = createDavPath(user, itemName)
-  return fetch(process.env.PROVIDER_BASE_URL + davPath, {
+  return fetch(createFullDavUrl(user, itemName), {
     method: 'DELETE',
     headers: validAuthHeaders
   })

--- a/tests/webdavHelper.js
+++ b/tests/webdavHelper.js
@@ -1,0 +1,76 @@
+const fetch = require('sync-fetch')
+const path = require('path')
+const {
+  validAuthHeaders
+} = require('./pactHelper.js')
+
+/**
+ *
+ * @param {string} userId
+ * @param {string} element
+ */
+const createDavPath = function (userId, element) {
+  return `/remote.php/dav/files/${userId}/${element}`
+}
+
+/**
+ * Create a folder using webDAV api.
+ *
+ * @param {string} user
+ * @param {string} folderName
+ * @returns {[]} all fetch results
+ */
+const createFolderRecrusive = function (user, folderName) {
+  const results = []
+  const folders = folderName.split(path.sep)
+  for (let i = 0; i < folders.length; i++) {
+    let recrusivePath = ''
+    for (let j = 0; j <= i; j++) {
+      recrusivePath += path.sep + folders[j]
+    }
+    const davPath = createDavPath(user, recrusivePath)
+    results[i] = fetch(process.env.PROVIDER_BASE_URL + davPath, {
+      method: 'MKCOL',
+      headers: validAuthHeaders
+    })
+  }
+  return results
+}
+
+/**
+ * Create a file using webDAV api.
+ *
+ * @param {string} user
+ * @param {string} fileName
+ * @param {string} contents
+ * @returns {*} result of the fetch request
+ */
+const createFile = function (user, fileName, contents = '') {
+  const davPath = createDavPath(user, fileName)
+  return fetch(process.env.PROVIDER_BASE_URL + davPath, {
+    method: 'PUT',
+    headers: validAuthHeaders,
+    body: contents
+  })
+}
+
+/**
+ * Delete a file or folder using webDAV api.
+ *
+ * @param {string} user
+ * @param {string} itemName
+ * @returns {*} result of the fetch request
+ */
+const deleteItem = function (user, itemName) {
+  const davPath = createDavPath(user, itemName)
+  return fetch(process.env.PROVIDER_BASE_URL + davPath, {
+    method: 'DELETE',
+    headers: validAuthHeaders
+  })
+}
+
+module.exports = {
+  createFolderRecrusive,
+  createFile,
+  deleteItem
+}


### PR DESCRIPTION
1. get rid of unneeded CORS headers
2. use matchers for etag and file ids
3. create states for creating files & folders

this is part of #709