### PR TITLE
modify files versions tests to pass with oC10 provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "sync-fetch": "^0.3.0",
     "webpack": "^4.30.0",
     "webpack-cli": "^3.3.2",
-    "webpack-node-externals": "^1.7.2"
+    "webpack-node-externals": "^1.7.2",
+    "xml2js": "^0.4.23"
   },
   "dependencies": {
     "axios": "^0.19.2",

--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -74,10 +74,10 @@ describe('Main: Currently testing file versions management,', function () {
     })
   }
 
-  const fileVersionPath = version => MatchersV3.regex({
-    matcher: `.*\\/remote\\.php\\/dav\\/meta\\/${fileInfo.id}\\/v\\/${fileInfo.versions[version].versionId}$`,
-    generate: `/remote.php/dav/meta/${fileInfo.id}/v/${fileInfo.versions[version].versionId}`
-  })
+  const fileVersionPath = version => MatchersV3.regex(
+   `.*\\/remote\\.php\\/dav\\/meta\\/${fileInfo.id}\\/v\\/${fileInfo.versions[version].versionId}$`,
+   `/remote.php/dav/meta/${fileInfo.id}/v/${fileInfo.versions[version].versionId}`
+  )
 
   describe.skip('file versions of non existing file', () => {
     it('retrieves file versions of not existing file', async function () {

--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -7,8 +7,6 @@ describe('Main: Currently testing file versions management,', function () {
 
   const {
     validAdminAuthHeaders,
-    accessControlAllowHeaders,
-    accessControlAllowMethods,
     applicationXmlResponseHeaders,
     getCurrentUserInformationInteraction,
     getCapabilitiesInteraction,
@@ -42,12 +40,6 @@ describe('Main: Currently testing file versions management,', function () {
       dPropfind.setAttributes({ 'xmlns:d': 'DAV:', 'xmlns:oc': 'http://owncloud.org/ns' })
       dPropfind.appendElement('d:prop', '', '')
     })
-  }
-
-  const header = {
-    ...applicationXmlResponseHeaders,
-    'Access-Control-Allow-Headers': accessControlAllowHeaders,
-    'Access-Control-Allow-Methods': accessControlAllowMethods
   }
 
   const propfindFileVersionsResponse = (node, version, contentLength) => {
@@ -115,7 +107,7 @@ describe('Main: Currently testing file versions management,', function () {
         .withRequest(propfindFileVersionsRequestData)
         .willRespondWith({
           status: 207,
-          headers: header,
+          headers: applicationXmlResponseHeaders,
           body: new XmlBuilder('1.0', '', 'd:multistatus').build(dMultistatus => {
             dMultistatus.setAttributes({
               'xmlns:d': 'DAV:',
@@ -150,7 +142,6 @@ describe('Main: Currently testing file versions management,', function () {
           })
           .willRespondWith({
             status: 200,
-            headers: header,
             body: fileInfo.versions[i].content
           })
       }
@@ -166,7 +157,7 @@ describe('Main: Currently testing file versions management,', function () {
         })
         .willRespondWith({
           status: 204,
-          headers: header
+          headers: applicationXmlResponseHeaders
         })
     }
 

--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -10,7 +10,6 @@ describe('Main: Currently testing file versions management,', function () {
     accessControlAllowHeaders,
     accessControlAllowMethods,
     applicationXmlResponseHeaders,
-    getContentsOfFileInteraction,
     getCurrentUserInformationInteraction,
     getCapabilitiesInteraction,
     createOwncloud,
@@ -201,32 +200,19 @@ describe('Main: Currently testing file versions management,', function () {
       })
     })
 
-    it.skip('restore file version', async function (done) {
+    it('restore file version', async function () {
       const provider = createProvider()
       await getCapabilitiesInteraction(provider)
       await getCurrentUserInformationInteraction(provider)
-      await provider.addInteraction(getContentsOfFileInteraction(versionedFile))
-      await PropfindFileVersionOfExistentFiles(provider)
-      await getFileVersionContents(provider)
       await restoreFileVersion(provider)
 
       return provider.executeTest(async () => {
         const oc = createOwncloud()
         await oc.login()
-        return oc.fileVersions.listVersions(fileInfo.id).then(versions => {
-          expect(versions.length).toEqual(2)
-          expect(versions[0].getSize()).toEqual(2)
-          expect(versions[1].getSize()).toEqual(1)
-          oc.fileVersions.restoreFileVersion(fileInfo.id, fileInfo.versions[0].versionId, versionedFile).then(status => {
-            expect(status).toBe(true)
-            oc.files.getFileContents(versionedFile).then(content => {
-              expect(content).toBe(fileInfo.versions[0].content)
-              done()
-            })
-          }).catch(reason => {
-            fail(reason)
-            done()
-          })
+        return oc.fileVersions.restoreFileVersion(fileInfo.id, fileInfo.versions[0].versionId, versionedFile).then(status => {
+          expect(status).toBe(true)
+        }).catch(reason => {
+          fail(reason)
         })
       })
     })

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -13,8 +13,7 @@ describe('provider testing', () => {
 
   const {
     createFolderRecrusive,
-    createFile,
-    deleteItem
+    createFile
   } = require('./webdavHelper.js')
 
   chai.use(chaiAsPromised)
@@ -103,20 +102,6 @@ describe('provider testing', () => {
           )
           chai.assert.isBelow(
             result.status, 300, `creating file '${parameters.fileName}' failed`
-          )
-        } else {
-          let itemToDelete
-          if (dirname !== '' && dirname !== '/') {
-            const folders = dirname.split(path.sep)
-            itemToDelete = folders[0]
-          } else {
-            itemToDelete = parameters.fileName
-          }
-          const result = deleteItem(
-            parameters.username, parameters.password, itemToDelete
-          )
-          chai.assert.strictEqual(
-            result.status, 204, `deleting '${itemToDelete}' failed`
           )
         }
         return Promise.resolve({ description: 'file created' })

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -6,6 +6,7 @@ describe('provider testing', () => {
   const chaiAsPromised = require('chai-as-promised')
   const path = require('path')
   const fetch = require('sync-fetch')
+  const { parseString } = require('xml2js')
 
   const {
     validAdminAuthHeaders
@@ -13,7 +14,9 @@ describe('provider testing', () => {
 
   const {
     createFolderRecrusive,
-    createFile
+    createFile,
+    getFileId,
+    listVersionsFolder
   } = require('./webdavHelper.js')
 
   chai.use(chaiAsPromised)
@@ -103,8 +106,8 @@ describe('provider testing', () => {
           chai.assert.isBelow(
             result.status, 300, `creating file '${parameters.fileName}' failed`
           )
+          return { fileId: result.headers.get('oc-fileid') }
         }
-        return Promise.resolve({ description: 'file created' })
       },
       'the user is recreated': (setup, parameters) => {
         if (setup) {
@@ -129,6 +132,26 @@ describe('provider testing', () => {
       },
       'provider base url is returned': () => {
         return { providerBaseURL: process.env.PROVIDER_BASE_URL }
+      },
+      'file version link is returned': (setup, parameters) => {
+        if (setup) {
+          const fileId = getFileId(parameters.username, parameters.password, parameters.fileName)
+          const versionsResult = listVersionsFolder(parameters.username, parameters.password, fileId)
+          let nodeValue = ''
+          parseString(versionsResult, function (err, result) {
+            if (
+              err ||
+              typeof result['d:multistatus']['d:response'][parameters.number]['d:href'][0] !== 'string'
+            ) {
+              throw new Error('could not parse PROPFIND response ' +
+                              `to list versions of '${parameters.fileName}' ${err}`)
+            }
+            nodeValue = result['d:multistatus']['d:response'][parameters.number]['d:href'][0]
+          })
+          // strip away any subfolder, pact will add it again if neededq
+          const link = nodeValue.replace(/^.*(\/remote\.php\/dav\/meta\/.*)$/, '$1')
+          return { versionLink: link }
+        }
       }
     }
     return new VerifierV3(opts).verifyProvider().then(output => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7515,7 +7515,7 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@^1.2.4:
+sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -8954,6 +8954,19 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
+xml2js@^0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
 xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
@@ -8973,6 +8986,11 @@ xmlhttprequest@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
   integrity sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=
+
+xpath@^0.0.32:
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/xpath/-/xpath-0.0.32.tgz#1b73d3351af736e17ec078d6da4b8175405c48af"
+  integrity sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
part of #709

- fix matcher to be correct V3Matcher function call
- delete unneeded checks
- delete access control headers
- don't delete created file after tests
- make fileVersions tests to work with oc10 provider
