### PR TITLE
add trailing slash for backendHost in example config

### DIFF
--- a/tests/config/config.sample.json
+++ b/tests/config/config.sample.json
@@ -1,5 +1,5 @@
 {
-    "backendHost": "http://127.0.0.1:1234",
+    "backendHost": "http://127.0.0.1:1234/",
     "pactMockPort": 1234,
     "adminUsername": "admin",
     "adminPassword": "admin",


### PR DESCRIPTION
the URL needs a trailing slash otherwise the tests cannot create correct path e.g. `Expected: "http://127.0.0.1:1234remote.php/dav/public-files/abcdef/foo/bar.txt"`
