### PR TITLE
[Tests-Only] Adjust pact interactions for provider tests for shareRecepient

### DIFF
--- a/src/shareManagement.js
+++ b/src/shareManagement.js
@@ -388,7 +388,7 @@ class Shares {
   }
 
   /**
-   * Deletes a share
+   * Get share Recipients
    * @param {string} search
    * @param {string} itemType
    * @param {number} page

--- a/tests/config/config.drone.json
+++ b/tests/config/config.drone.json
@@ -3,6 +3,7 @@
     "adminUsername": "admin",
     "adminPassword": "admin",
     "testUser": "test123",
+    "testUser2": "testABC",
     "testUserPassword": "test123",
     "testGroup": "testGroup",
     "nonExistentUser": "thisUserShouldNotExist",

--- a/tests/config/config.sample.json
+++ b/tests/config/config.sample.json
@@ -4,6 +4,7 @@
     "adminPassword": "admin",
     "testUser": "test123",
     "testUserPassword": "test123",
+    "testUser2": "testABC",
     "testGroup": "testGroup",
     "nonExistentUser": "thisUserShouldNotExist",
     "nonExistentGroup": "thisGroupShouldNotExist",

--- a/tests/shareRecipientTest.js
+++ b/tests/shareRecipientTest.js
@@ -4,14 +4,21 @@ describe('Main: Currently testing share recipient,', function () {
   var config = require('./config/config.json')
 
   const {
-    validAdminAuthHeaders,
+    getAuthHeaders,
     getCapabilitiesInteraction,
     getCurrentUserInformationInteraction,
     createOwncloud,
     createProvider
   } = require('./pactHelper.js')
 
-  const getShareesInteraction = (provider) => {
+  const sharer = config.testUser
+  const receiver = config.testUser2
+
+  const getShareesInteraction = (provider, folder = config.testFolder) => {
+    provider
+      .given('the user is recreated', { username: sharer })
+      .given('the user is recreated', { username: receiver })
+      .given('group exists', { groupName: config.testGroup })
     return provider
       .uponReceiving('a request to get share recipients (both users and groups)')
       .withRequest({
@@ -21,7 +28,7 @@ describe('Main: Currently testing share recipient,', function () {
           '/ocs/v2.php/apps/files_sharing/api/v1/sharees'
         ),
         query: { search: 'test', itemType: 'folder', page: '1', perPage: '200', format: 'json' },
-        headers: validAdminAuthHeaders
+        headers: { authorization: getAuthHeaders(sharer, sharer) }
       }).willRespondWith({
         status: 200,
         headers: {
@@ -29,10 +36,10 @@ describe('Main: Currently testing share recipient,', function () {
         },
         body: {
           ocs: {
-            meta: { status: 'ok', statusCode: 200, message: 'OK', totalitems: '', itemsperpage: '' },
+            meta: { status: 'ok', statuscode: 200, message: 'OK', totalitems: '', itemsperpage: '' },
             data: {
               exact: { users: [], groups: [], remotes: [] },
-              users: [{ label: config.testUser, value: { shareType: 0, shareWith: config.testUser } }],
+              users: [{ label: sharer, value: { shareType: 0, shareWith: sharer } }, { label: receiver, value: { shareType: 0, shareWith: receiver } }],
               groups: [{ label: config.testGroup, value: { shareType: 1, shareWith: config.testGroup } }],
               remotes: []
             }
@@ -45,7 +52,7 @@ describe('Main: Currently testing share recipient,', function () {
     const provider = createProvider()
 
     return provider.executeTest(() => {
-      const oc = createOwncloud()
+      const oc = createOwncloud(sharer, sharer)
 
       return oc.shares.getRecipients('test', 'folder', 'a', 'b').then(status => {
         fail('share.getRecipients should have thrown an error.')
@@ -59,7 +66,7 @@ describe('Main: Currently testing share recipient,', function () {
     const provider = createProvider()
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud()
+      const oc = createOwncloud(sharer, sharer)
 
       return oc.shares.getRecipients('test', 'folder', 2, 'b').then(status => {
         fail('share.getRecipients should have thrown an error.')
@@ -73,7 +80,7 @@ describe('Main: Currently testing share recipient,', function () {
     const provider = createProvider()
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud()
+      const oc = createOwncloud(sharer, sharer)
 
       return oc.shares.getRecipients('test', 'folder', -1, 'b').then(status => {
         fail('share.getRecipients should have thrown an error.')
@@ -85,17 +92,20 @@ describe('Main: Currently testing share recipient,', function () {
 
   it('testing behavior : searching for users and groups', async function () {
     const provider = createProvider()
-    await getCapabilitiesInteraction(provider)
-    await getCurrentUserInformationInteraction(provider)
+    await getCapabilitiesInteraction(provider, sharer, sharer)
+    await getCurrentUserInformationInteraction(provider, sharer, sharer)
     await getShareesInteraction(provider)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud()
+      const oc = createOwncloud(sharer, sharer)
       await oc.login()
 
       return oc.shares.getRecipients('test', 'folder', 1, 200).then(resp => {
         expect(resp.users[0]).toMatchObject({
-          label: config.testUser
+          label: sharer
+        })
+        expect(resp.users[1]).toMatchObject({
+          label: receiver
         })
         expect(resp.groups[0]).toMatchObject({
           label: config.testGroup


### PR DESCRIPTION
## Description:
In this PR, the share recipient test file is adjusted such that the tests pass on the provider side as well.

## Related Issue: 
- https://github.com/owncloud/owncloud-sdk/issues/709
- https://github.com/owncloud/core/issues/38397