### PR TITLE
remove pact log step from drone

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -51,19 +51,6 @@ def buildSystem():
             ],
     }]
 
-def pactLog():
-    return [{
-            'name': 'pact logs',
-            'image': 'owncloudci/nodejs:12',
-            'pull': 'always',
-            'detach': True,
-            'commands': [
-                'mkdir -p /var/www/owncloud/owncloud-sdk/tests/log',
-                'touch /var/www/owncloud/owncloud-sdk/tests/log/pact.log',
-                'tail -f /var/www/owncloud/owncloud-sdk/tests/log/pact.log'
-            ],
-    }]
-
 def prepareTestConfig(subFolderPath = '/'):
     return [{
         'name': 'prepare-test-config',
@@ -363,7 +350,6 @@ def consumerTestPipeline(subFolderPath = '/'):
         },
         'steps':
             buildSystem() +
-            pactLog() +
             prepareTestConfig(subFolderPath) +
             pactConsumerTests(True if subFolderPath == '/' else False),
     }
@@ -391,7 +377,6 @@ def ocisProviderTestPipeline():
         'depends_on': [ 'testConsumer-root', 'testConsumer-subfolder' ],
         'steps':
             buildSystem() +
-            pactLog() +
             prepareTestConfig() +
             cloneOCIS() +
             buildOCIS() +
@@ -426,7 +411,6 @@ def oc10ProviderTestPipeline():
         'depends_on': [ 'testConsumer-root', 'testConsumer-subfolder' ],
         'steps':
             buildSystem() +
-            pactLog() +
             prepareTestConfig() +
             installCore('daily-master-qa') +
             owncloudLog() +


### PR DESCRIPTION
with the current V3 version of pact we don't write a logfile, so this step is not needed as pointed out by @dpakach in https://github.com/owncloud/owncloud-sdk/pull/740#discussion_r579090880
