### PR TITLE
revert hacks that were introduced because of char encoding bug in pact

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
     "@babel/runtime": "^7.4.4",
-    "@pact-foundation/pact": "10.0.0-beta.30",
+    "@pact-foundation/pact": "10.0.0-beta.31",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.0.5",
     "chai": "^4.2.0",

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -496,10 +496,8 @@ const updateFileInteraction = function (provider, file, user = config.adminUsern
       headers: {
         authorization: getAuthHeaders(user, password),
         'Content-Type': 'text/plain;charset=utf-8'
-      }
-      // TODO: uncomment this once the issue is fixed
-      // https://github.com/pact-foundation/pact-js/issues/589
-      // body: config.testContent
+      },
+      body: config.testContent
     }).willRespondWith(file.includes('nonExistent') ? {
       status: 404,
       headers: applicationXmlResponseHeaders,

--- a/tests/sharingTest.js
+++ b/tests/sharingTest.js
@@ -3,20 +3,6 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 describe('Main: Currently testing file/folder sharing,', function () {
   const config = require('./config/config.json')
 
-  // TODO: Remove these once the issue is fixed
-  // https://github.com/pact-foundation/pact-js/issues/589
-  config.testFiles = [
-    'test space and + and #.txt',
-    'test.txt',
-    'hello world.txt'
-  ]
-
-  config.testFilesPath = [
-    '%2Ftest+space+and+%2B+and+%23.txt',
-    '%2Ftest.txt',
-    '%2Fhello+world.txt'
-  ]
-
   const {
     applicationXmlResponseHeaders,
     applicationFormUrlEncoded,
@@ -46,10 +32,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
   const sharedFiles = {
     'test space and + and #.txt': 18,
     'test.txt': 14,
-    'hello world.txt': 19
-    // TODO: uncomment this once the issue is fixed
-    // https://github.com/pact-foundation/pact-js/issues/589
-    // '%2F%E6%96%87%E4%BB%B6.txt': 19
+    '文件.txt': 19
   }
   const testFolderShareID = 9
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1069,10 +1069,10 @@
     unzipper "^0.10.10"
     url-join "^4.0.0"
 
-"@pact-foundation/pact@10.0.0-beta.30":
-  version "10.0.0-beta.30"
-  resolved "https://registry.yarnpkg.com/@pact-foundation/pact/-/pact-10.0.0-beta.30.tgz#801cdb75d01bffd8cedf56f6fe0b8f3834977dfc"
-  integrity sha512-jwt7nw2RVT7BYL1T7zwStO/JF0ZiWHm3a8oiDLfbnzoi1+wkj8YVXH7sMzZ9g0ThfP05yw7+TPdZL6rkQnXBvA==
+"@pact-foundation/pact@10.0.0-beta.31":
+  version "10.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact/-/pact-10.0.0-beta.31.tgz#606d4b43782f48a88252cc436cbb9aef456e557a"
+  integrity sha512-aunhrqcNhAgKRF7GR4x0m5B7y0VqUmHPLNgzUWWRsMq1AhEEXohEylTozt8po6ksNaiGjiU56aOTMwfZoW0DDg==
   dependencies:
     "@pact-foundation/pact-node" "^10.10.1"
     "@types/bluebird" "^3.5.20"


### PR DESCRIPTION
- update pact-js to 10.0.0-beta.31
- remove hacks that were added because of char encoding bug in pact
  see https://github.com/pact-foundation/pact-js/issues/589
