### PR TITLE
use consumerVersionTags option instead of consumerVersionSelectors

### DIFF
--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -47,12 +47,7 @@ describe('provider testing', () => {
       opts.publishVerificationResult = true
       opts.pactBrokerToken = process.env.PACTFLOW_TOKEN
       opts.enablePending = true
-      opts.consumerVersionSelectors = [
-        {
-          tag: process.env.DRONE_SOURCE_BRANCH,
-          latest: true
-        }
-      ]
+      opts.consumerVersionTags = process.env.DRONE_SOURCE_BRANCH
       opts.providerVersion = process.env.PROVIDER_VERSION
     } else {
       opts.pactUrls = [path.resolve(process.cwd(), 'tests', 'pacts', 'owncloud-sdk-oc-server.json')]


### PR DESCRIPTION
pact-js 10.x (using pact V3) does not use (yet) `consumerVersionSelectors` but `consumerVersionTags` see https://github.com/pact-foundation/pact-js/blob/feat/v3.0.0/src/v3/verifier.ts
