### PR TITLE
[tests-only] Consistent interaction names

### DIFF
--- a/tests/appsTest.js
+++ b/tests/appsTest.js
@@ -2,6 +2,7 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 describe('Main: Currently testing apps management,', function () {
   const nonExistentApp = 'nonExistentApp123'
+  const { adminUsername: username } = require('./config/config.json')
 
   // PACT setup
   const {
@@ -31,7 +32,7 @@ describe('Main: Currently testing apps management,', function () {
       })
     }
     return provider
-      .uponReceiving(action + ' apps')
+      .uponReceiving(`as '${username}', a ${method} request to ${action} an app`)
       .withRequest({
         method,
         path: MatchersV3.regex(
@@ -49,7 +50,7 @@ describe('Main: Currently testing apps management,', function () {
 
   const getAppsInteraction = (provider, query) => {
     return provider
-      .uponReceiving('a GET request for a list of apps')
+      .uponReceiving(`as '${username}', a GET request to get all apps`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -151,7 +152,6 @@ describe('Main: Currently testing apps management,', function () {
       return oc.apps.enableApp(nonExistentApp).then(status => {
         expect(status).toBe(true)
       }).catch(error => {
-        console.log(error)
         expect(error).toEqual('No app found by the name "' + nonExistentApp + '"')
       })
     })

--- a/tests/capabilitiesTest.js
+++ b/tests/capabilitiesTest.js
@@ -2,6 +2,7 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 describe('Main: Currently testing getConfig, getVersion and getCapabilities', () => {
   let oc
+  const { adminUsername: username } = require('./config/config.json')
 
   const {
     createProvider,
@@ -17,7 +18,7 @@ describe('Main: Currently testing getConfig, getVersion and getCapabilities', ()
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)
     await provider
-      .uponReceiving('GET config request')
+      .uponReceiving(`as '${username}', a GET request to get server config`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(

--- a/tests/fileTrashTest.js
+++ b/tests/fileTrashTest.js
@@ -6,6 +6,7 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 describe('oc.fileTrash', function () {
   const config = require('./config/config.json')
+  const username = config.adminUsername
 
   const trashEnabled = true
 
@@ -165,7 +166,7 @@ describe('oc.fileTrash', function () {
       await getCapabilitiesInteraction(provider)
       await getCurrentUserInformationInteraction(provider)
       await provider
-        .uponReceiving('PROPFIND empty trash')
+        .uponReceiving(`as '${username}', a PROPFIND request to list empty trash`)
         .withRequest(requestMethod('PROPFIND', trashbinPath, validAdminAuthHeaders, emptyTrashbinXmlRequestBody))
         .willRespondWith({
           status: 207,
@@ -197,7 +198,7 @@ describe('oc.fileTrash', function () {
     describe('and folder is not restored', function () {
       const propfindForTrashbinWithItems = provider => {
         return provider
-          .uponReceiving('PROPFIND to trashbin with items')
+          .uponReceiving(`as '${username}', a PROPFIND request to list trashbin items`)
           .withRequest(requestMethod('PROPFIND', trashbinPath, validAdminAuthHeaders, emptyTrashbinXmlRequestBody))
           .willRespondWith(responseMethod(
             207,
@@ -207,7 +208,7 @@ describe('oc.fileTrash', function () {
       }
       const listItemWithinADeletedFolder = provider => {
         return provider
-          .uponReceiving('list item within a deleted folder')
+          .uponReceiving(`as '${username}', a PROPFIND request to list item within a deleted folder`)
           .withRequest(requestMethod('PROPFIND', trashbinFolderPath, validAdminAuthHeaders, emptyTrashbinXmlRequestBody))
           .willRespondWith({
             status: 207,
@@ -303,7 +304,7 @@ describe('oc.fileTrash', function () {
       const originalLocation = testFolder
       const moveFolderFromTrashbinToFilesList = provider => {
         return provider
-          .uponReceiving('MOVE folder from trashbin to fileslist to original location')
+          .uponReceiving(`as '${username}', a MOVE request to restore folder from trashbin to fileslist to original location`)
           .withRequest({
             method: 'MOVE',
             path: trashbinFolderPath,
@@ -319,7 +320,7 @@ describe('oc.fileTrash', function () {
 
       const propfindForTrashbinWithItems = provider => {
         return provider
-          .uponReceiving('PROPFIND to trashbin with items')
+          .uponReceiving(`as '${username}', a PROPFIND request to list trashbin items`)
           .withRequest(requestMethod('PROPFIND', trashbinPath, validAdminAuthHeaders, emptyTrashbinXmlRequestBody))
           .willRespondWith(responseMethod(
             207,
@@ -330,7 +331,7 @@ describe('oc.fileTrash', function () {
 
       const propfindToARestoredFolderInOriginalLocation = provider => {
         return provider
-          .uponReceiving('PROPFIND to a restored folder in original location')
+          .uponReceiving(`as '${username}', a PROPFIND request to a restored folder in original location`)
           .withRequest({
             method: 'PROPFIND',
             path: MatchersV3.regex(
@@ -400,7 +401,7 @@ describe('oc.fileTrash', function () {
 
       const MoveFromTrashbinToDifferentLocation = provider => {
         return provider
-          .uponReceiving('MOVE folder from trashbin to fileslist to a different location')
+          .uponReceiving(`as '${username}', a MOVE request to restore folder from trashbin to fileslist to a different location`)
           .withRequest({
             method: 'MOVE',
             path: trashbinFolderPath,
@@ -416,7 +417,7 @@ describe('oc.fileTrash', function () {
 
       const PropfindToAnEmptytrashbinAfterRestoring = provider => {
         return provider
-          .uponReceiving('PROPFIND to an empty trashbin after restoring')
+          .uponReceiving(`as '${username}', a PROPFIND request to an empty trashbin after restoring`)
           .withRequest(requestMethod('PROPFIND', trashbinPath, validAdminAuthHeaders, emptyTrashbinXmlRequestBody))
           .willRespondWith(responseMethod(
             207,
@@ -427,7 +428,7 @@ describe('oc.fileTrash', function () {
 
       const PropfindToARestoredFolderInNewLocation = provider => {
         return provider
-          .uponReceiving('PROPFIND to a restored folder in new location')
+          .uponReceiving(`as '${username}', a PROPFIND request to a restored folder in new location`)
           .withRequest({
             method: 'PROPFIND',
             path: MatchersV3.regex(
@@ -499,7 +500,7 @@ describe('oc.fileTrash', function () {
     describe('and file is not restored', function () {
       const propfindTrashItemsBeforeDeletingFile = provider => {
         return provider
-          .uponReceiving('PROPFIND trash items before deleting file')
+          .uponReceiving(`as '${username}', a PROPFIND request to trash items before deleting file`)
           .withRequest(requestMethod('PROPFIND', trashbinPath, validAdminAuthHeaders, emptyTrashbinXmlRequestBody))
           .willRespondWith({
             status: 207,
@@ -573,7 +574,7 @@ describe('oc.fileTrash', function () {
       const originalLocation = testFile
       const MoveFromTrashbinToDifferentLocation = provider => {
         return provider
-          .uponReceiving('MOVE file from trashbin to fileslist to a different location')
+          .uponReceiving(`as '${username}', a MOVE request to restore file from trashbin to fileslist to a different location`)
           .withRequest({
             method: 'MOVE',
             path: trashbinFolderPath,
@@ -589,14 +590,14 @@ describe('oc.fileTrash', function () {
 
       const propfindTrashItemsAfterRestoringDeletingFile = provider => {
         return provider
-          .uponReceiving('PROPFIND trash items after restoring deleting file')
+          .uponReceiving(`as '${username}', a PROPFIND request to trash items after restoring deleting file`)
           .withRequest(requestMethod('PROPFIND', trashbinPath, validAdminAuthHeaders, emptyTrashbinXmlRequestBody))
           .willRespondWith(responseMethod(207, responseHeader('application/xml; charset=utf-8'), trashbinXmlResponseBody()))
       }
 
       const propfindToARestoredFileInOriginalLocation = provider => {
         return provider
-          .uponReceiving('PROPFIND to a restored file in original location')
+          .uponReceiving(`as '${username}', a PROPFIND request to a restored file in original location`)
           .withRequest({
             method: 'PROPFIND',
             path: MatchersV3.regex(
@@ -666,7 +667,7 @@ describe('oc.fileTrash', function () {
 
       const MoveFromTrashbinToDifferentLocation = provider => {
         return provider
-          .uponReceiving('MOVE file from trashbin to a new location')
+          .uponReceiving(`as '${username}', a MOVE request to restore file from trashbin to a new location`)
           .withRequest({
             method: 'MOVE',
             path: trashbinFolderPath,
@@ -681,7 +682,7 @@ describe('oc.fileTrash', function () {
       }
       const propfindToARestoredFileInNewLocationEmpty = provider => {
         return provider
-          .uponReceiving('PROPFIND trash items after restoring deleting file to new location')
+          .uponReceiving(`as '${username}', a PROPFIND request to trash items after restoring deleting file to new location`)
           .withRequest({
             method: 'PROPFIND',
             path: trashbinPath,
@@ -697,7 +698,7 @@ describe('oc.fileTrash', function () {
 
       const propfindToARestoredFileInNewLocation = provider => {
         return provider
-          .uponReceiving('PROPFIND to a restored file in new location')
+          .uponReceiving(`as '${username}', a PROPFIND request to a restored file in new location`)
           .withRequest({
             method: 'PROPFIND',
             path: MatchersV3.regex(

--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -4,6 +4,7 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 describe('Main: Currently testing file versions management,', function () {
   const config = require('./config/config.json')
+  const username = config.adminUsername
 
   const {
     validAdminAuthHeaders,
@@ -78,7 +79,7 @@ describe('Main: Currently testing file versions management,', function () {
       await getCapabilitiesInteraction(provider)
       await getCurrentUserInformationInteraction(provider)
       await provider
-        .uponReceiving('PROPFIND file versions of non existent file')
+        .uponReceiving(`as '${username}', a PROPFIND request to get file versions of non existent file`)
         .withRequest(propfindFileVersionsRequestData)
         .willRespondWith({
           status: 404,
@@ -105,7 +106,7 @@ describe('Main: Currently testing file versions management,', function () {
   describe('file versions for existing files', () => {
     const PropfindFileVersionOfExistentFiles = provider => {
       return provider
-        .uponReceiving('PROPFIND file versions of existent file')
+        .uponReceiving(`as '${username}', a PROPFIND request to get file versions of existent file`)
         .withRequest(propfindFileVersionsRequestData)
         .willRespondWith({
           status: 207,
@@ -136,7 +137,7 @@ describe('Main: Currently testing file versions management,', function () {
     const getFileVersionContents = async provider => {
       for (let i = 0; i < fileInfo.versions.length; i++) {
         await provider
-          .uponReceiving('GET file version contents')
+          .uponReceiving(`as '${username}', a GET request to get file version contents`)
           .withRequest({
             method: 'GET',
             path: fileVersionPath(fileInfo.id, fileInfo.versions[i].versionId),
@@ -208,7 +209,7 @@ describe('Main: Currently testing file versions management,', function () {
         })
         .given('provider base url is returned')
       provider
-        .uponReceiving('Restore file versions')
+        .uponReceiving(`as '${username}', a COPY request to restore file versions`)
         .withRequest({
           method: 'COPY',
           path: MatchersV3.fromProviderState(

--- a/tests/groupTest.js
+++ b/tests/groupTest.js
@@ -2,6 +2,7 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 describe('Main: Currently testing group management,', function () {
   const config = require('./config/config.json')
+  const username = config.adminUsername
   let provider = null
 
   const {
@@ -17,7 +18,7 @@ describe('Main: Currently testing group management,', function () {
   async function getGroupsInteraction (provider) {
     await provider
       .given('group exists', { groupName: config.testGroup })
-      .uponReceiving('a GET groups request')
+      .uponReceiving(`as '${username}', a GET request to get all groups`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -53,7 +54,7 @@ describe('Main: Currently testing group management,', function () {
     }
 
     await provider
-      .uponReceiving('a DELETE request for group, ' + group)
+      .uponReceiving(`as '${username}', a DELETE request to delete a group '${group}'`)
       .withRequest({
         method: 'DELETE',
         path: MatchersV3.regex(
@@ -123,7 +124,7 @@ describe('Main: Currently testing group management,', function () {
 
   it('checking method : getGroupMembers', async function () {
     await provider
-      .uponReceiving('a request to GET members of the admin group')
+      .uponReceiving(`as '${username}', a GET request to get all members of admin group`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -175,7 +176,7 @@ describe('Main: Currently testing group management,', function () {
     const headers = { ...validAdminAuthHeaders, ...{ 'Content-Type': 'application/x-www-form-urlencoded' } }
     await provider
       .given('group does not exist', { groupName: config.testGroup })
-      .uponReceiving('a create group POST request')
+      .uponReceiving(`as '${username}', a POST request to create a group`)
       .withRequest({
         method: 'POST',
         path: MatchersV3.regex(

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -157,7 +157,7 @@ const getContentsOfFileInteraction = (
       })
   }
   return provider
-    .uponReceiving('GET contents of file ' + file)
+    .uponReceiving(`as '${user}', a GET request to get contents of a file '${file}'`)
     .withRequest({
       method: 'GET',
       path: webdavPath(file),
@@ -212,7 +212,7 @@ const deleteResourceInteraction = (
       status: 204
     }
   }
-  return provider.uponReceiving(`as '${user}' delete a ${type} called '${resource}'`)
+  return provider.uponReceiving(`as '${user}', a DELETE request to delete a ${type} '${resource}'`)
     .withRequest({
       method: 'DELETE',
       path: webdavPath(resource),
@@ -227,7 +227,7 @@ async function getCurrentUserInformationInteraction (
     provider.given('the user is recreated', { username: user, password: password })
   }
   await provider
-    .uponReceiving(`as '${user}' get current user information`)
+    .uponReceiving(`as '${user}', a GET to get current user information`)
     .withRequest({
       method: 'GET',
       path: MatchersV3.regex(
@@ -260,7 +260,7 @@ async function getCapabilitiesInteraction (
     provider.given('the user is recreated', { username: user, password: password })
   }
   await provider
-    .uponReceiving(`as '${user}' get capabilities with valid authentication`)
+    .uponReceiving(`as '${user}', a GET request to get capabilities with valid authentication`)
     .withRequest({
       method: 'GET',
       path: MatchersV3.regex(
@@ -315,7 +315,7 @@ async function getCapabilitiesInteraction (
 }
 
 const getUserInformationAsAdminInteraction = function (provider) {
-  return provider.uponReceiving('a single user GET request to the cloud users endpoint')
+  return provider.uponReceiving(`as '${config.adminUsername}', a GET request to user information`)
     .withRequest({
       method: 'GET',
       path: MatchersV3.regex(
@@ -346,7 +346,7 @@ const getUserInformationAsAdminInteraction = function (provider) {
 }
 
 const getCapabilitiesWithInvalidAuthInteraction = function (provider, username = config.adminUsername, password = config.invalidPassword) {
-  return provider.uponReceiving(`a capabilities GET request with invalid authentication by ${username} with ${password}`)
+  return provider.uponReceiving(`as '${username}', a GET request to get capabilities with invalid auth`)
     .withRequest({
       method: 'GET',
       path: MatchersV3.regex(
@@ -375,7 +375,7 @@ const getCapabilitiesWithInvalidAuthInteraction = function (provider, username =
 }
 
 const createUserInteraction = function (provider) {
-  provider.uponReceiving('a create user request')
+  provider.uponReceiving(`as '${config.adminUsername}', a POST request to create a user`)
     .withRequest({
       method: 'POST',
       path: MatchersV3.regex(
@@ -396,7 +396,7 @@ const createUserInteraction = function (provider) {
 const createUserWithGroupMembershipInteraction = function (provider) {
   return provider
     .given('group exists', { groupName: config.testGroup })
-    .uponReceiving('a create user request including group membership')
+    .uponReceiving(`as '${config.adminUsername}', a POST request to create a user with group membership`)
     .withRequest({
       method: 'POST',
       path: MatchersV3.regex(
@@ -422,7 +422,7 @@ const createUserWithGroupMembershipInteraction = function (provider) {
 }
 
 const deleteUserInteraction = function (provider) {
-  provider.uponReceiving('a request to delete a user')
+  provider.uponReceiving(`as '${config.adminUsername}', a DELETE request to delete a user`)
     .withRequest({
       method: 'DELETE',
       path: MatchersV3.regex(
@@ -465,7 +465,7 @@ const createFolderInteraction = function (
     })
   }
   return provider
-    .uponReceiving(`create the folder '${folderName}'`)
+    .uponReceiving(`as '${user}', a MKCOL request to create a folder '${folderName}'`)
     .withRequest({
       method: 'MKCOL',
       path: MatchersV3.regex(
@@ -494,7 +494,7 @@ const updateFileInteraction = function (provider, file, user = config.adminUsern
   }
 
   const etagMatcher = MatchersV3.regex(/^"[a-f0-9:.]{1,32}"$/, config.testFileEtag)
-  return provider.uponReceiving(`as '${user}' upload file to '${file}'`)
+  return provider.uponReceiving(`as '${user}', a PUT request to upload a file to '${file}'`)
     .withRequest({
       method: 'PUT',
       path: webdavPath(file),

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -33,7 +33,7 @@ describe('oc.publicFiles', function () {
 
   const publicShareInteraction = (provider, description, method, responseBody) => {
     return provider
-      .uponReceiving(description)
+      .uponReceiving(`as '${testUser}', a ${method} request to ${description}`)
       .withRequest({
         method: method,
         path: MatchersV3.regex(
@@ -63,7 +63,7 @@ describe('oc.publicFiles', function () {
         shareType: 3,
         permissions: 15
       })
-      .uponReceiving(description)
+      .uponReceiving(`as '${testUser}', a ${method} request to ${description}`)
       .withRequest({
         method: method,
         path: MatchersV3.fromProviderState(
@@ -93,7 +93,7 @@ describe('oc.publicFiles', function () {
         permissions: 15
       })
       .given('file exists in last shared public share', { fileName: testFile })
-      .uponReceiving(description)
+      .uponReceiving(`as '${testUser}', a ${method} request to ${description}`)
       .withRequest({
         method: method,
         path: MatchersV3.fromProviderState(
@@ -192,7 +192,7 @@ describe('oc.publicFiles', function () {
           )
           if (data.shallGrantAccess) {
             await provider
-              .uponReceiving('list content of a public link folder')
+              .uponReceiving(`as '${testUser}', a PROPFIND request to list contents of a public link folder`)
               .withRequest({
                 method: 'PROPFIND',
                 path: publicLinkShareTokenPath
@@ -204,7 +204,7 @@ describe('oc.publicFiles', function () {
               })
           } else {
             await provider
-              .uponReceiving('list content of a password protected public link folder using the wrong password')
+              .uponReceiving(`as '${testUser}', a PROPFIND request to list contents of a password protected public link folder using the wrong password`)
               .withRequest({
                 method: 'PROPFIND',
                 path: publicLinkShareTokenPath,
@@ -269,7 +269,7 @@ describe('oc.publicFiles', function () {
           const provider = createProvider()
           if (data.shallGrantAccess) {
             await provider
-              .uponReceiving('download files from a public shared folder')
+              .uponReceiving(`as '${testUser}', a GET request to download files from a public shared folder`)
               .withRequest({
                 method: 'GET',
                 path: publicLinkShareTokenPath
@@ -284,7 +284,7 @@ describe('oc.publicFiles', function () {
               })
           } else {
             await provider
-              .uponReceiving('download files from a public shared folder using wrong password')
+              .uponReceiving(`as '${testUser}', a GET request to download files from a public shared folder using wrong password`)
               .withRequest({
                 method: 'GET',
                 path: publicLinkShareTokenPath
@@ -469,7 +469,7 @@ describe('oc.publicFiles', function () {
             .given('folder exists', { username: testUser, password: testUserPassword, folderName: testFolder })
             .given('resource is shared', { username: testUser, password: testUserPassword, resource: testFolder, shareType: 3, permissions: 15 })
             .given('file exists in last shared public share', { fileName: testFile })
-            .uponReceiving('Move a file' + ' ' + data.description)
+            .uponReceiving(`as '${testUser}', a MOVE request to move a file in public share ${data.description}`)
             .withRequest({
               method: 'MOVE',
               path: MatchersV3.fromProviderState(
@@ -508,7 +508,7 @@ describe('oc.publicFiles', function () {
             .given('resource is shared', { username: testUser, password: testUserPassword, resource: testFolder, shareType: 3, permissions: 15 })
             .given('folder exists in last shared public share', { folderName: 'foo' })
             .given('file exists in last shared public share', { fileName: testFile })
-            .uponReceiving('Move a file to subfolder' + ' ' + data.description)
+            .uponReceiving(`as '${testUser}', a MOVE request to move a file to subfolder in public share ${data.description}`)
             .withRequest({
               method: 'MOVE',
               path: MatchersV3.fromProviderState(
@@ -542,7 +542,7 @@ describe('oc.publicFiles', function () {
             .given('folder exists', { username: testUser, password: testUserPassword, folderName: testFolder })
             .given('resource is shared', { username: testUser, password: testUserPassword, resource: testFolder, shareType: 3, permissions: 15 })
             .given('folder exists in last shared public share', { folderName: 'foo' })
-            .uponReceiving('Move a folder to different name' + ' ' + data.description)
+            .uponReceiving(`as '${testUser}', a MOVE request to move a folder to different name in public share ${data.description}`)
             .withRequest({
               method: 'MOVE',
               path: MatchersV3.fromProviderState(
@@ -575,7 +575,7 @@ describe('oc.publicFiles', function () {
           await getCapabilitiesInteraction(provider)
           await getCurrentUserInformationInteraction(provider)
           await provider
-            .uponReceiving('Get file info of public share' + ' ' + data.description)
+            .uponReceiving(`as '${testUser}', a PROPFIND request to get file info of public share ${data.description}`)
             .withRequest({
               method: 'PROPFIND',
               path: publicLinkShareTokenPath,

--- a/tests/requestsOcsTest.js
+++ b/tests/requestsOcsTest.js
@@ -2,6 +2,7 @@ import { MatchersV3 } from '@pact-foundation/pact/v3'
 
 describe('Main: Currently testing low level OCS', function () {
   const config = require('./config/config.json')
+  const username = config.adminUsername
 
   const {
     getCapabilitiesInteraction,
@@ -48,7 +49,7 @@ describe('Main: Currently testing low level OCS', function () {
     await getCurrentUserInformationInteraction(provider)
 
     await provider
-      .uponReceiving('an update request for an unknown user')
+      .uponReceiving(`as '${username}', a PUT request to update an unknown user using OCS`)
       .withRequest({
         method: 'PUT',
         path: MatchersV3.regex(
@@ -95,7 +96,7 @@ describe('Main: Currently testing low level OCS', function () {
     await getCurrentUserInformationInteraction(provider)
     await provider
       .given('the user is recreated', { username: testUser, password: testUserPassword })
-      .uponReceiving('an update user request that sets email')
+      .uponReceiving(`as '${username}', a PUT request to update a user using OCS`)
       .withRequest({
         method: 'PUT',
         path: MatchersV3.regex(

--- a/tests/shareRecipientTest.js
+++ b/tests/shareRecipientTest.js
@@ -22,7 +22,7 @@ describe('Main: Currently testing share recipient,', function () {
       .given('the user is recreated', { username: receiver, password: receiverPassword })
       .given('group exists', { groupName: config.testGroup })
     return provider
-      .uponReceiving('a request to get share recipients (both users and groups)')
+      .uponReceiving(`as '${sharer}', a GET request to get share recipients (both users and groups)`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(

--- a/tests/sharingTest.js
+++ b/tests/sharingTest.js
@@ -2,6 +2,7 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 describe('Main: Currently testing file/folder sharing,', function () {
   const config = require('./config/config.json')
+  const username = config.adminUsername
 
   const {
     applicationXmlResponseHeaders,
@@ -42,11 +43,11 @@ describe('Main: Currently testing file/folder sharing,', function () {
   const OCS_PERMISSION_CREATE = 4
   const OCS_PERMISSION_SHARE = 16
 
-  const getSharesInteraction = function (provider, name, shareType, file) {
+  const getSharesInteraction = function (provider, requestName, shareType, file) {
     const iteration = testFiles.indexOf(file)
     const fileId = config.testFilesId[iteration]
     const fileToken = config.testFilesToken[iteration]
-    return provider.uponReceiving('a GET request for a ' + name + file)
+    return provider.uponReceiving(`as '${username}', a GET request to ${requestName}`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -76,7 +77,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
       })
   }
 
-  const getPublicLinkShareInteraction = function (provider, name, permissions, additionalBodyElem) {
+  const getPublicLinkShareInteraction = function (provider, requestName, permissions, additionalBodyElem) {
     const body = new XmlBuilder('1.0', '', 'ocs').build(ocs => {
       ocs.appendElement('meta', '', (meta) => {
         ocsMeta(meta, 'ok', '100')
@@ -92,7 +93,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
         })
       })
     })
-    return provider.uponReceiving('a GET request for a public link share' + name)
+    return provider.uponReceiving(`as '${username}', a GET request to ${requestName}`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -113,7 +114,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
 
   const getShareInteraction = (provider, fileid) => {
     return provider
-      .uponReceiving('a GET request for an existent share with id ' + fileid)
+      .uponReceiving(`as '${username}', a GET request to get single existing share of id '${fileid}'`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -144,7 +145,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
         const provider = createProvider()
         await getCapabilitiesInteraction(provider)
         await getCurrentUserInformationInteraction(provider)
-        await getPublicLinkShareInteraction(provider, 'to confirm the permissions is not changed', 1, '')
+        await getPublicLinkShareInteraction(provider, 'confirm the permissions is not changed', 1, '')
 
         return provider.executeTest(async () => {
           const oc = createOwncloud()
@@ -165,7 +166,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
         const provider = createProvider()
         await getCapabilitiesInteraction(provider)
         await getCurrentUserInformationInteraction(provider)
-        await getPublicLinkShareInteraction(provider, 'after making publicupload true', 15, '')
+        await getPublicLinkShareInteraction(provider, 'check publicupload after update', 15, '')
 
         return provider.executeTest(async () => {
           const oc = createOwncloud()
@@ -190,7 +191,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
         const provider = createProvider()
         await getCapabilitiesInteraction(provider)
         await getCurrentUserInformationInteraction(provider)
-        await getPublicLinkShareInteraction(provider, 'after password is added', 1, additionalBodyElement)
+        await getPublicLinkShareInteraction(provider, 'check password is added to share', 1, additionalBodyElement)
 
         return provider.executeTest(async () => {
           const oc = createOwncloud()
@@ -214,7 +215,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           await getCapabilitiesInteraction(provider)
           await getCurrentUserInformationInteraction(provider)
           for (let i = 0; i < testFiles.length; i++) {
-            await getSharesInteraction(provider, 'public link share for isShared', 3, testFiles[i])
+            await getSharesInteraction(provider, `check whether '${testFiles[i]}' is shared or not (public link share)`, 3, testFiles[i])
           }
 
           await provider.executeTest(async () => {
@@ -241,7 +242,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           await getCapabilitiesInteraction(provider)
           await getCurrentUserInformationInteraction(provider)
           for (let i = 0; i < testFiles.length; i++) {
-            await getSharesInteraction(provider, 'public link share for getShares', 3, testFiles[i])
+            await getSharesInteraction(provider, `get shares of '${testFiles[i]}' (public link share)`, 3, testFiles[i])
           }
           return provider.executeTest(async () => {
             const oc = createOwncloud()
@@ -295,7 +296,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           const provider = createProvider()
           await getCapabilitiesInteraction(provider)
           await getCurrentUserInformationInteraction(provider)
-          await getPublicLinkShareInteraction(provider, 'after confirming updated permission', maxPerms, '')
+          await getPublicLinkShareInteraction(provider, 'check updated permissions in user share', maxPerms, '')
           return provider.executeTest(async () => {
             const oc = createOwncloud()
             await oc.login()
@@ -316,7 +317,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           await getCapabilitiesInteraction(provider)
           await getCurrentUserInformationInteraction(provider)
           for (const file of testFiles) {
-            await getSharesInteraction(provider, 'user share ', 0, file)
+            await getSharesInteraction(provider, `check whether '${file}' is shared or not (user share)`, 0, file)
           }
           return provider.executeTest(async () => {
             const oc = createOwncloud()
@@ -336,7 +337,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           await getCapabilitiesInteraction(provider)
           await getCurrentUserInformationInteraction(provider)
 
-          await getPublicLinkShareInteraction(provider, 'to confirm the share', OCS_PERMISSION_READ, '')
+          await getPublicLinkShareInteraction(provider, 'confirm the share', OCS_PERMISSION_READ, '')
           return provider.executeTest(async () => {
             const oc = createOwncloud()
             await oc.login()
@@ -361,7 +362,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           await getCapabilitiesInteraction(provider)
           await getCurrentUserInformationInteraction(provider)
           for (let i = 0; i < testFiles.length; i++) {
-            await getSharesInteraction(provider, 'public link share: getShares for shared file', 3, testFiles[i])
+            await getSharesInteraction(provider, `get shares of '${testFiles[i]}' (user share)`, 0, testFiles[i])
           }
           return provider.executeTest(async () => {
             const oc = createOwncloud()
@@ -392,7 +393,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
         await getCapabilitiesInteraction(provider)
         await getCurrentUserInformationInteraction(provider)
         for (const file of config.testFiles) {
-          await getSharesInteraction(provider, 'group share ', 1, file)
+          await getSharesInteraction(provider, `check whether '${file}' is shared or not (group share)`, 1, file)
         }
         return provider.executeTest(async () => {
           const oc = createOwncloud()
@@ -439,7 +440,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
         await getCapabilitiesInteraction(provider)
         await getCurrentUserInformationInteraction(provider)
         for (let i = 0; i < testFiles.length; i++) {
-          await getSharesInteraction(provider, 'public link share: getShares shared file', 3, testFiles[i])
+          await getSharesInteraction(provider, `get shares of '${testFiles[i]}' (group share)`, 1, testFiles[i])
         }
 
         return provider.executeTest(async () => {
@@ -466,7 +467,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
 
     describe('checking method: ', function () {
       function linkSharePOSTNonExistentFile (provider) {
-        return provider.uponReceiving('a link share POST request with a non-existent file')
+        return provider.uponReceiving(`as '${username}', a POST request to create a public link share with non-existent file`)
           .withRequest({
             method: 'POST',
             path: MatchersV3.regex(
@@ -494,7 +495,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           })
       }
       function groupSharePOSTNonExistentFile (provider) {
-        return provider.uponReceiving('a group share POST request with valid auth but non-existent file')
+        return provider.uponReceiving(`as '${username}', a POST request to share non-existent file with existing group`)
           .withRequest({
             method: 'POST',
             path: MatchersV3.regex(
@@ -517,7 +518,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           })
       }
       function shareGETNonExistentFile (provider, name = '') {
-        return provider.uponReceiving('a GET request for a share with non-existent file ' + name)
+        return provider.uponReceiving(`as '${username}', a GET request to get share information of non-existent file '${name}'`)
           .withRequest({
             method: 'GET',
             path: MatchersV3.regex(
@@ -542,7 +543,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           })
       }
       function shareGETExistingNonSharedFile (provider, name) {
-        return provider.uponReceiving('a GET request for an existent but non-shared file ' + name)
+        return provider.uponReceiving(`as '${username}', a GET request to get share information of existent but non-shared file '${name}'`)
           .withRequest({
             method: 'GET',
             path: MatchersV3.regex(
@@ -568,7 +569,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           })
       }
       function shareGetNonExistentShare (provider) {
-        return provider.uponReceiving('a GET request for a non-existent share')
+        return provider.uponReceiving(`as '${username}', a GET request to get non-existent share`)
           .withRequest({
             method: 'GET',
             path: MatchersV3.regex(
@@ -588,7 +589,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           })
       }
       function putFileWithExmptyContent (provider) {
-        return provider.uponReceiving('Put file contents as empty content in files specified')
+        return provider.uponReceiving(`as '${username}', a PUT request to put file contents as empty content in files specified`)
           .withRequest({
             method: 'PUT',
             path: MatchersV3.regex(
@@ -606,7 +607,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
       }
 
       function sharePOSTRequestWithExpirationDateSet (provider, file) {
-        return provider.uponReceiving('a user share POST request with valid auth and expiration date set to path ' + file)
+        return provider.uponReceiving(`as '${username}', a POST request to share a file '${file}' to user with expiration date set`)
           .withRequest({
             method: 'POST',
             path: MatchersV3.regex(
@@ -635,7 +636,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
 
       function updateDeleteShareNonExistent (provider, method) {
         return provider
-          .uponReceiving('a ' + method + ' request to update/delete a non-existent share')
+          .uponReceiving(`as '${username}', a ${method} request to update/delete a non-existent share`)
           .withRequest({
             method,
             path: MatchersV3.regex(

--- a/tests/sharingWithAttributesTest.js
+++ b/tests/sharingWithAttributesTest.js
@@ -2,6 +2,7 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 describe('oc.shares', function () {
   const config = require('./config/config.json')
+  const username = config.adminUsername
 
   const {
     validAdminAuthHeaders,
@@ -38,7 +39,7 @@ describe('oc.shares', function () {
 
   const sharingWithAttributes = (provider) => {
     return provider
-      .uponReceiving('Share with permissions in attributes')
+      .uponReceiving(`as '${username}', a POST request to share a file with permissions in attributes`)
       .withRequest({
         method: 'POST',
         path: MatchersV3.regex(

--- a/tests/signedUrlIntegrationTest.js
+++ b/tests/signedUrlIntegrationTest.js
@@ -2,6 +2,7 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 describe('Signed urls', function () {
   var config = require('./config/config.json')
+  const username = config.adminUsername
 
   const fetch = require('node-fetch')
   const {
@@ -18,7 +19,7 @@ describe('Signed urls', function () {
 
   const getSigningKeyInteraction = (provider) => {
     return provider
-      .uponReceiving('a GET request for a signing key')
+      .uponReceiving(`as '${username}', a GET request to get a signing key`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -48,7 +49,7 @@ describe('Signed urls', function () {
 
   const downloadWithSignedURLInteraction = (provider) => {
     return provider
-      .uponReceiving('a GET request for a file download using signed url')
+      .uponReceiving(`as '${username}', a GET request to download a file using signed url`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(

--- a/tests/unauthorized/appsTest.js
+++ b/tests/unauthorized/appsTest.js
@@ -2,6 +2,7 @@ import { MatchersV3 } from '@pact-foundation/pact/v3'
 
 describe('Unauthorized: Currently testing apps management,', function () {
   const config = require('../config/config.json')
+  const username = config.adminUsername
 
   const {
     unauthorizedXmlResponseBody,
@@ -24,7 +25,7 @@ describe('Unauthorized: Currently testing apps management,', function () {
 
   const getAppsInvalidAuthInteraction = async (provider, query) => {
     return provider
-      .uponReceiving('an GET app request with invalid auth')
+      .uponReceiving(`as '${username}', a GET request to get all apps with invalid auth`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -37,9 +38,9 @@ describe('Unauthorized: Currently testing apps management,', function () {
       .willRespondWith(unauthorizedResponseObject)
   }
 
-  const appRequestInvalidAuthInteraction = async (provider, method, app) => {
+  const appRequestInvalidAuthInteraction = async (provider, requestName, method, app) => {
     return provider
-      .uponReceiving(`an ${method} app request with invalid auth`)
+      .uponReceiving(`as '${username}', a ${method} request to ${requestName} with invalid auth`)
       .withRequest({
         method: method,
         path: MatchersV3.regex(
@@ -76,7 +77,7 @@ describe('Unauthorized: Currently testing apps management,', function () {
   it('checking method : enableApp when app exists', async function () {
     const provider = createProvider()
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await appRequestInvalidAuthInteraction(provider, 'POST', 'files')
+    await appRequestInvalidAuthInteraction(provider, 'enable app', 'POST', 'files')
 
     await provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -97,7 +98,7 @@ describe('Unauthorized: Currently testing apps management,', function () {
   it('checking method : disableApp', async function (done) {
     const provider = createProvider()
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await appRequestInvalidAuthInteraction(provider, 'DELETE', 'files')
+    await appRequestInvalidAuthInteraction(provider, 'disable app', 'DELETE', 'files')
 
     await provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)

--- a/tests/unauthorized/filesTest.js
+++ b/tests/unauthorized/filesTest.js
@@ -4,6 +4,7 @@ import { MatchersV3 } from '@pact-foundation/pact/v3'
 
 describe('Unauthorized: Currently testing files management,', function () {
   const config = require('../config/config.json')
+  const username = config.adminUsername
   var timeRightNow = new Date().getTime()
 
   // PACT setup
@@ -37,9 +38,9 @@ describe('Unauthorized: Currently testing files management,', function () {
     `/remote.php/webdav/${config.testFolder}`
   )
 
-  const unauthorizedWebDavInteraction = (provider, method) => {
+  const unauthorizedWebDavInteraction = (provider, requestName, method) => {
     return provider
-      .uponReceiving(`a ${method} request on file contents with invalid authentication`)
+      .uponReceiving(`as '${username}', a ${method} request to ${requestName} with invalid auth`)
       .withRequest({
         method: method,
         path: webdavUrl,
@@ -59,7 +60,7 @@ describe('Unauthorized: Currently testing files management,', function () {
 
   it.skip('checking method : list', async function () {
     const provider = createProvider()
-    await unauthorizedWebDavInteraction(provider, 'PROPFIND')
+    await unauthorizedWebDavInteraction(provider, 'list folder contents', 'PROPFIND')
     await getCapabilitiesWithInvalidAuthInteraction(provider)
 
     return provider.executeTest(async () => {
@@ -80,7 +81,7 @@ describe('Unauthorized: Currently testing files management,', function () {
   it.skip('checking method : getFileContents', async function () {
     const provider = createProvider()
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await unauthorizedWebDavInteraction(provider, 'GET')
+    await unauthorizedWebDavInteraction(provider, 'get file contents', 'GET')
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -94,7 +95,6 @@ describe('Unauthorized: Currently testing files management,', function () {
         await oc.files.getFileContents(testSubFiles[i]).then(() => {
           fail()
         }).catch(error => {
-          console.log(error)
           expect(error).toMatch(expectedUnAuthorizedMessage)
         })
       }
@@ -105,7 +105,7 @@ describe('Unauthorized: Currently testing files management,', function () {
     const newFile = config.testFolder + '/' + 'file.txt'
     const provider = createProvider()
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await unauthorizedWebDavInteraction(provider, 'PUT')
+    await unauthorizedWebDavInteraction(provider, 'update file contents', 'PUT')
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.adminPassword + timeRightNow)
@@ -126,7 +126,7 @@ describe('Unauthorized: Currently testing files management,', function () {
     const newFolder = config.testFolder + '/' + 'new folder/'
     const provider = createProvider()
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await unauthorizedWebDavInteraction(provider, 'MKCOL')
+    await unauthorizedWebDavInteraction(provider, 'create a directory', 'MKCOL')
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.adminPassword + timeRightNow)
@@ -147,7 +147,7 @@ describe('Unauthorized: Currently testing files management,', function () {
     const newFolder = config.testFolder + '/' + 'new folder'
     const provider = createProvider()
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await unauthorizedWebDavInteraction(provider, 'DELETE')
+    await unauthorizedWebDavInteraction(provider, 'delete a folder', 'DELETE')
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.adminPassword + timeRightNow)
@@ -168,7 +168,7 @@ describe('Unauthorized: Currently testing files management,', function () {
     const file = 'tempFile'
     const provider = createProvider()
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await unauthorizedWebDavInteraction(provider, 'PUT')
+    await unauthorizedWebDavInteraction(provider, 'get a file', 'PUT')
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.adminPassword + timeRightNow)
@@ -188,7 +188,7 @@ describe('Unauthorized: Currently testing files management,', function () {
   it.skip('checking method : move', async function () {
     const provider = createProvider()
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await unauthorizedWebDavInteraction(provider, 'MOVE')
+    await unauthorizedWebDavInteraction(provider, 'move a file', 'MOVE')
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.adminPassword + timeRightNow)
@@ -208,7 +208,7 @@ describe('Unauthorized: Currently testing files management,', function () {
   it.skip('checking method : copy', async function () {
     const provider = createProvider()
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await unauthorizedWebDavInteraction(provider, 'COPY')
+    await unauthorizedWebDavInteraction(provider, 'copy a file', 'COPY')
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.adminPassword + timeRightNow)

--- a/tests/unauthorized/groupTest.js
+++ b/tests/unauthorized/groupTest.js
@@ -2,6 +2,7 @@ import { MatchersV3 } from '@pact-foundation/pact/v3'
 
 describe('Unauthorized: Currently testing group management,', function () {
   const config = require('../config/config.json')
+  const username = config.adminUsername
 
   const {
     unauthorizedXmlResponseBody,
@@ -22,9 +23,9 @@ describe('Unauthorized: Currently testing group management,', function () {
     authorization: invalidAuthHeader
   }
 
-  const groupsInteraction = (provider, method) => {
+  const groupsInteraction = (provider, requestName, method) => {
     return provider
-      .uponReceiving(`a ${method} group(s) request with invalid auth`)
+      .uponReceiving(`as '${username}', a ${method} request to ${requestName} with invalid auth`)
       .withRequest({
         method: method,
         path: MatchersV3.regex(
@@ -38,7 +39,7 @@ describe('Unauthorized: Currently testing group management,', function () {
 
   const deleteGroupInteraction = (provider) => {
     return provider
-      .uponReceiving('a DELETE group request with invalid auth')
+      .uponReceiving(`as '${username}', a DELETE request to delete a group with invalid auth`)
       .withRequest({
         method: 'DELETE',
         path: MatchersV3.regex(
@@ -52,7 +53,7 @@ describe('Unauthorized: Currently testing group management,', function () {
 
   const getGroupMembersInteraction = (provider) => {
     return provider
-      .uponReceiving('a GET group member request with invalid auth')
+      .uponReceiving(`as '${username}', a GET request to get members of a group with invalid auth`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -68,7 +69,7 @@ describe('Unauthorized: Currently testing group management,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await groupsInteraction(provider, 'GET')
+    await groupsInteraction(provider, 'get all groups', 'GET')
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -91,7 +92,7 @@ describe('Unauthorized: Currently testing group management,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await groupsInteraction(provider, 'POST')
+    await groupsInteraction(provider, 'create a group', 'POST')
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -114,7 +115,7 @@ describe('Unauthorized: Currently testing group management,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await groupsInteraction(provider, 'GET')
+    await groupsInteraction(provider, 'check group existence', 'GET')
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)

--- a/tests/unauthorized/sharingTest.js
+++ b/tests/unauthorized/sharingTest.js
@@ -16,7 +16,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     testUser,
     testFile,
     testGroup,
-    username,
+    adminUsername: username,
     invalidPassword
   } = config
 
@@ -79,7 +79,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await createShareInteraction(provider, 'a link share POST request with invalid auth')
+    await createShareInteraction(provider, `as '${username}', a POST request to create public link share with invalid auth`)
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(username, invalidPassword)
@@ -102,7 +102,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await createShareInteraction(provider, 'a user share POST request with invalid auth')
+    await createShareInteraction(provider, `as '${username}', a POST request to share a file to a user with invalid auth`)
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(username, invalidPassword)
@@ -125,7 +125,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await createShareInteraction(provider, 'a group share POST request with invalid auth')
+    await createShareInteraction(provider, `as '${username}', a POST request to share a file to a group with invalid auth`)
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(username, invalidPassword)
@@ -150,7 +150,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await getSharesInteraction(provider, 'a GET request to get share info of a share with invalid auth', testFile)
+    await getSharesInteraction(provider, `as '${username}', a GET request to check whether a file is shared or not with invalid auth`, testFile)
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(username, invalidPassword)
@@ -173,7 +173,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await getShareInteraction(provider, 'a GET request to get a share with invalid auth', 'GET')
+    await getShareInteraction(provider, `as '${username}', a GET request to get single share of a file with invalid auth`, 'GET')
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(username, invalidPassword)
@@ -196,7 +196,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await getSharesInteraction(provider, 'a GET request for existent shares with invalid auth', testFile)
+    await getSharesInteraction(provider, `as '${username}', a GET request to get shares of a file with invalid auth`, testFile)
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(username, invalidPassword)
@@ -219,7 +219,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await getShareInteraction(provider, 'a PUT request to update a share with invalid auth', 'PUT')
+    await getShareInteraction(provider, `as '${username}', a PUT request to update a share with invalid auth`, 'PUT')
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(username, invalidPassword)
@@ -242,7 +242,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await getShareInteraction(provider, 'a DELETE request to delete a share with invalid auth', 'DELETE')
+    await getShareInteraction(provider, `as '${username}', a DELETE request to delete a share with invalid auth`, 'DELETE')
 
     return provider.executeTest(async () => {
       const oc = createOwncloud(username, invalidPassword)

--- a/tests/unauthorized/userTest.js
+++ b/tests/unauthorized/userTest.js
@@ -4,6 +4,7 @@ describe('Unauthorized: Currently testing user management,', function () {
   // CURRENT TIME
   var timeRightNow = new Date().getTime()
   var config = require('../config/config.json')
+  const username = config.adminUsername
 
   const {
     invalidAuthHeader,
@@ -18,7 +19,7 @@ describe('Unauthorized: Currently testing user management,', function () {
 
   const invalidAuthInteraction = (provider, requestName, method, path, query) => {
     return provider
-      .uponReceiving(requestName)
+      .uponReceiving(`as '${username}', a ${method} request to ${requestName} with invalid auth`)
       .withRequest({
         method: method,
         path: path,
@@ -71,7 +72,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await invalidAuthInteraction(provider, 'a GET request with invalid auth to check for user admin', 'GET', adminUserEndpointPath)
+    await invalidAuthInteraction(provider, 'admin user', 'GET', adminUserEndpointPath)
 
     await provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -92,7 +93,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await invalidAuthInteraction(provider, 'a create user POST request with invalid auth', 'POST', usersEndpointPath)
+    await invalidAuthInteraction(provider, 'create a user', 'POST', usersEndpointPath)
 
     await provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -113,7 +114,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await invalidAuthInteraction(provider, 'a GET request with invalid auth to search user', 'GET', usersEndpointPath)
+    await invalidAuthInteraction(provider, 'search users', 'GET', usersEndpointPath)
 
     await provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -135,7 +136,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     const query = { search: config.adminUsername }
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await invalidAuthInteraction(provider, 'a admin GET request with invalid auth', 'GET', usersEndpointPath, query)
+    await invalidAuthInteraction(provider, 'check user existence', 'GET', usersEndpointPath, query)
 
     await provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -156,7 +157,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await invalidAuthInteraction(provider, 'a user PUT request with invalid auth to add user to group', 'PUT', testUserEndpointPath)
+    await invalidAuthInteraction(provider, 'edit user', 'PUT', testUserEndpointPath)
 
     await provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -177,7 +178,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await invalidAuthInteraction(provider, 'a user POST request with invalid auth', 'POST', groupsEndpointPath)
+    await invalidAuthInteraction(provider, 'add user to a group', 'POST', groupsEndpointPath)
 
     await provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -198,7 +199,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await invalidAuthInteraction(provider, 'a GET request with invalid auth to get user in group', 'GET', groupsEndpointPath)
+    await invalidAuthInteraction(provider, 'get users of a group', 'GET', groupsEndpointPath)
 
     await provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -219,7 +220,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await invalidAuthInteraction(provider, 'a GET request with invalid auth to check for user', 'GET', groupsEndpointPath)
+    await invalidAuthInteraction(provider, 'check user existence in a group', 'GET', groupsEndpointPath)
 
     await provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -240,7 +241,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await invalidAuthInteraction(provider, 'a GET request with invalid auth to check for user endpoint', 'GET', testUserEndpointPath)
+    await invalidAuthInteraction(provider, 'normal user', 'GET', testUserEndpointPath)
 
     await provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -261,7 +262,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await invalidAuthInteraction(provider, 'a DELETE request with invalid auth to remove user from group', 'DELETE', groupsEndpointPath)
+    await invalidAuthInteraction(provider, 'remove user from a group', 'DELETE', groupsEndpointPath)
 
     await provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -282,7 +283,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await invalidAuthInteraction(provider, 'a POST request with invalid auth to add user to subadmin group', 'POST', subadminsUserEndpointPath)
+    await invalidAuthInteraction(provider, 'add a user to subadmin group', 'POST', subadminsUserEndpointPath)
 
     await provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -303,7 +304,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await invalidAuthInteraction(provider, 'a GET request with invalid auth to get user of subadmin group', 'GET', subadminsUserEndpointPath)
+    await invalidAuthInteraction(provider, 'get users of subadmin group', 'GET', subadminsUserEndpointPath)
 
     await provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -324,7 +325,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await invalidAuthInteraction(provider, 'a GET request with invalid auth to check user is in subadmin group', 'GET', subadminsUserEndpointPath)
+    await invalidAuthInteraction(provider, 'check user existence in subadmin group', 'GET', subadminsUserEndpointPath)
 
     await provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)
@@ -345,7 +346,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     const provider = createProvider()
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await invalidAuthInteraction(provider, 'a request to DELETE a non-existent user with invalid auth', 'DELETE', nonExistingUserEndpoint)
+    await invalidAuthInteraction(provider, 'delete a non-existent user', 'DELETE', nonExistingUserEndpoint)
 
     await provider.executeTest(async () => {
       const oc = createOwncloud(config.adminUsername, config.invalidPassword)

--- a/tests/userTest.js
+++ b/tests/userTest.js
@@ -2,6 +2,7 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 describe('Main: Currently testing user management,', function () {
   var config = require('./config/config.json')
+  const username = config.adminUsername
 
   // PACT setup
   const {
@@ -22,7 +23,7 @@ describe('Main: Currently testing user management,', function () {
         .given('the user is recreated', { username: username, password: config.testUserPassword })
     }
     return provider
-      .uponReceiving('a request to GET user information ' + requestName)
+      .uponReceiving(`as '${username}', a GET request to ${requestName}`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -41,7 +42,7 @@ describe('Main: Currently testing user management,', function () {
   const getUsersInteraction = function (provider, requestName, query, bodyData) {
     return provider
       .given('the user is recreated', { username: config.testUser, password: config.testUserPassword })
-      .uponReceiving('a request to list all users ' + requestName)
+      .uponReceiving(`as '${username}', a GET request to ${requestName}`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -69,7 +70,7 @@ describe('Main: Currently testing user management,', function () {
     }
 
     return provider
-      .uponReceiving('set user attribute of ' + requestName)
+      .uponReceiving(`as '${username}', a PUT request to set user attribute of ${requestName}`)
       .withRequest({
         method: 'PUT',
         path: MatchersV3.regex(
@@ -108,7 +109,7 @@ describe('Main: Currently testing user management,', function () {
     }
 
     return provider
-      .uponReceiving('add user to group ' + requestName)
+      .uponReceiving(`as '${username}', a POST request to ${requestName}`)
       .withRequest({
         method: 'POST',
         path: MatchersV3.regex(
@@ -143,7 +144,7 @@ describe('Main: Currently testing user management,', function () {
         .given('user is added to group', { username: username, groupName: config.testGroup })
     }
     return provider
-      .uponReceiving('a request to GET the groups that a user is a member of ' + requestName)
+      .uponReceiving(`as '${username}', a GET request to get groups of ${requestName}`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -173,7 +174,7 @@ describe('Main: Currently testing user management,', function () {
         .given('group exists', { groupName: group })
     }
     return provider
-      .uponReceiving('Remove user from a group ' + requestName)
+      .uponReceiving(`as '${username}', a DELETE request to remove ${requestName}`)
       .withRequest({
         method: 'DELETE',
         path: MatchersV3.regex(
@@ -201,7 +202,7 @@ describe('Main: Currently testing user management,', function () {
       })
   }
 
-  const addUserToSubAdminGroupInteraction = async function (provider, request, username, group, responseOcsMeta) {
+  const addUserToSubAdminGroupInteraction = async function (provider, requestName, username, group, responseOcsMeta) {
     if (username !== config.adminUsername && username !== config.nonExistentUser) {
       await provider
         .given('the user is recreated', { username: username, password: config.testUserPassword })
@@ -211,7 +212,7 @@ describe('Main: Currently testing user management,', function () {
         .given('group exists', { groupName: group })
     }
     return provider
-      .uponReceiving('Add user to subadmin group ' + request)
+      .uponReceiving(`as '${username}', a POST request to make ${requestName}`)
       .withRequest({
         method: 'POST',
         path: MatchersV3.regex(
@@ -243,7 +244,7 @@ describe('Main: Currently testing user management,', function () {
         .given('user is made group subadmin', { username: username, groupName: config.testGroup })
     }
     return provider
-      .uponReceiving('a request to GET groups that a user is a subadmin of ' + requestName)
+      .uponReceiving(`as '${username}', a GET request to get subadmin groups of ${requestName}`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -262,7 +263,7 @@ describe('Main: Currently testing user management,', function () {
   const getUserInformationOfNonExistentUserInteraction = function (provider) {
     return getUserInformationInteraction(
       provider,
-      'of a non-existent user',
+      'get user information of a non-existent user',
       config.nonExistentUser,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
@@ -280,7 +281,7 @@ describe('Main: Currently testing user management,', function () {
       await getCurrentUserInformationInteraction(provider)
       await getGroupOfUserInteraction(
         provider,
-        ' with existent user',
+        'existent user',
         config.testUser,
         new XmlBuilder('1.0', '', 'ocs')
           .build(ocs => {
@@ -312,7 +313,7 @@ describe('Main: Currently testing user management,', function () {
 
       await getGroupOfUserInteraction(
         provider,
-        ' with existent user',
+        'existent user',
         config.testUser,
         new XmlBuilder('1.0', '', 'ocs')
           .build(ocs => {
@@ -346,7 +347,7 @@ describe('Main: Currently testing user management,', function () {
 
       await getUsersSubAdminGroupsInteraction(
         provider,
-        ' with an existent user',
+        'an existent user',
         config.testUser,
         new XmlBuilder('1.0', '', 'ocs')
           .build(ocs => {
@@ -377,7 +378,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await getUserInformationInteraction(
       provider,
-      'of an existing user',
+      'get user information of an existing user',
       config.adminUsername,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
@@ -459,7 +460,7 @@ describe('Main: Currently testing user management,', function () {
     await createUserWithGroupMembershipInteraction(provider)
     await getGroupOfUserInteraction(
       provider,
-      ' with existent user',
+      'existent user',
       config.testUser,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
@@ -496,7 +497,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await getUsersInteraction(
       provider,
-      'to get all users',
+      'search a user',
       {},
       data => {
         data.appendElement('users', '', users => {
@@ -549,7 +550,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await getUsersInteraction(
       provider,
-      'search for a user that exists',
+      'check user existence with existing user',
       { search: config.adminUsername },
       data => {
         data.appendElement('users', '', users => {
@@ -575,7 +576,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await getUsersInteraction(
       provider,
-      'search for a user that doesn\'t exists',
+      'check user existence with non-existing user',
       { search: config.nonExistentUser },
       data => {
         data.appendElement('users', '', '')
@@ -677,7 +678,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await addUserToGroupInteraction(
       provider,
-      'with an existent user and a non existent group',
+      'add existent user in a non existent group',
       config.testUser,
       config.nonExistentGroup
     )
@@ -702,7 +703,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await addUserToGroupInteraction(
       provider,
-      'with a non-existent user and an existent group',
+      'add non-existent user in an existent group',
       config.nonExistentUser,
       config.testGroup
     )
@@ -725,7 +726,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     getGroupOfUserInteraction(
       provider,
-      ' non existing user',
+      'non-existing user',
       config.nonExistentUser,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
@@ -753,7 +754,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await getGroupOfUserInteraction(
       provider,
-      ' with existent user and group that user isn\'t part of ',
+      'existent user and group that user isn\'t part of',
       config.testUser,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
@@ -783,7 +784,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await getGroupOfUserInteraction(
       provider,
-      ' with existent user and nonexistant group',
+      'existent user and nonexistant group',
       config.testUser,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
@@ -814,7 +815,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await getGroupOfUserInteraction(
       provider,
-      ' with a non-existent user',
+      'non-existent user',
       config.nonExistentUser,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
@@ -841,7 +842,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await getUserInformationInteraction(
       provider,
-      'to get user attribute of an existent user, ' + config.testUser,
+      `get user attribute of an existent user '${config.testUser}'`,
       config.testUser,
 
       new XmlBuilder('1.0', '', 'ocs')
@@ -893,7 +894,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await removeUserFromGroupInteraction(
       provider,
-      'with existent user and non-existent group',
+      'existent user from a non-existent group',
       config.testUser,
       config.nonExistentGroup
     )
@@ -916,7 +917,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await removeUserFromGroupInteraction(
       provider,
-      'with a non-existent user and an existent group',
+      'non-existent user from an existent group',
       config.nonExistentUser,
       config.testGroup
     )
@@ -940,7 +941,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await addUserToSubAdminGroupInteraction(
       provider,
-      'with existent user non existent group',
+      'existent user subadmin of non-existent group',
       config.testUser,
       config.nonExistentGroup,
       meta => {
@@ -966,7 +967,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await addUserToSubAdminGroupInteraction(
       provider,
-      'with a non-existent user and an existent group',
+      'non-existent user subadmin of an existent group',
       config.nonExistentUser,
       config.testGroup,
       meta => {
@@ -990,7 +991,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await getUsersSubAdminGroupsInteraction(
       provider,
-      ' with a non-existent user',
+      'non-existent user',
       config.nonExistentUser,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
@@ -1018,7 +1019,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await getUsersSubAdminGroupsInteraction(
       provider,
-      ' with an existent user',
+      'existent user',
       config.testUser,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
@@ -1047,7 +1048,7 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await getUsersSubAdminGroupsInteraction(
       provider,
-      ' with a non-existent user',
+      'non-existent user',
       config.nonExistentUser,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
@@ -1074,7 +1075,7 @@ describe('Main: Currently testing user management,', function () {
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)
     await provider
-      .uponReceiving('a request to delete a non-existent user')
+      .uponReceiving(`as '${username}', a request to delete a non-existent user`)
       .withRequest({
         method: 'DELETE',
         path: MatchersV3.regex(


### PR DESCRIPTION
This PR makes pact interaction names more consistent
All interaction names follow the same pattern i.e. `.uponReceiving(a <METHOD> request ...)`

closes https://github.com/owncloud/owncloud-sdk/issues/723