### PR TITLE
[tests-only]Refactor backendHost and pactMockPort to get complete URL

### DIFF
--- a/tests/config/config.drone.json
+++ b/tests/config/config.drone.json
@@ -1,5 +1,5 @@
 {
-    "backendHost": "http://localhost:1234${SUBFOLDER}",
+    "pactMockHost": "http://localhost",
     "pactMockPort": 1234,
     "adminUsername": "admin",
     "adminPassword": "admin",

--- a/tests/config/config.sample.json
+++ b/tests/config/config.sample.json
@@ -1,5 +1,5 @@
 {
-    "backendHost": "http://127.0.0.1:1234/",
+    "pactMockHost": "http://127.0.0.1",
     "pactMockPort": 1234,
     "adminUsername": "admin",
     "adminPassword": "admin",

--- a/tests/fileTrashTest.js
+++ b/tests/fileTrashTest.js
@@ -16,7 +16,8 @@ describe('oc.fileTrash', function () {
     getCapabilitiesInteraction,
     createOwncloud,
     createProvider,
-    applicationXmlResponseHeaders
+    applicationXmlResponseHeaders,
+    getMockServerBaseUrl
   } = require('./pactHelper.js')
 
   const mockServerBaseUrl = getMockServerBaseUrl()
@@ -417,7 +418,7 @@ describe('oc.fileTrash', function () {
             method: 'MOVE',
             path: trashbinFolderPath,
             headers: {
-              Destination: config.backendHost + 'remote.php/dav/files/' + config.adminUsername + '/' + config.testFolder + '%20(restored%20to%20a%20different%20location)',
+              Destination: mockServerBaseUrl + 'remote.php/dav/files/' + config.adminUsername + '/' + config.testFolder + '%20(restored%20to%20a%20different%20location)',
               ...validAdminAuthHeaders
             }
           })

--- a/tests/fileTrashTest.js
+++ b/tests/fileTrashTest.js
@@ -19,6 +19,8 @@ describe('oc.fileTrash', function () {
     applicationXmlResponseHeaders
   } = require('./pactHelper.js')
 
+  const mockServerBaseUrl = getMockServerBaseUrl()
+
   const deletedFolderId = '2147596415'
   const deletedFileId = '2147596419'
 
@@ -313,7 +315,7 @@ describe('oc.fileTrash', function () {
             method: 'MOVE',
             path: trashbinFolderPath,
             headers: {
-              Destination: config.backendHost + 'remote.php/dav/files/' + config.adminUsername + '/' + config.testFolder
+              Destination: mockServerBaseUrl + 'remote.php/dav/files/' + config.adminUsername + '/' + config.testFolder
             }
           })
           .willRespondWith(responseMethod(
@@ -599,7 +601,7 @@ describe('oc.fileTrash', function () {
             method: 'MOVE',
             path: trashbinFolderPath,
             headers: {
-              Destination: config.backendHost + 'remote.php/dav/files/' + config.adminUsername + '/' + testFile
+              Destination: mockServerBaseUrl + 'remote.php/dav/files/' + config.adminUsername + '/' + testFile
             }
           })
           .willRespondWith({
@@ -697,7 +699,7 @@ describe('oc.fileTrash', function () {
             method: 'MOVE',
             path: trashbinFolderPath,
             headers: {
-              Destination: config.backendHost + 'remote.php/dav/files/' + config.adminUsername + '/file%20(restored%20to%20a%20different%20location).txt'
+              Destination: mockServerBaseUrl + 'remote.php/dav/files/' + config.adminUsername + '/file%20(restored%20to%20a%20different%20location).txt'
             }
           })
           .willRespondWith({

--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -31,6 +31,7 @@ describe('Main: Currently testing file versions management,', function () {
       }
     ]
   }
+  const mockServerBaseUrl = getMockServerBaseUrl()
   const propfindFileVersionsRequestData = {
     method: 'PROPFIND',
     path: MatchersV3.regex(
@@ -152,7 +153,7 @@ describe('Main: Currently testing file versions management,', function () {
     it('checking method: getFileVersionUrl', function () {
       const oc = createOwncloud()
       const url = oc.fileVersions.getFileVersionUrl(666, 123456)
-      expect(url).toBe(config.backendHost + 'remote.php/dav/meta/666/v/123456')
+      expect(url).toBe(mockServerBaseUrl + 'remote.php/dav/meta/666/v/123456')
     })
 
     it('retrieves file versions', async function () {
@@ -220,7 +221,7 @@ describe('Main: Currently testing file versions management,', function () {
             authorization: getAuthHeaders(config.testUser, config.testUserPassword),
             Destination: MatchersV3.fromProviderState(
               `\${providerBaseURL}${destinationWebDavPath}`,
-              `${config.backendHost}${destinationWebDavPath}`
+              `${mockServerBaseUrl}${destinationWebDavPath}`
             )
           }
         })

--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -12,7 +12,8 @@ describe('Main: Currently testing file versions management,', function () {
     createOwncloud,
     createProvider,
     getAuthHeaders,
-    validAuthHeaders
+    validAuthHeaders,
+    getMockServerBaseUrl
   } = require('./pactHelper.js')
 
   const { createDavPath } = require('./webdavHelper.js')

--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -24,12 +24,14 @@ describe('Main: Currently testing files management,', function () {
     createFolderInteraction,
     updateFileInteraction,
     createOwncloud,
-    createProvider
+    createProvider,
+    getMockServerBaseUrl
   } = require('./pactHelper.js')
 
   // TESTING CONFIGS
-  const { testFolder, testFile, testContent, nonExistentFile, nonExistentDir, backendHost } = config
+  const { testFolder, testFile, testContent, nonExistentFile, nonExistentDir } = config
   const testSubDir = testFolder + '/' + 'subdir'
+  const mockServerBaseUrl = getMockServerBaseUrl()
 
   const moveFileInteraction = function (provider, requestName, header, response) {
     return provider
@@ -472,7 +474,7 @@ describe('Main: Currently testing files management,', function () {
     it('checking method: getFileUrl', function () {
       const oc = createOwncloud()
       const url = oc.files.getFileUrl('/foo/bar')
-      expect(url).toBe(backendHost + 'remote.php/webdav/foo/bar')
+      expect(url).toBe(mockServerBaseUrl + 'remote.php/webdav/foo/bar')
     })
 
     it('checking method: getFileUrlV2', async function () {
@@ -484,7 +486,7 @@ describe('Main: Currently testing files management,', function () {
         const oc = createOwncloud()
         await oc.login()
         const url = oc.files.getFileUrlV2('/foo/bar')
-        expect(url).toBe(backendHost + 'remote.php/dav/files/' + config.adminUsername + '/foo/bar')
+        expect(url).toBe(mockServerBaseUrl + 'remote.php/dav/files/' + config.adminUsername + '/foo/bar')
       })
     })
 
@@ -592,7 +594,7 @@ describe('Main: Currently testing files management,', function () {
         'same name',
         {
           ...validAuthHeaders,
-          Destination: `${backendHost}remote.php/webdav/testFolder/%E4%B8%AD%E6%96%87.txt`
+          Destination: `${mockServerBaseUrl}remote.php/webdav/testFolder/%E4%B8%AD%E6%96%87.txt`
         },
         {
           status: 403,
@@ -639,7 +641,7 @@ describe('Main: Currently testing files management,', function () {
             authorization: getAuthHeaders(config.testUser, config.testUserPassword),
             Destination: MatchersV3.fromProviderState(
               `\${providerBaseURL}/${destinationWebDavPath}`,
-              `${config.backendHost}${destinationWebDavPath}`
+              `${mockServerBaseUrl}${destinationWebDavPath}`
             )
           }
         })
@@ -668,7 +670,7 @@ describe('Main: Currently testing files management,', function () {
           path: webdavPath(nonExistentFile),
           headers: {
             ...validAuthHeaders,
-            Destination: `${backendHost}remote.php/webdav/abcd.txt`
+            Destination: `${mockServerBaseUrl}remote.php/webdav/abcd.txt`
           }
         })
         .willRespondWith({
@@ -699,7 +701,7 @@ describe('Main: Currently testing files management,', function () {
           path: webdavPath(`${testFolder}/${encodeURI('中文.txt')}`),
           headers: {
             ...validAuthHeaders,
-            Destination: `${backendHost}remote.php/webdav/${testFolder}/${encodeURI('中文.txt')}`
+            Destination: `${mockServerBaseUrl}remote.php/webdav/${testFolder}/${encodeURI('中文.txt')}`
           }
         })
         .willRespondWith({
@@ -730,7 +732,7 @@ describe('Main: Currently testing files management,', function () {
           path: webdavPath(nonExistentFile),
           headers: {
             ...validAuthHeaders,
-            Destination: `${backendHost}remote.php/webdav/abcd.txt`
+            Destination: `${mockServerBaseUrl}remote.php/webdav/abcd.txt`
           }
         })
         .willRespondWith({
@@ -995,7 +997,7 @@ describe('Main: Currently testing files management,', function () {
           authorization: getAuthHeaders(config.testUser, config.testUserPassword),
           Destination: MatchersV3.fromProviderState(
             `\${providerBaseURL}/${destinationWebDavPath}`,
-            `${config.backendHost}${destinationWebDavPath}`
+            `${mockServerBaseUrl}${destinationWebDavPath}`
           )
         },
         {
@@ -1044,7 +1046,7 @@ describe('Main: Currently testing files management,', function () {
             authorization: getAuthHeaders(config.testUser, config.testUserPassword),
             Destination: MatchersV3.fromProviderState(
               `\${providerBaseURL}/${destinationWebDavPath}`,
-              `${config.backendHost}${destinationWebDavPath}`
+              `${mockServerBaseUrl}${destinationWebDavPath}`
             )
           }
         })
@@ -1098,7 +1100,7 @@ describe('Main: Currently testing files management,', function () {
             authorization: getAuthHeaders(config.testUser, config.testUserPassword),
             Destination: MatchersV3.fromProviderState(
               `\${providerBaseURL}/${destinationWebDavPath}`,
-              `${config.backendHost}${destinationWebDavPath}`
+              `${mockServerBaseUrl}${destinationWebDavPath}`
             )
           }
         })

--- a/tests/loginTest.js
+++ b/tests/loginTest.js
@@ -16,8 +16,11 @@ describe('Main: Currently testing Login and initLibrary,', function () {
     createProvider,
     getCapabilitiesWithInvalidAuthInteraction,
     getCapabilitiesInteraction,
-    getCurrentUserInformationInteraction
+    getCurrentUserInformationInteraction,
+    getMockServerBaseUrl
   } = require('./pactHelper.js')
+
+  const mockServerBaseUrl = getMockServerBaseUrl()
 
   beforeEach(function () {
     oc = null
@@ -50,7 +53,7 @@ describe('Main: Currently testing Login and initLibrary,', function () {
 
     return provider.executeTest(async () => {
       oc = new OwnCloud({
-        baseUrl: config.backendHost,
+        baseUrl: mockServerBaseUrl,
         auth: {
           basic: {
             username: nonExistentUser,
@@ -73,7 +76,7 @@ describe('Main: Currently testing Login and initLibrary,', function () {
 
     return provider.executeTest(async () => {
       oc = new OwnCloud({
-        baseUrl: config.backendHost,
+        baseUrl: mockServerBaseUrl,
         auth: {
           basic: {
             username: config.adminUsername,
@@ -96,7 +99,7 @@ describe('Main: Currently testing Login and initLibrary,', function () {
     await getCurrentUserInformationInteraction(provider)
     return provider.executeTest(async () => {
       oc = new OwnCloud({
-        baseUrl: config.backendHost,
+        baseUrl: mockServerBaseUrl,
         auth: {
           basic: {
             username: config.adminUsername,

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -52,7 +52,7 @@ const shareResponseOcsData = function (node, shareType, id, permissions, fileTar
   if (shareType === 3) {
     res.appendElement('url', '', MatchersV3.regex(
       '.*\\/s\\/[a-zA-Z0-9]+',
-      config.backendHost + 's/yrkoLeS33y1aTya'))
+      getMockServerBaseUrl() + 's/yrkoLeS33y1aTya'))
   }
   return res
 }
@@ -132,7 +132,7 @@ const sanitizeUrl = (url) => {
 
 const createOwncloud = function (username = config.adminUsername, password = config.adminPassword) {
   const oc = new OwnCloud({
-    baseUrl: config.backendHost,
+    baseUrl: getMockServerBaseUrl(),
     auth: {
       basic: {
         username,

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -505,7 +505,7 @@ const getProviderBaseUrl = function () {
 
 const getMockServerBaseUrl = function () {
   const subfolder = process.env.SUBFOLDER || '/'
-  return config.pactMockHost + ':' + config.pactMockPort + subfolder
+  return `${config.pactMockHost}:${config.pactMockPort}${subfolder}`
 }
 
 module.exports = {

--- a/tests/pactHelper.js
+++ b/tests/pactHelper.js
@@ -503,6 +503,11 @@ const getProviderBaseUrl = function () {
   return providerBaseUrl
 }
 
+const getMockServerBaseUrl = function () {
+  const subfolder = process.env.SUBFOLDER || '/'
+  return config.pactMockHost + ':' + config.pactMockPort + subfolder
+}
+
 module.exports = {
   getAuthHeaders,
   getContentsOfFileInteraction,
@@ -537,5 +542,6 @@ module.exports = {
   createFolderInteraction,
   updateFileInteraction,
   sanitizeUrl,
-  getProviderBaseUrl
+  getProviderBaseUrl,
+  getMockServerBaseUrl
 }

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -18,6 +18,8 @@ describe('oc.publicFiles', function () {
     validAdminAuthHeaders
   } = require('./pactHelper.js')
 
+  const mockServerBaseUrl = getMockServerBaseUrl()
+
   const publicLinkShareTokenPath = MatchersV3.regex(
     '.*\\/remote\\.php\\/dav\\/public-files\\/' + config.shareTokenOfPublicLinkFolder,
     '/remote.php/dav/public-files/' + config.shareTokenOfPublicLinkFolder + '/'
@@ -183,7 +185,7 @@ describe('oc.publicFiles', function () {
       it('shall work with ' + description, function () {
         const oc = createOwncloud()
         expect(oc.publicFiles.getFileUrl(data.token, data.path))
-          .toBe(config.backendHost + data.expected)
+          .toBe(mockServerBaseUrl + data.expected)
       })
     })
   })
@@ -600,7 +602,7 @@ describe('oc.publicFiles', function () {
                 ...getPublicLinkAuthHeader(data.shareParams.headers),
                 Destination: MatchersV3.fromProviderState(
                   '\${providerBaseURL}/remote.php/dav/public-files/\${token}/lorem123456.txt', /* eslint-disable-line */
-                  `${config.backendHost}remote.php/dav/public-files/${config.shareTokenOfPublicLinkFolder}/lorem123456.txt`)
+                  `${mockServerBaseUrl}remote.php/dav/public-files/${config.shareTokenOfPublicLinkFolder}/lorem123456.txt`)
               }
             })
             .willRespondWith(moveResourceResponse)
@@ -640,7 +642,7 @@ describe('oc.publicFiles', function () {
                 ...getPublicLinkAuthHeader(data.shareParams.headers),
                 Destination: MatchersV3.fromProviderState(
                   '\${providerBaseURL}/remote.php/dav/public-files/\${token}/foo/lorem.txt', /* eslint-disable-line */
-                  `${config.backendHost}remote.php/dav/public-files/${config.shareTokenOfPublicLinkFolder}/foo/lorem.txt`)
+                  `${mockServerBaseUrl}remote.php/dav/public-files/${config.shareTokenOfPublicLinkFolder}/foo/lorem.txt`)
               }
             })
             .willRespondWith(moveResourceResponse)
@@ -674,7 +676,7 @@ describe('oc.publicFiles', function () {
               headers: {
                 Destination: MatchersV3.fromProviderState(
                   '\${providerBaseURL}/remote.php/dav/public-files/\${token}/bar', /* eslint-disable-line */
-                  `${config.backendHost}remote.php/dav/public-files/${config.shareTokenOfPublicLinkFolder}/bar`
+                  `${mockServerBaseUrl}remote.php/dav/public-files/${config.shareTokenOfPublicLinkFolder}/bar`
                 )
               }
             }).willRespondWith(moveResourceResponse)

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -15,7 +15,8 @@ describe('oc.publicFiles', function () {
     textPlainResponseHeaders,
     ocsMeta,
     applicationFormUrlEncoded,
-    validAdminAuthHeaders
+    validAdminAuthHeaders,
+    getMockServerBaseUrl
   } = require('./pactHelper.js')
 
   const mockServerBaseUrl = getMockServerBaseUrl()

--- a/tests/signedUrlTest.js
+++ b/tests/signedUrlTest.js
@@ -2,7 +2,7 @@ describe('Main: Currently testing url signing,', function () {
   var OwnCloud = require('../src/owncloud')
   var config = require('./config/config.json')
 
-  const getMockServerBaseUrl = require('./pactHelper.js')
+  const { getMockServerBaseUrl } = require('./pactHelper.js')
   const mockServerBaseUrl = getMockServerBaseUrl()
 
   // saved date object

--- a/tests/signedUrlTest.js
+++ b/tests/signedUrlTest.js
@@ -2,6 +2,9 @@ describe('Main: Currently testing url signing,', function () {
   var OwnCloud = require('../src/owncloud')
   var config = require('./config/config.json')
 
+  const getMockServerBaseUrl = require('./pactHelper.js')
+  const mockServerBaseUrl = getMockServerBaseUrl()
+
   // saved date object
   var realDate
 
@@ -27,7 +30,7 @@ describe('Main: Currently testing url signing,', function () {
 
   it('checking method : signUrl', function () {
     const oc = new OwnCloud({
-      baseUrl: config.backendHost,
+      baseUrl: mockServerBaseUrl,
       auth: {
         basic: {
           username: config.adminUsername,

--- a/tests/unauthenticated/appsTest.js
+++ b/tests/unauthenticated/appsTest.js
@@ -1,6 +1,6 @@
 describe('Unauthenticated: Currently testing apps management,', function () {
   var OwnCloud = require('../../src')
-  const getMockServerBaseUrl = require('./pactHelper.js')
+  const { getMockServerBaseUrl } = require('../pactHelper.js')
   const mockServerBaseUrl = getMockServerBaseUrl()
   // LIBRARY INSTANCE
   var oc

--- a/tests/unauthenticated/appsTest.js
+++ b/tests/unauthenticated/appsTest.js
@@ -1,13 +1,13 @@
 describe('Unauthenticated: Currently testing apps management,', function () {
   var OwnCloud = require('../../src')
-  var config = require('../config/config.json')
-
+  const getMockServerBaseUrl = require('./pactHelper.js')
+  const mockServerBaseUrl = getMockServerBaseUrl()
   // LIBRARY INSTANCE
   var oc
 
   beforeEach(function () {
     oc = new OwnCloud({
-      baseUrl: config.backendHost
+      baseUrl: mockServerBaseUrl
     })
   })
 

--- a/tests/unauthenticated/capabilitiesTest.js
+++ b/tests/unauthenticated/capabilitiesTest.js
@@ -1,13 +1,13 @@
 describe('Unauthenticated: Currently testing getConfig, getVersion and getCapabilities', function () {
   const OwnCloud = require('../../src')
-  const config = require('../config/config.json')
-
+  const getMockServerBaseUrl = require('./pactHelper.js')
+  const mockServerBaseUrl = getMockServerBaseUrl()
   // LIBRARY INSTANCE
   let oc
 
   beforeEach(function () {
     oc = new OwnCloud({
-      baseUrl: config.backendHost
+      baseUrl: mockServerBaseUrl
     })
   })
 

--- a/tests/unauthenticated/capabilitiesTest.js
+++ b/tests/unauthenticated/capabilitiesTest.js
@@ -1,6 +1,6 @@
 describe('Unauthenticated: Currently testing getConfig, getVersion and getCapabilities', function () {
   const OwnCloud = require('../../src')
-  const getMockServerBaseUrl = require('./pactHelper.js')
+  const { getMockServerBaseUrl } = require('../pactHelper.js')
   const mockServerBaseUrl = getMockServerBaseUrl()
   // LIBRARY INSTANCE
   let oc

--- a/tests/unauthenticated/filesTest.js
+++ b/tests/unauthenticated/filesTest.js
@@ -2,7 +2,7 @@ describe('Unauthenticated: Currently testing files management,', function () {
   // CURRENT TIME
   var timeRightNow = new Date().getTime()
   var OwnCloud = require('../../src')
-  const getMockServerBaseUrl = require('./pactHelper.js')
+  const { getMockServerBaseUrl } = require('../pactHelper.js')
   const mockServerBaseUrl = getMockServerBaseUrl()
   // LIBRARY INSTANCE
   var oc

--- a/tests/unauthenticated/filesTest.js
+++ b/tests/unauthenticated/filesTest.js
@@ -2,8 +2,8 @@ describe('Unauthenticated: Currently testing files management,', function () {
   // CURRENT TIME
   var timeRightNow = new Date().getTime()
   var OwnCloud = require('../../src')
-  var config = require('../config/config.json')
-
+  const getMockServerBaseUrl = require('./pactHelper.js')
+  const mockServerBaseUrl = getMockServerBaseUrl()
   // LIBRARY INSTANCE
   var oc
 
@@ -20,7 +20,7 @@ describe('Unauthenticated: Currently testing files management,', function () {
 
   beforeEach(function () {
     oc = new OwnCloud({
-      baseUrl: config.backendHost
+      baseUrl: mockServerBaseUrl
     })
   })
 

--- a/tests/unauthenticated/groupTest.js
+++ b/tests/unauthenticated/groupTest.js
@@ -1,6 +1,6 @@
 describe('Unauthenticated: Currently testing group management,', function () {
   var OwnCloud = require('../../src')
-  const getMockServerBaseUrl = require('./pactHelper.js')
+  const { getMockServerBaseUrl } = require('../pactHelper.js')
   const mockServerBaseUrl = getMockServerBaseUrl()
 
   // CURRENT TIME

--- a/tests/unauthenticated/groupTest.js
+++ b/tests/unauthenticated/groupTest.js
@@ -1,6 +1,7 @@
 describe('Unauthenticated: Currently testing group management,', function () {
   var OwnCloud = require('../../src')
-  var config = require('../config/config.json')
+  const getMockServerBaseUrl = require('./pactHelper.js')
+  const mockServerBaseUrl = getMockServerBaseUrl()
 
   // CURRENT TIME
   var timeRightNow = new Date().getTime()
@@ -13,7 +14,7 @@ describe('Unauthenticated: Currently testing group management,', function () {
 
   beforeEach(function () {
     oc = new OwnCloud({
-      baseUrl: config.backendHost
+      baseUrl: mockServerBaseUrl
     })
   })
 

--- a/tests/unauthenticated/sharingTest.js
+++ b/tests/unauthenticated/sharingTest.js
@@ -2,8 +2,8 @@ describe('Unauthenticated: Currently testing file/folder sharing,', function () 
   // CURRENT TIME
   var timeRightNow = new Date().getTime()
   var OwnCloud = require('../../src')
-  var config = require('../config/config.json')
-
+  const getMockServerBaseUrl = require('./pactHelper.js')
+  const mockServerBaseUrl = getMockServerBaseUrl()
   // LIBRARY INSTANCE
   var oc
 
@@ -17,7 +17,7 @@ describe('Unauthenticated: Currently testing file/folder sharing,', function () 
 
   beforeEach(function () {
     oc = new OwnCloud({
-      baseUrl: config.backendHost
+      baseUrl: mockServerBaseUrl
     })
   })
 

--- a/tests/unauthenticated/sharingTest.js
+++ b/tests/unauthenticated/sharingTest.js
@@ -2,7 +2,7 @@ describe('Unauthenticated: Currently testing file/folder sharing,', function () 
   // CURRENT TIME
   var timeRightNow = new Date().getTime()
   var OwnCloud = require('../../src')
-  const getMockServerBaseUrl = require('./pactHelper.js')
+  const { getMockServerBaseUrl } = require('../pactHelper.js')
   const mockServerBaseUrl = getMockServerBaseUrl()
   // LIBRARY INSTANCE
   var oc

--- a/tests/unauthenticated/userTest.js
+++ b/tests/unauthenticated/userTest.js
@@ -3,6 +3,8 @@ describe('Unauthenticated: Currently testing user management,', function () {
   var timeRightNow = new Date().getTime()
   var OwnCloud = require('../../src')
   var config = require('../config/config.json')
+  const getMockServerBaseUrl = require('./pactHelper.js')
+  const mockServerBaseUrl = getMockServerBaseUrl()
 
   // LIBRARY INSTANCE
   var oc
@@ -15,7 +17,7 @@ describe('Unauthenticated: Currently testing user management,', function () {
 
   beforeEach(function () {
     oc = new OwnCloud({
-      baseUrl: config.backendHost
+      baseUrl: mockServerBaseUrl
     })
   })
 

--- a/tests/unauthenticated/userTest.js
+++ b/tests/unauthenticated/userTest.js
@@ -3,7 +3,7 @@ describe('Unauthenticated: Currently testing user management,', function () {
   var timeRightNow = new Date().getTime()
   var OwnCloud = require('../../src')
   var config = require('../config/config.json')
-  const getMockServerBaseUrl = require('./pactHelper.js')
+  const { getMockServerBaseUrl } = require('../pactHelper.js')
   const mockServerBaseUrl = getMockServerBaseUrl()
 
   // LIBRARY INSTANCE


### PR DESCRIPTION
Fixes https://github.com/owncloud/owncloud-sdk/issues/775

- [x] - Remove port from backendHost and rename it to pactMockHost
- [x] - Create new method `getMockServerBaseUrl` in pactHelper.js to get complete URL
- [x] - Remove `${SUB_FOLDER}` from drone config.json 