### PR TITLE
[Tests-Only] Refactor backendHost and pact port config for pact tests

### DIFF
--- a/tests/config/config.drone.json
+++ b/tests/config/config.drone.json
@@ -1,5 +1,6 @@
 {
-    "owncloudURL": "http://localhost:1234${SUBFOLDER}",
+    "backendHost": "http://localhost:1234${SUBFOLDER}",
+    "pactMockPort": 1234,
     "adminUsername": "admin",
     "adminPassword": "admin",
     "adminDisplayName": "Admin",

--- a/tests/config/config.sample.json
+++ b/tests/config/config.sample.json
@@ -1,5 +1,6 @@
 {
-    "owncloudURL": "http://127.0.0.1:1234/${SUBFOLDER}",
+    "backendHost": "http://127.0.0.1:1234",
+    "pactMockPort": 1234,
     "adminUsername": "admin",
     "adminPassword": "admin",
     "adminDisplayName": "Admin",

--- a/tests/fileTrashTest.js
+++ b/tests/fileTrashTest.js
@@ -309,7 +309,7 @@ describe('oc.fileTrash', function () {
             method: 'MOVE',
             path: trashbinFolderPath,
             headers: {
-              Destination: config.owncloudURL + 'remote.php/dav/files/' + config.adminUsername + '/' + config.testFolder
+              Destination: config.backendHost + 'remote.php/dav/files/' + config.adminUsername + '/' + config.testFolder
             }
           })
           .willRespondWith(responseMethod(
@@ -406,7 +406,7 @@ describe('oc.fileTrash', function () {
             method: 'MOVE',
             path: trashbinFolderPath,
             headers: {
-              Destination: config.owncloudURL + 'remote.php/dav/files/' + config.adminUsername + '/' + config.testFolder + '%20(restored%20to%20a%20different%20location)'
+              Destination: config.backendHost + 'remote.php/dav/files/' + config.adminUsername + '/' + config.testFolder + '%20(restored%20to%20a%20different%20location)'
             }
           })
           .willRespondWith(responseMethod(
@@ -579,7 +579,7 @@ describe('oc.fileTrash', function () {
             method: 'MOVE',
             path: trashbinFolderPath,
             headers: {
-              Destination: config.owncloudURL + 'remote.php/dav/files/' + config.adminUsername + '/' + testFile
+              Destination: config.backendHost + 'remote.php/dav/files/' + config.adminUsername + '/' + testFile
             }
           })
           .willRespondWith({
@@ -672,7 +672,7 @@ describe('oc.fileTrash', function () {
             method: 'MOVE',
             path: trashbinFolderPath,
             headers: {
-              Destination: config.owncloudURL + 'remote.php/dav/files/' + config.adminUsername + '/file%20(restored%20to%20a%20different%20location).txt'
+              Destination: config.backendHost + 'remote.php/dav/files/' + config.adminUsername + '/file%20(restored%20to%20a%20different%20location).txt'
             }
           })
           .willRespondWith({

--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -153,7 +153,7 @@ describe('Main: Currently testing file versions management,', function () {
     it('checking method: getFileVersionUrl', function () {
       const oc = createOwncloud()
       const url = oc.fileVersions.getFileVersionUrl(666, 123456)
-      expect(url).toBe(config.owncloudURL + 'remote.php/dav/meta/666/v/123456')
+      expect(url).toBe(config.backendHost + 'remote.php/dav/meta/666/v/123456')
     })
 
     it.skip('retrieves file versions', async function () {
@@ -221,7 +221,7 @@ describe('Main: Currently testing file versions management,', function () {
             authorization: getAuthHeaders(config.testUser, config.testUserPassword),
             Destination: MatchersV3.fromProviderState(
               `\${providerBaseURL}${destinationWebDavPath}`,
-              `${config.owncloudURL}${destinationWebDavPath}`
+              `${config.backendHost}${destinationWebDavPath}`
             )
           }
         })

--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -29,7 +29,7 @@ describe('Main: Currently testing files management,', function () {
   } = require('./pactHelper.js')
 
   // TESTING CONFIGS
-  const { testFolder, testFile, testContent, nonExistentFile, nonExistentDir, owncloudURL } = config
+  const { testFolder, testFile, testContent, nonExistentFile, nonExistentDir, backendHost } = config
   const testSubDir = testFolder + '/' + 'subdir'
 
   const moveFileInteraction = function (provider, requestName, header, response) {
@@ -463,7 +463,7 @@ describe('Main: Currently testing files management,', function () {
     it('checking method: getFileUrl', function () {
       const oc = createOwncloud()
       const url = oc.files.getFileUrl('/foo/bar')
-      expect(url).toBe(owncloudURL + 'remote.php/webdav/foo/bar')
+      expect(url).toBe(backendHost + 'remote.php/webdav/foo/bar')
     })
 
     it('checking method: getFileUrlV2', async function () {
@@ -475,7 +475,7 @@ describe('Main: Currently testing files management,', function () {
         const oc = createOwncloud()
         await oc.login()
         const url = oc.files.getFileUrlV2('/foo/bar')
-        expect(url).toBe(owncloudURL + 'remote.php/dav/files/' + config.adminUsername + '/foo/bar')
+        expect(url).toBe(backendHost + 'remote.php/dav/files/' + config.adminUsername + '/foo/bar')
       })
     })
 
@@ -583,7 +583,7 @@ describe('Main: Currently testing files management,', function () {
         'same name',
         {
           ...validAuthHeaders,
-          Destination: `${owncloudURL}remote.php/webdav/testFolder/%E4%B8%AD%E6%96%87.txt`
+          Destination: `${backendHost}remote.php/webdav/testFolder/%E4%B8%AD%E6%96%87.txt`
         },
         {
           status: 403,
@@ -630,7 +630,7 @@ describe('Main: Currently testing files management,', function () {
             authorization: getAuthHeaders(config.testUser, config.testUserPassword),
             Destination: MatchersV3.fromProviderState(
               `\${providerBaseURL}${destinationWebDavPath}`,
-              `${config.owncloudURL}${destinationWebDavPath}`
+              `${config.backendHost}${destinationWebDavPath}`
             )
           }
         })
@@ -660,7 +660,7 @@ describe('Main: Currently testing files management,', function () {
           path: webdavPath(nonExistentFile),
           headers: {
             ...validAuthHeaders,
-            Destination: `${owncloudURL}remote.php/webdav/abcd.txt`
+            Destination: `${backendHost}remote.php/webdav/abcd.txt`
           }
         })
         .willRespondWith({
@@ -691,7 +691,7 @@ describe('Main: Currently testing files management,', function () {
           path: webdavPath(`${testFolder}/${encodeURI('中文.txt')}`),
           headers: {
             ...validAuthHeaders,
-            Destination: `${owncloudURL}remote.php/webdav/${testFolder}/${encodeURI('中文.txt')}`
+            Destination: `${backendHost}remote.php/webdav/${testFolder}/${encodeURI('中文.txt')}`
           }
         })
         .willRespondWith({
@@ -722,7 +722,7 @@ describe('Main: Currently testing files management,', function () {
           path: webdavPath(nonExistentFile),
           headers: {
             ...validAuthHeaders,
-            Destination: `${owncloudURL}remote.php/webdav/abcd.txt`
+            Destination: `${backendHost}remote.php/webdav/abcd.txt`
           }
         })
         .willRespondWith({
@@ -972,7 +972,7 @@ describe('Main: Currently testing files management,', function () {
           authorization: getAuthHeaders(config.testUser, config.testUserPassword),
           Destination: MatchersV3.fromProviderState(
             `\${providerBaseURL}${destinationWebDavPath}`,
-            `${config.owncloudURL}${destinationWebDavPath}`
+            `${config.backendHost}${destinationWebDavPath}`
           )
         },
         {
@@ -1022,7 +1022,7 @@ describe('Main: Currently testing files management,', function () {
             authorization: getAuthHeaders(config.testUser, config.testUserPassword),
             Destination: MatchersV3.fromProviderState(
               `\${providerBaseURL}${destinationWebDavPath}`,
-              `${config.owncloudURL}${destinationWebDavPath}`
+              `${config.backendHost}${destinationWebDavPath}`
             )
           }
         })
@@ -1077,7 +1077,7 @@ describe('Main: Currently testing files management,', function () {
             authorization: getAuthHeaders(config.testUser, config.testUserPassword),
             Destination: MatchersV3.fromProviderState(
               `\${providerBaseURL}${destinationWebDavPath}`,
-              `${config.owncloudURL}${destinationWebDavPath}`
+              `${config.backendHost}${destinationWebDavPath}`
             )
           }
         })

--- a/tests/loginTest.js
+++ b/tests/loginTest.js
@@ -50,7 +50,7 @@ describe('Main: Currently testing Login and initLibrary,', function () {
 
     return provider.executeTest(async () => {
       oc = new OwnCloud({
-        baseUrl: config.owncloudURL,
+        baseUrl: config.backendHost,
         auth: {
           basic: {
             username: nonExistentUser,
@@ -73,7 +73,7 @@ describe('Main: Currently testing Login and initLibrary,', function () {
 
     return provider.executeTest(async () => {
       oc = new OwnCloud({
-        baseUrl: config.owncloudURL,
+        baseUrl: config.backendHost,
         auth: {
           basic: {
             username: config.adminUsername,
@@ -96,7 +96,7 @@ describe('Main: Currently testing Login and initLibrary,', function () {
     await getCurrentUserInformationInteraction(provider)
     return provider.executeTest(async () => {
       oc = new OwnCloud({
-        baseUrl: config.owncloudURL,
+        baseUrl: config.backendHost,
         auth: {
           basic: {
             username: config.adminUsername,

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -50,7 +50,7 @@ const shareResponseOcsData = function (node, shareType, id, permissions, fileTar
     .appendElement('stime', '', MatchersV3.string(Math.floor(Date.now() / 1000)))
 
   if (shareType === 3) {
-    res.appendElement('url', '', config.owncloudURL + '/s/yrkoLeS33y1aTya')
+    res.appendElement('url', '', config.backendHost + '/s/yrkoLeS33y1aTya')
   }
   return res
 }
@@ -117,7 +117,7 @@ const createProvider = function () {
   return new PactV3({
     consumer: 'owncloud-sdk',
     provider: 'oc-server',
-    port: 1234,
+    port: config.pactMockPort,
     dir: path.resolve(process.cwd(), 'tests', 'pacts')
   })
 }
@@ -128,7 +128,7 @@ const sanitizeUrl = (url) => {
 
 const createOwncloud = function (username = config.adminUsername, password = config.adminPassword) {
   const oc = new OwnCloud({
-    baseUrl: config.owncloudURL,
+    baseUrl: config.backendHost,
     auth: {
       basic: {
         username,

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -133,7 +133,7 @@ describe('oc.publicFiles', function () {
       it('shall work with ' + description, function () {
         const oc = createOwncloud()
         expect(oc.publicFiles.getFileUrl(data.token, data.path))
-          .toBe(config.owncloudURL + data.expected)
+          .toBe(config.backendHost + data.expected)
       })
     })
   })
@@ -479,7 +479,7 @@ describe('oc.publicFiles', function () {
               headers: {
                 Destination: MatchersV3.fromProviderState(
                   '\${providerBaseURL}/remote.php/dav/public-files/\${token}/lorem123456.txt', /* eslint-disable-line */
-                  `${config.owncloudURL}remote.php/dav/public-files/${config.shareTokenOfPublicLinkFolder}/lorem123456.txt`)
+                  `${config.backendHost}remote.php/dav/public-files/${config.shareTokenOfPublicLinkFolder}/lorem123456.txt`)
               }
             })
             .willRespondWith(moveResourceResponse)
@@ -518,7 +518,7 @@ describe('oc.publicFiles', function () {
               headers: {
                 Destination: MatchersV3.fromProviderState(
                   '\${providerBaseURL}/remote.php/dav/public-files/\${token}/foo/lorem.txt', /* eslint-disable-line */
-                  `${config.owncloudURL}remote.php/dav/public-files/${config.shareTokenOfPublicLinkFolder}/foo/lorem.txt`)
+                  `${config.backendHost}remote.php/dav/public-files/${config.shareTokenOfPublicLinkFolder}/foo/lorem.txt`)
               }
             })
             .willRespondWith(moveResourceResponse)
@@ -552,7 +552,7 @@ describe('oc.publicFiles', function () {
               headers: {
                 Destination: MatchersV3.fromProviderState(
                   '\${providerBaseURL}/remote.php/dav/public-files/\${token}/bar', /* eslint-disable-line */
-                  `${config.owncloudURL}remote.php/dav/public-files/${config.shareTokenOfPublicLinkFolder}/bar`
+                  `${config.backendHost}remote.php/dav/public-files/${config.shareTokenOfPublicLinkFolder}/bar`
                 )
               }
             }).willRespondWith(moveResourceResponse)

--- a/tests/signedUrlTest.js
+++ b/tests/signedUrlTest.js
@@ -27,7 +27,7 @@ describe('Main: Currently testing url signing,', function () {
 
   it('checking method : signUrl', function () {
     const oc = new OwnCloud({
-      baseUrl: config.owncloudURL,
+      baseUrl: config.backendHost,
       auth: {
         basic: {
           username: config.adminUsername,

--- a/tests/unauthenticated/appsTest.js
+++ b/tests/unauthenticated/appsTest.js
@@ -7,7 +7,7 @@ describe('Unauthenticated: Currently testing apps management,', function () {
 
   beforeEach(function () {
     oc = new OwnCloud({
-      baseUrl: config.owncloudURL
+      baseUrl: config.backendHost
     })
   })
 

--- a/tests/unauthenticated/capabilitiesTest.js
+++ b/tests/unauthenticated/capabilitiesTest.js
@@ -7,7 +7,7 @@ describe('Unauthenticated: Currently testing getConfig, getVersion and getCapabi
 
   beforeEach(function () {
     oc = new OwnCloud({
-      baseUrl: config.owncloudURL
+      baseUrl: config.backendHost
     })
   })
 

--- a/tests/unauthenticated/filesTest.js
+++ b/tests/unauthenticated/filesTest.js
@@ -20,7 +20,7 @@ describe('Unauthenticated: Currently testing files management,', function () {
 
   beforeEach(function () {
     oc = new OwnCloud({
-      baseUrl: config.owncloudURL
+      baseUrl: config.backendHost
     })
   })
 

--- a/tests/unauthenticated/groupTest.js
+++ b/tests/unauthenticated/groupTest.js
@@ -13,7 +13,7 @@ describe('Unauthenticated: Currently testing group management,', function () {
 
   beforeEach(function () {
     oc = new OwnCloud({
-      baseUrl: config.owncloudURL
+      baseUrl: config.backendHost
     })
   })
 

--- a/tests/unauthenticated/sharingTest.js
+++ b/tests/unauthenticated/sharingTest.js
@@ -17,7 +17,7 @@ describe('Unauthenticated: Currently testing file/folder sharing,', function () 
 
   beforeEach(function () {
     oc = new OwnCloud({
-      baseUrl: config.owncloudURL
+      baseUrl: config.backendHost
     })
   })
 

--- a/tests/unauthenticated/userTest.js
+++ b/tests/unauthenticated/userTest.js
@@ -15,7 +15,7 @@ describe('Unauthenticated: Currently testing user management,', function () {
 
   beforeEach(function () {
     oc = new OwnCloud({
-      baseUrl: config.owncloudURL
+      baseUrl: config.backendHost
     })
   })
 


### PR DESCRIPTION
Fixes https://github.com/owncloud/owncloud-sdk/issues/757

- [x] - Change config ownCloudUrl to backendHost
- [x] - Create new config pactMockPort for mock server port
- [x] - Remove `${SUB_FOLDER}` from default local config.json 