### PR TITLE
adjust create/delete folder tests to pass on oc10 provider

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -196,8 +196,7 @@ def pactProviderTests(version):
             'PACTFLOW_TOKEN': {
                 'from_secret': 'pactflow_token'
             },
-            'PROVIDER_VERSION': version,
-            'LOG_LEVEL': 'info'
+            'PROVIDER_VERSION': version
         },
         'commands': [
             'yarn test-provider'

--- a/tests/appsTest.js
+++ b/tests/appsTest.js
@@ -5,7 +5,7 @@ describe('Main: Currently testing apps management,', function () {
 
   // PACT setup
   const {
-    validAuthHeaders,
+    validAdminAuthHeaders,
     getCapabilitiesInteraction,
     getCurrentUserInformationInteraction,
     xmlResponseHeaders,
@@ -38,7 +38,7 @@ describe('Main: Currently testing apps management,', function () {
           /.*\/ocs\/v1\.php\/cloud\/apps\/.+$/,
           '/ocs/v1.php/cloud/apps/files'
         ),
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       })
       .willRespondWith({
         status: 200,
@@ -57,7 +57,7 @@ describe('Main: Currently testing apps management,', function () {
           '/ocs/v1.php/cloud/apps'
         ),
         query: query,
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       })
       .willRespondWith({
         status: 200,

--- a/tests/capabilitiesTest.js
+++ b/tests/capabilitiesTest.js
@@ -8,7 +8,7 @@ describe('Main: Currently testing getConfig, getVersion and getCapabilities', ()
     createOwncloud,
     getCapabilitiesInteraction,
     getCurrentUserInformationInteraction,
-    validAuthHeaders,
+    validAdminAuthHeaders,
     applicationXmlResponseHeaders
   } = require('./pactHelper.js')
 
@@ -24,7 +24,7 @@ describe('Main: Currently testing getConfig, getVersion and getCapabilities', ()
           /.*\/ocs\/v1\.php\/config/,
           '/ocs/v1.php/config'
         ),
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       })
       .willRespondWith({
         status: 200,

--- a/tests/fileTrashTest.js
+++ b/tests/fileTrashTest.js
@@ -11,7 +11,7 @@ describe('oc.fileTrash', function () {
 
   const {
     origin,
-    validAuthHeaders,
+    validAdminAuthHeaders,
     accessControlAllowHeaders,
     accessControlAllowMethods,
     getCurrentUserInformationInteraction,
@@ -166,7 +166,7 @@ describe('oc.fileTrash', function () {
       await getCurrentUserInformationInteraction(provider)
       await provider
         .uponReceiving('PROPFIND empty trash')
-        .withRequest(requestMethod('PROPFIND', trashbinPath, validAuthHeaders, emptyTrashbinXmlRequestBody))
+        .withRequest(requestMethod('PROPFIND', trashbinPath, validAdminAuthHeaders, emptyTrashbinXmlRequestBody))
         .willRespondWith({
           status: 207,
           headers: {
@@ -198,7 +198,7 @@ describe('oc.fileTrash', function () {
       const propfindForTrashbinWithItems = provider => {
         return provider
           .uponReceiving('PROPFIND to trashbin with items')
-          .withRequest(requestMethod('PROPFIND', trashbinPath, validAuthHeaders, emptyTrashbinXmlRequestBody))
+          .withRequest(requestMethod('PROPFIND', trashbinPath, validAdminAuthHeaders, emptyTrashbinXmlRequestBody))
           .willRespondWith(responseMethod(
             207,
             responseHeader('application/xml; charset=utf-8'),
@@ -208,7 +208,7 @@ describe('oc.fileTrash', function () {
       const listItemWithinADeletedFolder = provider => {
         return provider
           .uponReceiving('list item within a deleted folder')
-          .withRequest(requestMethod('PROPFIND', trashbinFolderPath, validAuthHeaders, emptyTrashbinXmlRequestBody))
+          .withRequest(requestMethod('PROPFIND', trashbinFolderPath, validAdminAuthHeaders, emptyTrashbinXmlRequestBody))
           .willRespondWith({
             status: 207,
             headers: responseHeader('application/xml; charset=utf-8'),
@@ -320,7 +320,7 @@ describe('oc.fileTrash', function () {
       const propfindForTrashbinWithItems = provider => {
         return provider
           .uponReceiving('PROPFIND to trashbin with items')
-          .withRequest(requestMethod('PROPFIND', trashbinPath, validAuthHeaders, emptyTrashbinXmlRequestBody))
+          .withRequest(requestMethod('PROPFIND', trashbinPath, validAdminAuthHeaders, emptyTrashbinXmlRequestBody))
           .willRespondWith(responseMethod(
             207,
             responseHeader('application/xml; charset=utf-8'),
@@ -337,7 +337,7 @@ describe('oc.fileTrash', function () {
               '.*\\/remote\\.php\\/webdav\\/' + testFolder,
               '/remote.php/webdav/' + testFolder
             ),
-            headers: validAuthHeaders,
+            headers: validAdminAuthHeaders,
             body: filesListXmlRequestBody
           })
           .willRespondWith({
@@ -417,7 +417,7 @@ describe('oc.fileTrash', function () {
       const PropfindToAnEmptytrashbinAfterRestoring = provider => {
         return provider
           .uponReceiving('PROPFIND to an empty trashbin after restoring')
-          .withRequest(requestMethod('PROPFIND', trashbinPath, validAuthHeaders, emptyTrashbinXmlRequestBody))
+          .withRequest(requestMethod('PROPFIND', trashbinPath, validAdminAuthHeaders, emptyTrashbinXmlRequestBody))
           .willRespondWith(responseMethod(
             207,
             responseHeader('text/html; charset=utf-8'),
@@ -434,7 +434,7 @@ describe('oc.fileTrash', function () {
               '.*\\/remote\\.php\\/webdav\\/' + testFolder + '.*$',
               '/remote.php/webdav/' + testFolder + '.*$'
             ),
-            headers: validAuthHeaders,
+            headers: validAdminAuthHeaders,
             body: filesListXmlRequestBody
           })
           .willRespondWith({
@@ -500,7 +500,7 @@ describe('oc.fileTrash', function () {
       const propfindTrashItemsBeforeDeletingFile = provider => {
         return provider
           .uponReceiving('PROPFIND trash items before deleting file')
-          .withRequest(requestMethod('PROPFIND', trashbinPath, validAuthHeaders, emptyTrashbinXmlRequestBody))
+          .withRequest(requestMethod('PROPFIND', trashbinPath, validAdminAuthHeaders, emptyTrashbinXmlRequestBody))
           .willRespondWith({
             status: 207,
             headers: responseHeader('application/xml; charset=utf-8'),
@@ -590,7 +590,7 @@ describe('oc.fileTrash', function () {
       const propfindTrashItemsAfterRestoringDeletingFile = provider => {
         return provider
           .uponReceiving('PROPFIND trash items after restoring deleting file')
-          .withRequest(requestMethod('PROPFIND', trashbinPath, validAuthHeaders, emptyTrashbinXmlRequestBody))
+          .withRequest(requestMethod('PROPFIND', trashbinPath, validAdminAuthHeaders, emptyTrashbinXmlRequestBody))
           .willRespondWith(responseMethod(207, responseHeader('application/xml; charset=utf-8'), trashbinXmlResponseBody()))
       }
 
@@ -603,7 +603,7 @@ describe('oc.fileTrash', function () {
               '.*\\/remote\\.php\\/webdav\\/' + testFolder + '.*$',
               '/remote.php/webdav/' + testFolder + '.*$'
             ),
-            headers: validAuthHeaders,
+            headers: validAdminAuthHeaders,
             body: filesListXmlRequestBody
           })
           .willRespondWith({
@@ -685,7 +685,7 @@ describe('oc.fileTrash', function () {
           .withRequest({
             method: 'PROPFIND',
             path: trashbinPath,
-            headers: validAuthHeaders,
+            headers: validAdminAuthHeaders,
             body: emptyTrashbinXmlRequestBody
           })
           .willRespondWith({
@@ -704,7 +704,7 @@ describe('oc.fileTrash', function () {
               '.*\\/remote\\.php\\/webdav\\/.*',
               '/remote.php/webdav/.*$'
             ),
-            headers: validAuthHeaders,
+            headers: validAdminAuthHeaders,
             body: filesListXmlRequestBody
           })
           .willRespondWith({

--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -6,7 +6,7 @@ describe('Main: Currently testing file versions management,', function () {
   const config = require('./config/config.json')
 
   const {
-    validAuthHeaders,
+    validAdminAuthHeaders,
     accessControlAllowHeaders,
     accessControlAllowMethods,
     applicationXmlResponseHeaders,
@@ -38,7 +38,7 @@ describe('Main: Currently testing file versions management,', function () {
       matcher: `.*\\/remote\\.php\\/dav\\/meta\\/${fileInfo.id}\\/v$`,
       generate: `/remote.php/dav/meta/${fileInfo.id}/v`
     }),
-    headers: validAuthHeaders,
+    headers: validAdminAuthHeaders,
     body: new XmlBuilder('1.0', '', 'd:propfind').build(dPropfind => {
       dPropfind.setAttributes({ 'xmlns:d': 'DAV:', 'xmlns:oc': 'http://owncloud.org/ns' })
       dPropfind.appendElement('d:prop', '', '')
@@ -147,7 +147,7 @@ describe('Main: Currently testing file versions management,', function () {
           .withRequest({
             method: 'GET',
             path: fileVersionPath(i),
-            headers: validAuthHeaders
+            headers: validAdminAuthHeaders
           })
           .willRespondWith({
             status: 200,
@@ -163,7 +163,7 @@ describe('Main: Currently testing file versions management,', function () {
         .withRequest({
           method: 'COPY',
           path: fileVersionPath(0),
-          headers: validAuthHeaders
+          headers: validAdminAuthHeaders
         })
         .willRespondWith({
           status: 204,

--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -248,14 +248,14 @@ describe('Main: Currently testing files management,', function () {
 
     it('deletes the test folder at instance', async function () {
       const provider = createProvider()
-      await getCapabilitiesInteraction(provider, config.adminUsername, config.adminPassword)
-      await getCurrentUserInformationInteraction(provider, config.adminUsername, config.adminPassword)
+      await getCapabilitiesInteraction(provider, config.testUser, config.testUserPassword)
+      await getCurrentUserInformationInteraction(provider, config.testUser, config.testUserPassword)
       await deleteResourceInteraction(
-        provider, testFolder, 'folder', config.adminUsername, config.adminPassword
+        provider, testFolder, 'folder', config.testUser, config.testUserPassword
       )
 
       return provider.executeTest(async () => {
-        const oc = createOwncloud(config.adminUsername, config.adminPassword)
+        const oc = createOwncloud(config.testUser, config.testUserPassword)
         await oc.login()
         return oc.files.delete(testFolder).then(status => {
           expect(status).toBe(true)

--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -373,13 +373,13 @@ describe('Main: Currently testing files management,', function () {
       const provider = createProvider()
 
       for (const file of uriEncodedTestSubFiles) {
-        await getContentsOfFileInteraction(provider, file)
+        await getContentsOfFileInteraction(provider, file, config.testUser, config.testUserPassword)
       }
-      await getCapabilitiesInteraction(provider)
-      await getCurrentUserInformationInteraction(provider)
+      await getCapabilitiesInteraction(provider, config.testUser, config.testUserPassword)
+      await getCurrentUserInformationInteraction(provider, config.testUser, config.testUserPassword)
 
       return provider.executeTest(async () => {
-        const oc = createOwncloud()
+        const oc = createOwncloud(config.testUser, config.testUserPassword)
         await oc.login()
         for (let i = 0; i < testSubFiles.length; i++) {
           await oc.files.getFileContents(testSubFiles[i], { resolveWithResponseObject: true }).then((resp) => {
@@ -476,12 +476,12 @@ describe('Main: Currently testing files management,', function () {
     it('checking method : mkdir for an existing parent path', async function () {
       const newFolder = testFolder + '/' + 'new folder'
       const provider = createProvider()
-      await getCapabilitiesInteraction(provider)
-      await getCurrentUserInformationInteraction(provider)
-      await createFolderInteraction(provider, encodeURI(newFolder))
+      await getCapabilitiesInteraction(provider, config.testUser, config.testUserPassword)
+      await getCurrentUserInformationInteraction(provider, config.testUser, config.testUserPassword)
+      await createFolderInteraction(provider, encodeURI(newFolder), config.testUser, config.testUserPassword)
 
       return provider.executeTest(async () => {
-        const oc = createOwncloud()
+        const oc = createOwncloud(config.testUser, config.testUserPassword)
         await oc.login()
 
         return oc.files.mkdir(newFolder).then(status => {
@@ -520,15 +520,21 @@ describe('Main: Currently testing files management,', function () {
       })
     })
 
-    it('checking method : delete for an existing file', async function () {
+    it('checking method : delete for an existing folder', async function () {
       const newFolder = testSubDir
       const provider = createProvider()
-      await getCapabilitiesInteraction(provider)
-      await getCurrentUserInformationInteraction(provider)
-      await deleteResourceInteraction(provider, encodeURI(newFolder))
+      await getCapabilitiesInteraction(
+        provider, config.testUser, config.testUserPassword
+      )
+      await getCurrentUserInformationInteraction(
+        provider, config.testUser, config.testUserPassword
+      )
+      await deleteResourceInteraction(
+        provider, encodeURI(newFolder), 'folder', config.testUser, config.testUserPassword
+      )
 
       return provider.executeTest(async () => {
-        const oc = createOwncloud()
+        const oc = createOwncloud(config.testUser, config.testUserPassword)
         await oc.login()
         return oc.files.delete(newFolder)
           .then(status2 => {
@@ -539,14 +545,20 @@ describe('Main: Currently testing files management,', function () {
       })
     })
 
-    it.skip('checking method : delete for a non-existent file', async function () {
+    it.skip('checking method : delete for a non-existent folder', async function () {
       const provider = createProvider()
-      await getCapabilitiesInteraction(provider)
-      await getCurrentUserInformationInteraction(provider)
-      await deleteResourceInteraction(provider, encodeURI(nonExistentDir))
+      await getCapabilitiesInteraction(
+        provider, config.testUser, config.testUserPassword
+      )
+      await getCurrentUserInformationInteraction(
+        provider, config.testUser, config.testUserPassword
+      )
+      await deleteResourceInteraction(
+        provider, encodeURI(nonExistentDir), 'folder', config.testUser, config.testUserPassword
+      )
 
       return provider.executeTest(async () => {
-        const oc = createOwncloud()
+        const oc = createOwncloud(config.testUser, config.testUserPassword)
         await oc.login()
         return oc.files.delete(nonExistentDir).then(status => {
           expect(status).toBe(null)

--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -190,12 +190,16 @@ describe('Main: Currently testing files management,', function () {
   describe('file/folder creation and deletion', function () {
     it('creates the testFolder at instance', async function () {
       const provider = createProvider()
-      await getCapabilitiesInteraction(provider)
-      await getCurrentUserInformationInteraction(provider)
-      await createFolderInteraction(provider, testFolder)
+      await getCapabilitiesInteraction(provider, config.testUser, config.testUserPassword)
+      await getCurrentUserInformationInteraction(
+        provider, config.testUser, config.testUserPassword
+      )
+      await createFolderInteraction(
+        provider, testFolder, config.testUser, config.testUserPassword
+      )
 
       return provider.executeTest(async () => {
-        const oc = createOwncloud()
+        const oc = createOwncloud(config.testUser, config.testUserPassword)
         await oc.login()
         return oc.files.createFolder(testFolder).then(status => {
           expect(status).toBe(true)
@@ -207,12 +211,14 @@ describe('Main: Currently testing files management,', function () {
 
     it('creates subfolder at instance', async function () {
       const provider = createProvider()
-      await getCapabilitiesInteraction(provider)
-      await getCurrentUserInformationInteraction(provider)
-      await createFolderInteraction(provider, testSubDir)
+      await getCapabilitiesInteraction(provider, config.testUser, config.testUserPassword)
+      await getCurrentUserInformationInteraction(provider, config.testUser, config.testUserPassword)
+      await createFolderInteraction(
+        provider, testSubDir, config.testUser, config.testUserPassword
+      )
 
       return provider.executeTest(async () => {
-        const oc = createOwncloud()
+        const oc = createOwncloud(config.testUser, config.testUserPassword)
         await oc.login()
         return oc.files.mkdir(testSubDir).then(status => {
           expect(status).toBe(true)
@@ -249,7 +255,9 @@ describe('Main: Currently testing files management,', function () {
     it('deletes the test folder at instance', async function () {
       const provider = createProvider()
       await getCapabilitiesInteraction(provider, config.testUser, config.testUserPassword)
-      await getCurrentUserInformationInteraction(provider, config.testUser, config.testUserPassword)
+      await getCurrentUserInformationInteraction(
+        provider, config.testUser, config.testUserPassword
+      )
       await deleteResourceInteraction(
         provider, testFolder, 'folder', config.testUser, config.testUserPassword
       )

--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -248,12 +248,14 @@ describe('Main: Currently testing files management,', function () {
 
     it('deletes the test folder at instance', async function () {
       const provider = createProvider()
-      await getCapabilitiesInteraction(provider)
-      await getCurrentUserInformationInteraction(provider)
-      await deleteResourceInteraction(provider, testFolder)
+      await getCapabilitiesInteraction(provider, config.adminUsername, config.adminPassword)
+      await getCurrentUserInformationInteraction(provider, config.adminUsername, config.adminPassword)
+      await deleteResourceInteraction(
+        provider, testFolder, 'folder', config.adminUsername, config.adminPassword
+      )
 
       return provider.executeTest(async () => {
-        const oc = createOwncloud()
+        const oc = createOwncloud(config.adminUsername, config.adminPassword)
         await oc.login()
         return oc.files.delete(testFolder).then(status => {
           expect(status).toBe(true)

--- a/tests/groupTest.js
+++ b/tests/groupTest.js
@@ -6,7 +6,7 @@ describe('Main: Currently testing group management,', function () {
 
   const {
     createProvider,
-    validAuthHeaders,
+    validAdminAuthHeaders,
     xmlResponseHeaders,
     ocsMeta,
     getCapabilitiesInteraction,
@@ -24,7 +24,7 @@ describe('Main: Currently testing group management,', function () {
           /.*\/ocs\/v1\.php\/cloud\/groups$/,
           '/ocs/v1.php/cloud/groups'
         ),
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       })
       .willRespondWith({
         status: 200,
@@ -60,7 +60,7 @@ describe('Main: Currently testing group management,', function () {
           new RegExp('.*\\/ocs\\/v1\\.php\\/cloud\\/groups\\/' + group + '$'),
           '/ocs/v1.php/cloud/groups/' + group
         ),
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       })
       .willRespondWith({
         status: 200,
@@ -130,7 +130,7 @@ describe('Main: Currently testing group management,', function () {
           /.*\/ocs\/v1\.php\/cloud\/groups\/admin$/,
           '/ocs/v1.php/cloud/groups/admin'
         ),
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       })
       .willRespondWith({
         status: 200,
@@ -172,7 +172,7 @@ describe('Main: Currently testing group management,', function () {
   })
 
   it('checking method : createGroup', async function () {
-    const headers = { ...validAuthHeaders, ...{ 'Content-Type': 'application/x-www-form-urlencoded' } }
+    const headers = { ...validAdminAuthHeaders, ...{ 'Content-Type': 'application/x-www-form-urlencoded' } }
     await provider
       .given('group does not exist', { groupName: config.testGroup })
       .uponReceiving('a create group POST request')

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -134,17 +134,28 @@ const createOwncloud = function (username = config.adminUsername, password = con
   return oc
 }
 
-const getContentsOfFileInteraction = (provider, file) => {
+const getContentsOfFileInteraction = (
+  provider, file,
+  user = config.adminUsername,
+  password = config.adminPassword
+) => {
+  if (user !== config.adminUsername) {
+    provider.given('the user is recreated', { username: user, password: password })
+  }
   if (file !== config.nonExistentFile) {
     provider
-      .given('file exists', { fileName: file })
+      .given('file exists', {
+        fileName: file,
+        username: user,
+        password: password
+      })
   }
   return provider
     .uponReceiving('GET contents of file ' + file)
     .withRequest({
       method: 'GET',
       path: webdavPath(file),
-      headers: validAdminAuthHeaders
+      headers: { authorization: getAuthHeaders(user, password) }
     }).willRespondWith(file !== config.nonExistentFile ? {
       status: 200,
       headers: textPlainResponseHeaders,

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -161,6 +161,9 @@ const deleteResourceInteraction = (
   user = config.adminUsername, password = config.adminPassword
 ) => {
   let response
+  if (user !== config.adminUsername) {
+    provider.given('the user is recreated', { username: user, password: password })
+  }
   if (resource.includes('nonExistent')) {
     response = {
       status: 404,
@@ -203,6 +206,9 @@ const deleteResourceInteraction = (
 async function getCurrentUserInformationInteraction (
   provider, user = config.adminUsername, password = config.adminPassword
 ) {
+  if (user !== config.adminUsername) {
+    provider.given('the user is recreated', { username: user, password: password })
+  }
   await provider
     .uponReceiving(`as '${user}' get current user information`)
     .withRequest({
@@ -222,8 +228,8 @@ async function getCurrentUserInformationInteraction (
             .appendElement('statuscode', '', '100')
             .appendElement('message', '', 'OK')
         }).appendElement('data', '', (data) => {
-          data.appendElement('id', '', config.adminUsername)
-          data.appendElement('display-name', '', config.adminUsername)
+          data.appendElement('id', '', user)
+          data.appendElement('display-name', '', user)
           data.appendElement('email', '', '')
         })
       })
@@ -233,6 +239,9 @@ async function getCurrentUserInformationInteraction (
 async function getCapabilitiesInteraction (
   provider, user = config.adminUsername, password = config.adminPassword
 ) {
+  if (user !== config.adminUsername) {
+    provider.given('the user is recreated', { username: user, password: password })
+  }
   await provider
     .uponReceiving(`as '${user}' get capabilities with valid authentication`)
     .withRequest({

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -1,7 +1,7 @@
 import { MatchersV3, PactV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 const config = require('./config/config.json')
-var validUserPasswordHash = Buffer.from(config.adminUsername + ':' + config.adminPassword, 'binary').toString('base64')
+var adminPasswordHash = Buffer.from(config.adminUsername + ':' + config.adminPassword, 'binary').toString('base64')
 
 const path = require('path')
 const OwnCloud = require('../src/owncloud')
@@ -9,8 +9,8 @@ const OwnCloud = require('../src/owncloud')
 const accessControlAllowHeaders = 'OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With'
 const accessControlAllowMethods = 'GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT,COPY,MOVE,HEAD,LOCK,UNLOCK'
 const origin = 'http://localhost:9876'
-const validAuthHeaders = {
-  authorization: 'Basic ' + validUserPasswordHash
+const validAdminAuthHeaders = {
+  authorization: 'Basic ' + adminPasswordHash
 }
 
 const testSubFiles = [
@@ -144,7 +144,7 @@ const getContentsOfFileInteraction = (provider, file) => {
     .withRequest({
       method: 'GET',
       path: webdavPath(file),
-      headers: validAuthHeaders
+      headers: validAdminAuthHeaders
     }).willRespondWith(file !== config.nonExistentFile ? {
       status: 200,
       headers: textPlainResponseHeaders,
@@ -185,7 +185,7 @@ const deleteResourceInteraction = (provider, resource, type = 'folder') => {
     .withRequest({
       method: 'DELETE',
       path: webdavPath(resource),
-      headers: validAuthHeaders
+      headers: validAdminAuthHeaders
     }).willRespondWith(response)
 }
 
@@ -198,7 +198,7 @@ async function getCurrentUserInformationInteraction (provider) {
         /.*\/ocs\/v1\.php\/cloud\/user$/,
         '/ocs/v1.php/cloud/user'
       ),
-      headers: validAuthHeaders
+      headers: validAdminAuthHeaders
     })
     .willRespondWith({
       status: 200,
@@ -227,7 +227,7 @@ async function getCapabilitiesInteraction (provider) {
         '/ocs/v1.php/cloud/capabilities'
       ),
       query: { format: 'json' },
-      headers: validAuthHeaders
+      headers: validAdminAuthHeaders
     })
     .willRespondWith({
       status: 200,
@@ -282,7 +282,7 @@ const getUserInformationAsAdminInteraction = function (provider) {
         '/ocs/v2.php/cloud/users/' + config.testUser
       ),
       query: { format: 'json' },
-      headers: validAuthHeaders
+      headers: validAdminAuthHeaders
     })
     .willRespondWith({
       status: 200,
@@ -342,7 +342,7 @@ const createUserInteraction = function (provider) {
         '/ocs/v1.php/cloud/users'
       ),
       headers: {
-        ...validAuthHeaders,
+        ...validAdminAuthHeaders,
         ...applicationFormUrlEncoded
       },
       body: `password=${config.testUserPassword}&userid=${config.testUser}`
@@ -364,7 +364,7 @@ const createUserWithGroupMembershipInteraction = function (provider) {
         '/ocs/v1.php/cloud/users'
       ),
       headers: {
-        ...validAuthHeaders,
+        ...validAdminAuthHeaders,
         ...applicationFormUrlEncoded
       },
       body: 'password=' + config.testUserPassword + '&userid=' + config.testUser + '&groups%5B0%5D=' + config.testGroup
@@ -389,7 +389,7 @@ const deleteUserInteraction = function (provider) {
         '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + config.testUser + '$',
         '/ocs/v1.php/cloud/users/' + config.testUser
       ),
-      headers: validAuthHeaders
+      headers: validAdminAuthHeaders
     }).willRespondWith({
       status: 200,
       headers: xmlResponseHeaders,
@@ -414,7 +414,7 @@ const createFolderInteraction = function (provider, folderName) {
         `.*\\/remote\\.php\\/webdav\\/${folderName}\\/?`,
         '/remote.php/webdav/' + folderName + '/'
       ),
-      headers: validAuthHeaders
+      headers: validAdminAuthHeaders
     }).willRespondWith({
       status: 201,
       headers: htmlResponseHeaders
@@ -428,7 +428,7 @@ const updateFileInteraction = function (provider, file) {
       method: 'PUT',
       path: webdavPath(file),
       headers: {
-        ...validAuthHeaders,
+        ...validAdminAuthHeaders,
         'Content-Type': 'text/plain;charset=utf-8'
       }
       // TODO: uncomment this once the issue is fixed
@@ -458,7 +458,7 @@ module.exports = {
   resourceNotFoundExceptionMessage,
   webdavPath,
   origin,
-  validAuthHeaders,
+  validAdminAuthHeaders,
   invalidAuthHeader,
   xmlResponseHeaders,
   htmlResponseHeaders,

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -144,5 +144,5 @@ describe('provider testing', () => {
     }).catch(function (error) {
       chai.assert.fail(error.message)
     })
-  }, 60000)
+  }, 120000)
 })

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -71,7 +71,10 @@ describe('provider testing', () => {
       },
       'folder exists': (setup, parameters) => {
         if (setup) {
-          createFolderRecrusive(config.adminUsername, parameters.folderName)
+          const results = createFolderRecrusive(config.adminUsername, parameters.folderName)
+          chai.assert.isBelow(
+            results[0].status, 300, `creating folder '${parameters.folderName}' failed`
+          )
         }
         return Promise.resolve({ description: 'folder created' })
       },
@@ -79,9 +82,17 @@ describe('provider testing', () => {
         const dirname = path.dirname(parameters.fileName)
         if (setup) {
           if (dirname !== '' && dirname !== '/') {
-            createFolderRecrusive(config.adminUsername, dirname)
+            const results = createFolderRecrusive(config.adminUsername, dirname)
+            for (let i = 0; i < results.length; i++) {
+              chai.assert.isBelow(
+                results[i].status, 300, `creating folder '${dirname}' failed'`
+              )
+            }
           }
-          createFile(config.adminUsername, parameters.fileName, config.testContent)
+          const result = createFile(config.adminUsername, parameters.fileName, config.testContent)
+          chai.assert.isBelow(
+            result.status, 300, `creating file '${parameters.fileName}' failed`
+          )
         } else {
           let itemToDelete
           if (dirname !== '' && dirname !== '/') {
@@ -90,7 +101,10 @@ describe('provider testing', () => {
           } else {
             itemToDelete = parameters.fileName
           }
-          deleteItem(config.adminUsername, itemToDelete)
+          const result = deleteItem(config.adminUsername, itemToDelete)
+          chai.assert.strictEqual(
+            result.status, 204, `deleting '${itemToDelete}' failed`
+          )
         }
         return Promise.resolve({ description: 'file created' })
       }

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -23,7 +23,8 @@ describe('provider testing', () => {
     const opts = {
       provider: 'oc-server',
       providerBaseUrl: process.env.PROVIDER_BASE_URL || 'http://localhost/',
-      disableSSLVerification: true
+      disableSSLVerification: true,
+      callbackTimeout: 10000
     }
     if (process.env.CI === 'true') {
       opts.pactBrokerUrl = 'https://jankaritech.pactflow.io'

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -22,7 +22,6 @@ describe('provider testing', () => {
   it('verifies the provider', () => {
     const opts = {
       provider: 'oc-server',
-      logLevel: 'debug',
       providerBaseUrl: process.env.PROVIDER_BASE_URL || 'http://localhost/',
       disableSSLVerification: true
     }

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -71,7 +71,9 @@ describe('provider testing', () => {
       },
       'folder exists': (setup, parameters) => {
         if (setup) {
-          const results = createFolderRecrusive(config.adminUsername, parameters.folderName)
+          const results = createFolderRecrusive(
+            parameters.username, parameters.password, parameters.folderName
+          )
           chai.assert.isBelow(
             results[0].status, 300, `creating folder '${parameters.folderName}' failed`
           )
@@ -82,14 +84,18 @@ describe('provider testing', () => {
         const dirname = path.dirname(parameters.fileName)
         if (setup) {
           if (dirname !== '' && dirname !== '/') {
-            const results = createFolderRecrusive(config.adminUsername, dirname)
+            const results = createFolderRecrusive(
+              parameters.username, parameters.password, dirname
+            )
             for (let i = 0; i < results.length; i++) {
               chai.assert.isBelow(
                 results[i].status, 300, `creating folder '${dirname}' failed'`
               )
             }
           }
-          const result = createFile(config.adminUsername, parameters.fileName, config.testContent)
+          const result = createFile(
+            parameters.username, parameters.password, parameters.fileName, config.testContent
+          )
           chai.assert.isBelow(
             result.status, 300, `creating file '${parameters.fileName}' failed`
           )
@@ -101,7 +107,9 @@ describe('provider testing', () => {
           } else {
             itemToDelete = parameters.fileName
           }
-          const result = deleteItem(config.adminUsername, itemToDelete)
+          const result = deleteItem(
+            parameters.username, parameters.password, itemToDelete
+          )
           chai.assert.strictEqual(
             result.status, 204, `deleting '${itemToDelete}' failed`
           )

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -115,6 +115,27 @@ describe('provider testing', () => {
           )
         }
         return Promise.resolve({ description: 'file created' })
+      },
+      'the user is recreated': (setup, parameters) => {
+        if (setup) {
+          fetch(process.env.PROVIDER_BASE_URL + '/ocs/v2.php/cloud/users/' + parameters.username, {
+            method: 'DELETE',
+            headers: validAdminAuthHeaders
+          })
+          const result = fetch(process.env.PROVIDER_BASE_URL + '/ocs/v2.php/cloud/users',
+            {
+              method: 'POST',
+              body: `userid=${parameters.username}&password=${parameters.username}`,
+              headers: {
+                ...validAdminAuthHeaders,
+                ...{ 'Content-Type': 'application/x-www-form-urlencoded' }
+              }
+            })
+          chai.assert.strictEqual(
+            result.status, 200, `creating user '${parameters.username}' failed`
+          )
+          return Promise.resolve({ description: 'user created' })
+        }
       }
     }
     return new VerifierV3(opts).verifyProvider().then(output => {

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -8,7 +8,7 @@ describe('provider testing', () => {
   const fetch = require('sync-fetch')
 
   const {
-    validAuthHeaders
+    validAdminAuthHeaders
   } = require('./pactHelper.js')
 
   const {
@@ -49,7 +49,7 @@ describe('provider testing', () => {
             method: 'POST',
             body: 'groupid=' + parameters.groupName,
             headers: {
-              ...validAuthHeaders,
+              ...validAdminAuthHeaders,
               ...{ 'Content-Type': 'application/x-www-form-urlencoded' }
             }
           })
@@ -57,7 +57,7 @@ describe('provider testing', () => {
         } else {
           fetch(process.env.PROVIDER_BASE_URL + '/ocs/v1.php/cloud/groups/' + parameters.groupName, {
             method: 'DELETE',
-            headers: validAuthHeaders
+            headers: validAdminAuthHeaders
           })
           return Promise.resolve({ description: 'group deleted' })
         }
@@ -65,7 +65,7 @@ describe('provider testing', () => {
       'group does not exist': (setup, parameters) => {
         fetch(process.env.PROVIDER_BASE_URL + '/ocs/v1.php/cloud/groups/' + parameters.groupName, {
           method: 'DELETE',
-          headers: validAuthHeaders
+          headers: validAdminAuthHeaders
         })
         return Promise.resolve({ description: 'group deleted' })
       },

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -7,7 +7,7 @@ describe('oc.publicFiles', function () {
   const using = require('jasmine-data-provider')
 
   const {
-    validAuthHeaders,
+    validAdminAuthHeaders,
     origin,
     xmlResponseAndAccessControlCombinedHeader,
     htmlResponseAndAccessControlCombinedHeader,
@@ -39,7 +39,7 @@ describe('oc.publicFiles', function () {
           '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares',
           '/ocs/v1.php/apps/files_sharing/api/v1/shares'
         ),
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       }).willRespondWith({
         status: 200,
         headers: xmlResponseAndAccessControlCombinedHeader,

--- a/tests/requestsOcsTest.js
+++ b/tests/requestsOcsTest.js
@@ -6,7 +6,7 @@ describe('Main: Currently testing low level OCS', function () {
   const {
     getCapabilitiesInteraction,
     getCurrentUserInformationInteraction,
-    validAuthHeaders,
+    validAdminAuthHeaders,
     getUserInformationAsAdminInteraction,
     createOwncloud,
     createProvider,
@@ -57,7 +57,7 @@ describe('Main: Currently testing low level OCS', function () {
           '/ocs/v2.php/cloud/users/unknown-user'
         ),
         query: { format: 'json' },
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       })
       .willRespondWith({
         status: 401,
@@ -109,7 +109,7 @@ describe('Main: Currently testing low level OCS', function () {
           '/ocs/v1.php/cloud/users/' + config.testUser
         ),
         query: { format: 'json' },
-        headers: validAuthHeaders,
+        headers: validAdminAuthHeaders,
         body: {
           key: 'email',
           value: 'foo@bar.net'

--- a/tests/shareRecipientTest.js
+++ b/tests/shareRecipientTest.js
@@ -4,7 +4,7 @@ describe('Main: Currently testing share recipient,', function () {
   var config = require('./config/config.json')
 
   const {
-    validAuthHeaders,
+    validAdminAuthHeaders,
     getCapabilitiesInteraction,
     getCurrentUserInformationInteraction,
     createOwncloud,
@@ -21,7 +21,7 @@ describe('Main: Currently testing share recipient,', function () {
           '/ocs/v2.php/apps/files_sharing/api/v1/sharees'
         ),
         query: { search: 'test', itemType: 'folder', page: '1', perPage: '200', format: 'json' },
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       }).willRespondWith({
         status: 200,
         headers: {

--- a/tests/sharingTest.js
+++ b/tests/sharingTest.js
@@ -22,7 +22,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
     applicationFormUrlEncoded,
     accessControlAllowHeaders,
     accessControlAllowMethods,
-    validAuthHeaders,
+    validAdminAuthHeaders,
     xmlResponseHeaders,
     getCapabilitiesInteraction,
     getCurrentUserInformationInteraction,
@@ -71,7 +71,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           '/ocs/v1.php/apps/files_sharing/api/v1/shares'
         ),
         query: { path: '/' + file },
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       }).willRespondWith({
         status: 200,
         headers: {
@@ -116,7 +116,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares\\/\\d+$',
           '/ocs/v1.php/apps/files_sharing/api/v1/shares/9'
         ),
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       }).willRespondWith({
         status: 200,
         headers: {
@@ -137,7 +137,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares\\/' + fileid + '$',
           '/ocs/v1.php/apps/files_sharing/api/v1/shares/' + fileid
         ),
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       })
       .willRespondWith({
         status: 200,
@@ -491,7 +491,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
               '/ocs/v1.php/apps/files_sharing/api/v1/shares'
             ),
             headers: {
-              ...validAuthHeaders,
+              ...validAdminAuthHeaders,
               ...applicationFormUrlEncoded
             },
             body: 'shareType=3' + '&path=%2F' + config.nonExistentFile + '&password=' + config.testUserPassword
@@ -519,7 +519,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
               '/ocs/v1.php/apps/files_sharing/api/v1/shares'
             ),
             headers: {
-              ...validAuthHeaders,
+              ...validAdminAuthHeaders,
               ...applicationFormUrlEncoded
             },
             body: 'shareType=1&shareWith=' + config.testGroup + '&path=%2F' + config.nonExistentFile + '&permissions=19'
@@ -542,7 +542,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
               '/ocs/v1.php/apps/files_sharing/api/v1/shares'
             ),
             query: { path: '/' + config.nonExistentFile },
-            headers: validAuthHeaders
+            headers: validAdminAuthHeaders
           }).willRespondWith({
             status: 200,
             headers: {
@@ -567,7 +567,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
               '/ocs/v1.php/apps/files_sharing/api/v1/shares'
             ),
             query: { path: '/newFileCreated123' }, // 'path=%2FnewFileCreated123',
-            headers: validAuthHeaders
+            headers: validAdminAuthHeaders
           })
           .willRespondWith({
             status: 200,
@@ -592,7 +592,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
               '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares\\/-1$',
               '/ocs/v1.php/apps/files_sharing/api/v1/shares/-1'
             ),
-            headers: validAuthHeaders
+            headers: validAdminAuthHeaders
           })
           .willRespondWith({
             status: 200,
@@ -612,7 +612,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
               '.*\\/remote\\.php\\/webdav\\/newFileCreated123$',
               '/remote.php/webdav/newFileCreated123'
             ),
-            headers: validAuthHeaders
+            headers: validAdminAuthHeaders
           })
           .willRespondWith({
             status: 200,
@@ -631,7 +631,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
               '/ocs/v1.php/apps/files_sharing/api/v1/shares'
             ),
             headers: {
-              ...validAuthHeaders,
+              ...validAdminAuthHeaders,
               ...applicationFormUrlEncoded
             },
             body: 'shareType=0&shareWith=' + config.testUser + '&path=' + file + '&expireDate=' + config.expirationDate
@@ -659,7 +659,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
               '.*\\/ocs\\/v1\\.php\\/apps\\/files_sharing\\/api\\/v1\\/shares\\/-1$',
               '/ocs/v1.php/apps/files_sharing/api/v1/shares/-1'
             ),
-            headers: validAuthHeaders
+            headers: validAdminAuthHeaders
           })
           .willRespondWith({
             status: 200,

--- a/tests/sharingWithAttributesTest.js
+++ b/tests/sharingWithAttributesTest.js
@@ -4,7 +4,7 @@ describe('oc.shares', function () {
   const config = require('./config/config.json')
 
   const {
-    validAuthHeaders,
+    validAdminAuthHeaders,
     applicationXmlResponseHeaders,
     applicationFormUrlEncoded,
     ocsMeta,
@@ -46,7 +46,7 @@ describe('oc.shares', function () {
           '/ocs/v1.php/apps/files_sharing/api/v1/shares'
         ),
         headers: {
-          ...validAuthHeaders,
+          ...validAdminAuthHeaders,
           ...applicationFormUrlEncoded
         },
         body: `shareType=0&shareWith=${testUser}&path=%2F${testFile}&attributes%5B0%5D%5Bscope%5D=${shareAttributes.attributes[0].scope}&attributes%5B0%5D%5Bkey%5D=${shareAttributes.attributes[0].key}&attributes%5B0%5D%5Bvalue%5D=${shareAttributes.attributes[0].value}&attributes%5B1%5D%5Bscope%5D=${shareAttributes.attributes[1].scope}&attributes%5B1%5D%5Bkey%5D=${shareAttributes.attributes[1].key}&attributes%5B1%5D%5Bvalue%5D=${shareAttributes.attributes[1].value}`

--- a/tests/signedUrlIntegrationTest.js
+++ b/tests/signedUrlIntegrationTest.js
@@ -9,7 +9,7 @@ describe('Signed urls', function () {
     createOwncloud,
     accessControlAllowHeaders,
     accessControlAllowMethods,
-    validAuthHeaders,
+    validAdminAuthHeaders,
     origin,
     getCapabilitiesInteraction,
     getCurrentUserInformationInteraction,
@@ -25,7 +25,7 @@ describe('Signed urls', function () {
           '.*\\/ocs\\/v1\\.php\\/cloud\\/user\\/signing-key',
           '/ocs/v1.php/cloud/user/signing-key'
         ),
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       }).willRespondWith({
         status: 200,
         headers: {

--- a/tests/userTest.js
+++ b/tests/userTest.js
@@ -14,7 +14,7 @@ describe('Main: Currently testing user management,', function () {
     createOwncloud,
     createProvider
   } = require('./pactHelper.js')
-  const { validAuthHeaders, xmlResponseHeaders, applicationFormUrlEncoded } = require('./pactHelper.js')
+  const { validAdminAuthHeaders, xmlResponseHeaders, applicationFormUrlEncoded } = require('./pactHelper.js')
 
   const getUserInformationInteraction = function (provider, requestName, username, responseBody) {
     return provider
@@ -25,7 +25,7 @@ describe('Main: Currently testing user management,', function () {
           '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + username + '$',
           '/ocs/v1.php/cloud/users/' + username
         ),
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       })
       .willRespondWith({
         status: 200,
@@ -44,7 +44,7 @@ describe('Main: Currently testing user management,', function () {
           '/ocs/v1.php/cloud/users'
         ),
         query: query,
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       })
       .willRespondWith({
         status: 200,
@@ -67,7 +67,7 @@ describe('Main: Currently testing user management,', function () {
           '/ocs/v1.php/cloud/users/' + username
         ),
         headers: {
-          ...validAuthHeaders,
+          ...validAdminAuthHeaders,
           ...applicationFormUrlEncoded
         },
         body: requestBody
@@ -96,7 +96,7 @@ describe('Main: Currently testing user management,', function () {
         ),
         headers:
           {
-            ...validAuthHeaders,
+            ...validAdminAuthHeaders,
             ...applicationFormUrlEncoded
           },
         body: 'groupid=' + group
@@ -124,7 +124,7 @@ describe('Main: Currently testing user management,', function () {
           '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + username + '\\/groups$',
           '/ocs/v1.php/cloud/users/' + username + '/groups'
         ),
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       })
       .willRespondWith({
         status: 200,
@@ -144,7 +144,7 @@ describe('Main: Currently testing user management,', function () {
         ),
         headers:
           {
-            ...validAuthHeaders,
+            ...validAdminAuthHeaders,
             ...applicationFormUrlEncoded
           },
         body: 'groupid=' + group
@@ -174,7 +174,7 @@ describe('Main: Currently testing user management,', function () {
         ),
         headers:
           {
-            ...validAuthHeaders,
+            ...validAdminAuthHeaders,
             ...applicationFormUrlEncoded
           },
         body: 'groupid=' + group
@@ -199,7 +199,7 @@ describe('Main: Currently testing user management,', function () {
           '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + username + '\\/subadmins$',
           '/ocs/v1.php/cloud/users/' + username + '/subadmins'
         ),
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       })
       .willRespondWith({
         status: 200,
@@ -1055,7 +1055,7 @@ describe('Main: Currently testing user management,', function () {
           '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + config.nonExistentUser + '$',
           '/ocs/v1.php/cloud/users/' + config.nonExistentUser
         ),
-        headers: validAuthHeaders
+        headers: validAdminAuthHeaders
       })
       .willRespondWith({
         status: 200,

--- a/tests/webdavHelper.js
+++ b/tests/webdavHelper.js
@@ -1,7 +1,7 @@
 const fetch = require('sync-fetch')
 const path = require('path')
 const {
-  validAuthHeaders
+  validAdminAuthHeaders
 } = require('./pactHelper.js')
 
 /**
@@ -41,7 +41,7 @@ const createFolderRecrusive = function (user, folderName) {
     }
     results[i] = fetch(createFullDavUrl(user, recrusivePath), {
       method: 'MKCOL',
-      headers: validAuthHeaders
+      headers: validAdminAuthHeaders
     })
   }
   return results
@@ -58,7 +58,7 @@ const createFolderRecrusive = function (user, folderName) {
 const createFile = function (user, fileName, contents = '') {
   return fetch(createFullDavUrl(user, fileName), {
     method: 'PUT',
-    headers: validAuthHeaders,
+    headers: validAdminAuthHeaders,
     body: contents
   })
 }
@@ -73,7 +73,7 @@ const createFile = function (user, fileName, contents = '') {
 const deleteItem = function (user, itemName) {
   return fetch(createFullDavUrl(user, itemName), {
     method: 'DELETE',
-    headers: validAuthHeaders
+    headers: validAdminAuthHeaders
   })
 }
 

--- a/tests/webdavHelper.js
+++ b/tests/webdavHelper.js
@@ -34,6 +34,8 @@ const createFullDavUrl = function (userId, resource) {
  */
 const createFolderRecrusive = function (user, password, folderName) {
   const results = []
+  folderName = folderName.replace(/\/$/, '')
+  folderName = folderName.replace(/^\//, '')
   const folders = folderName.split(path.sep)
   for (let i = 0; i < folders.length; i++) {
     let recrusivePath = ''

--- a/tests/webdavHelper.js
+++ b/tests/webdavHelper.js
@@ -1,7 +1,7 @@
 const fetch = require('sync-fetch')
 const path = require('path')
 const {
-  validAdminAuthHeaders
+  getAuthHeaders
 } = require('./pactHelper.js')
 
 /**
@@ -28,10 +28,11 @@ const createFullDavUrl = function (userId, resource) {
  * Create a folder using webDAV api.
  *
  * @param {string} user
+ * @param {string} password
  * @param {string} folderName
  * @returns {[]} all fetch results
  */
-const createFolderRecrusive = function (user, folderName) {
+const createFolderRecrusive = function (user, password, folderName) {
   const results = []
   const folders = folderName.split(path.sep)
   for (let i = 0; i < folders.length; i++) {
@@ -41,7 +42,7 @@ const createFolderRecrusive = function (user, folderName) {
     }
     results[i] = fetch(createFullDavUrl(user, recrusivePath), {
       method: 'MKCOL',
-      headers: validAdminAuthHeaders
+      headers: { authorization: getAuthHeaders(user, password) }
     })
   }
   return results
@@ -51,14 +52,15 @@ const createFolderRecrusive = function (user, folderName) {
  * Create a file using webDAV api.
  *
  * @param {string} user
+ * @param {string} password
  * @param {string} fileName
  * @param {string} contents
  * @returns {*} result of the fetch request
  */
-const createFile = function (user, fileName, contents = '') {
+const createFile = function (user, password, fileName, contents = '') {
   return fetch(createFullDavUrl(user, fileName), {
     method: 'PUT',
-    headers: validAdminAuthHeaders,
+    headers: { authorization: getAuthHeaders(user, password) },
     body: contents
   })
 }
@@ -67,13 +69,14 @@ const createFile = function (user, fileName, contents = '') {
  * Delete a file or folder using webDAV api.
  *
  * @param {string} user
+ * @param {string} password
  * @param {string} itemName
  * @returns {*} result of the fetch request
  */
-const deleteItem = function (user, itemName) {
+const deleteItem = function (user, password, itemName) {
   return fetch(createFullDavUrl(user, itemName), {
     method: 'DELETE',
-    headers: validAdminAuthHeaders
+    headers: { authorization: getAuthHeaders(user, password) }
   })
 }
 


### PR DESCRIPTION
In order to be able to test the interactions that create or delete folders this PR makes some general changes
- renaming authHeader variables to make it clear that those are admin auth
- new state to recreate (delete and create again) a user
- runs create/delete folder tests as `testUser`
- recreates the `testUser` in provider tests