### PR TITLE
run provider tests in ocis

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,0 +1,3 @@
+# The version of OCIS to use in pipelines that test against OCIS
+OCIS_COMMITID=d85650673886332f762686e654f007647274c7e2
+OCIS_BRANCH=master

--- a/.drone.star
+++ b/.drone.star
@@ -369,6 +369,11 @@ def consumerTestPipeline(subFolderPath = '/'):
     }
 
 def ocisProviderTestPipeline():
+    extraEnvironment = {
+        'NODE_TLS_REJECT_UNAUTHORIZED': 0,
+        'NODE_NO_WARNINGS': '1',
+        'RUN_ON_OCIS': 'true'
+    }
     return {
         'kind': 'pipeline',
         'name': 'testOCISProvider',
@@ -391,7 +396,7 @@ def ocisProviderTestPipeline():
             cloneOCIS() +
             buildOCIS() +
             ocisService() +
-            pactProviderTests('ocis-master', 'https://ocis:9200', {'NODE_TLS_REJECT_UNAUTHORIZED': 0, 'RUN_ON_OCIS': 'true'}),
+            pactProviderTests('ocis-master', 'https://ocis:9200', extraEnvironment),
          'services':
             redisService(),
          'volumes': [{

--- a/.drone.star
+++ b/.drone.star
@@ -11,7 +11,7 @@ config = {
 }
 
 def main(ctx):
-    return [ consumerTestPipeline(), consumerTestPipeline('/sub/'), providerTestPipeline(), publish() ]
+    return [ consumerTestPipeline(), consumerTestPipeline('/sub/'), oc10ProviderTestPipeline(),  ocisProviderTestPipeline(), publish() ]
 
 def incrementVersion():
     return [{
@@ -116,6 +116,86 @@ def setupServerAndApp(logLevel):
         ]
     }]
 
+def cloneOCIS():
+    return[{
+        'name': 'clone-ocis',
+        'image': 'webhippie/golang:1.15',
+        'pull': 'always',
+        'commands': [
+            'source .drone.env',
+            'mkdir -p /srv/app/src',
+            'cd $GOPATH/src',
+            'mkdir -p github.com/owncloud/',
+            'cd github.com/owncloud/',
+            'git clone -b $OCIS_BRANCH --single-branch --no-tags https://github.com/owncloud/ocis',
+        ],
+        'volumes': [{
+            'name': 'gopath',
+            'path': '/srv/app',
+        }, {
+            'name': 'configs',
+            'path': '/srv/config'
+        }],
+    }]
+
+def buildOCIS():
+    return[{
+        'name': 'build-ocis',
+        'image': 'webhippie/golang:1.15',
+        'pull': 'always',
+        'commands': [
+            'source .drone.env',
+            'cd $GOPATH/src/github.com/owncloud/ocis',
+            'git checkout $OCIS_COMMITID',
+            'cd ocis',
+            'make build',
+            'cp bin/ocis /var/www/owncloud'
+        ],
+        'volumes': [{
+            'name': 'gopath',
+            'path': '/srv/app',
+        }, {
+            'name': 'configs',
+            'path': '/srv/config'
+        }],
+    }]
+
+def ocisService():
+    return[{
+        'name': 'ocis',
+        'image': 'webhippie/golang:1.15',
+        'pull': 'always',
+        'detach': True,
+        'environment' : {
+            'OCIS_URL': 'https://ocis:9200',
+            'STORAGE_HOME_DRIVER': 'owncloud',
+            'STORAGE_USERS_DRIVER': 'owncloud',
+            'STORAGE_DRIVER_OCIS_ROOT': '/srv/app/tmp/ocis/storage/users',
+            'STORAGE_DRIVER_LOCAL_ROOT': '/srv/app/tmp/ocis/local/root',
+            'STORAGE_DRIVER_OWNCLOUD_DATADIR': '/srv/app/tmp/ocis/owncloud/data',
+            'STORAGE_METADATA_ROOT': '/srv/app/tmp/ocis/metadata',
+            'STORAGE_DRIVER_OWNCLOUD_REDIS_ADDR': 'redis:6379',
+            'PROXY_OIDC_INSECURE': 'true',
+            'STORAGE_HOME_DATA_SERVER_URL': 'http://ocis:9155/data',
+            'STORAGE_USERS_DATA_SERVER_URL': 'http://ocis:9158/data',
+            'ACCOUNTS_DATA_PATH': '/srv/app/tmp/ocis-accounts/',
+            'PROXY_ENABLE_BASIC_AUTH': True,
+        },
+        'commands': [
+            'cd /var/www/owncloud',
+            'mkdir -p /srv/app/tmp/ocis/owncloud/data/',
+            'mkdir -p /srv/app/tmp/ocis/storage/users/',
+            './ocis --log-level debug server'
+        ],
+        'volumes': [{
+            'name': 'gopath',
+            'path': '/srv/app',
+        }, {
+            'name': 'configs',
+            'path': '/srv/config'
+        }],
+    }]
+
 def fixPermissions():
     return [{
         'name': 'fix-permissions',
@@ -168,6 +248,17 @@ def databaseService():
         }
     }]
 
+
+def redisService():
+    return[{
+        'name': 'redis',
+        'image': 'webhippie/redis',
+        'pull': 'always',
+        'environment': {
+            'REDIS_DATABASES': 1
+        },
+    }]
+
 def pactConsumerTests(uploadPact):
     return [{
         'name': 'test',
@@ -186,18 +277,24 @@ def pactConsumerTests(uploadPact):
         ] if uploadPact else [])
     }]
 
-def pactProviderTests(version):
+def pactProviderTests(version, baseUrl, extraEnvironment = {}):
+    environment = {}
+    environment['PROVIDER_BASE_URL'] = baseUrl
+    environment['PACTFLOW_TOKEN'] = {
+        'from_secret': 'pactflow_token'
+    }
+    environment['PROVIDER_VERSION'] = version
+    environment['PROVIDER_BASE_URL'] = baseUrl
+
+
+    for env in extraEnvironment:
+        environment[env] = extraEnvironment[env]
+
     return [{
         'name': 'test',
         'image': 'owncloudci/nodejs:12',
         'pull': 'always',
-        'environment': {
-            'PROVIDER_BASE_URL': 'http://owncloud/',
-            'PACTFLOW_TOKEN': {
-                'from_secret': 'pactflow_token'
-            },
-            'PROVIDER_VERSION': version
-        },
+        'environment': environment,
         'commands': [
             'yarn test-provider'
         ]
@@ -271,10 +368,45 @@ def consumerTestPipeline(subFolderPath = '/'):
             pactConsumerTests(True if subFolderPath == '/' else False),
     }
 
-def providerTestPipeline():
+def ocisProviderTestPipeline():
     return {
         'kind': 'pipeline',
-        'name': 'testProvider',
+        'name': 'testOCISProvider',
+        'platform': {
+            'os': 'linux',
+            'arch': 'amd64'
+        },
+        'workspace': {
+            'base': '/var/www/owncloud',
+            'path': 'owncloud-sdk'
+        },
+        'trigger': {
+            'branch': 'master'
+        },
+        'depends_on': [ 'testConsumer-root', 'testConsumer-subfolder' ],
+        'steps':
+            buildSystem() +
+            pactLog() +
+            prepareTestConfig() +
+            cloneOCIS() +
+            buildOCIS() +
+            ocisService() +
+            pactProviderTests('ocis-master', 'https://ocis:9200', {'NODE_TLS_REJECT_UNAUTHORIZED': 0, 'RUN_ON_OCIS': 'true'}),
+         'services':
+            redisService(),
+         'volumes': [{
+            'name': 'configs',
+                'temp': {}
+            }, {
+                'name': 'gopath',
+                'temp': {}
+            }]
+    }
+
+def oc10ProviderTestPipeline():
+    return {
+        'kind': 'pipeline',
+        'name': 'testOc10Provider',
         'platform': {
             'os': 'linux',
             'arch': 'amd64'
@@ -295,12 +427,11 @@ def providerTestPipeline():
             owncloudLog() +
             setupServerAndApp('2') +
             fixPermissions()+
-            pactProviderTests('daily-master-qa'),
+            pactProviderTests('daily-master-qa', 'http://owncloud/'),
          'services':
             owncloudService() +
             databaseService()
     }
-
 
 def publish():
     return {
@@ -314,7 +445,7 @@ def publish():
             'base': '/var/www/owncloud',
             'path': 'owncloud-sdk'
         },
-        'depends_on': [ 'testConsumer-root', 'testConsumer-subfolder', 'testProvider' ],
+        'depends_on': [ 'testConsumer-root', 'testConsumer-subfolder', 'testOc10Provider', 'testOCISProvider' ],
         'trigger': {
             'branch': 'master'
         },

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -112,6 +112,7 @@ describe('provider testing', () => {
         }
       },
       'the user is recreated': (setup, parameters) => {
+        const email = `${parameters.username}@example.com`
         if (setup) {
           fetch(process.env.PROVIDER_BASE_URL + '/ocs/v2.php/cloud/users/' + parameters.username, {
             method: 'DELETE',
@@ -120,7 +121,7 @@ describe('provider testing', () => {
           const result = fetch(process.env.PROVIDER_BASE_URL + '/ocs/v2.php/cloud/users',
             {
               method: 'POST',
-              body: `userid=${parameters.username}&password=${parameters.password}`,
+              body: `userid=${parameters.username}&password=${parameters.password}&email=${email}`,
               headers: {
                 ...validAdminAuthHeaders,
                 ...applicationFormUrlEncoded

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -11,7 +11,8 @@ describe('provider testing', () => {
 
   const {
     validAdminAuthHeaders,
-    applicationFormUrlEncoded
+    applicationFormUrlEncoded,
+    getAuthHeaders
   } = require('./pactHelper.js')
 
   const {
@@ -130,6 +131,12 @@ describe('provider testing', () => {
           chai.assert.strictEqual(
             result.status, 200, `creating user '${parameters.username}' failed`
           )
+          // a hack for https://github.com/owncloud/ocis/issues/1675
+          fetch(process.env.PROVIDER_BASE_URL + '/ocs/v2.php/cloud/capabilities',
+            {
+              method: 'GET',
+              headers: { authorization: getAuthHeaders(parameters.username, parameters.password) }
+            })
           return Promise.resolve({ description: 'user created' })
         }
       },

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -164,7 +164,9 @@ describe('provider testing', () => {
         }
       },
       'user is made group subadmin': (setup, parameters) => {
-        if (setup) {
+        // don't try to make users subadmins on OCIS because of
+        // https://github.com/owncloud/product/issues/289
+        if (setup && process.env.RUN_ON_OCIS !== 'true') {
           const response = fetch(process.env.PROVIDER_BASE_URL +
                           '/ocs/v1.php/cloud/users/' + parameters.username +
                           '/subadmins?format=json', {


### PR DESCRIPTION
## Description:
- create a user with email address, as it is required in OCIS. 
- after recreating the user make an extra requests to have a workaround for  owncloud/ocis#1675
- on ocis skip the provider state that makes users subadmins of groups see https://github.com/owncloud/product/issues/289
- run the tests in drone and upload to pactflow

next step (in other PRs) will be to make as much test pass as possible and raise issues for the other ones