### PR TITLE
[tests-only] Make sharing and providerState helper functions modular/flexible

### DIFF
--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -1,5 +1,11 @@
 const config = require('../config/config.json')
 
+const SHARE_TYPE = Object.freeze({
+  user: 0,
+  group: 1,
+  public: 3
+})
+
 /**
  * provider state: creates a given user
  *
@@ -57,9 +63,7 @@ const givenFolderExists = (provider, username, password, resource) => {
  * @param {sring} userPassword
  * @param {sring} path
  * @param {string} shareWith
- * @param {number} permissions
- * @param {sring} expireDate
- * @param {object} attributes
+ * @param {object} optionalParams
  */
 const givenUserShareExists = (
   provider,
@@ -67,20 +71,16 @@ const givenUserShareExists = (
   userPassword,
   path,
   shareWith,
-  permissions,
-  expireDate,
-  attributes
+  optionalParams
 ) => {
   return provider
     .given('resource is shared', {
       username,
       userPassword,
       path,
-      shareType: 0,
+      shareType: SHARE_TYPE.user,
       shareWith,
-      permissions,
-      expireDate,
-      attributes
+      ...optionalParams
     })
 }
 
@@ -92,9 +92,7 @@ const givenUserShareExists = (
  * @param {sring} userPassword
  * @param {sring} path
  * @param {string} shareWith
- * @param {number} permissions
- * @param {sring} expireDate
- * @param {object} attributes
+ * @param {object} optionalParams
  */
 const givenGroupShareExists = (
   provider,
@@ -102,20 +100,16 @@ const givenGroupShareExists = (
   userPassword,
   path,
   shareWith,
-  permissions,
-  expireDate,
-  attributes
+  optionalParams
 ) => {
   return provider
     .given('resource is shared', {
       username,
       userPassword,
       path,
-      shareType: 1,
+      shareType: SHARE_TYPE.group,
       shareWith,
-      permissions,
-      expireDate,
-      attributes
+      ...optionalParams
     })
 }
 
@@ -126,34 +120,22 @@ const givenGroupShareExists = (
  * @param {string} username
  * @param {sring} userPassword
  * @param {sring} path
- * @param {boolean} publicUpload
- * @param {number} permissions
- * @param {sring} password public link share password
- * @param {sring} expireDate
- * @param {object} attributes
+ * @param {object} optionalParams
  */
 const givenPublicShareExists = (
   provider,
   username,
   userPassword,
   path,
-  permissions,
-  password,
-  publicUpload,
-  expireDate,
-  attributes
+  optionalParams
 ) => {
   return provider
     .given('resource is shared', {
       username,
       userPassword,
       path,
-      shareType: 3,
-      password,
-      permissions,
-      publicUpload,
-      expireDate,
-      attributes
+      shareType: SHARE_TYPE.public,
+      ...optionalParams
     })
 }
 
@@ -202,19 +184,21 @@ const givenResourceIsShared = async (
   password,
   publicUpload
 ) => {
-  if (shareType === 3) {
+  if (shareType === SHARE_TYPE.public) {
     return givenPublicShareExists(
       provider,
       username,
       userPassword,
       resource,
-      permissions,
-      password,
-      publicUpload,
-      expireDate,
-      attributes
+      {
+        permissions,
+        password,
+        publicUpload,
+        expireDate,
+        attributes
+      }
     )
-  } else if (shareType === 0) {
+  } else if (shareType === SHARE_TYPE.user) {
     await givenUserExists(provider, shareWith, config.testUser2Password)
     return givenUserShareExists(
       provider,
@@ -222,11 +206,13 @@ const givenResourceIsShared = async (
       userPassword,
       resource,
       shareWith,
-      permissions,
-      expireDate,
-      attributes
+      {
+        permissions,
+        expireDate,
+        attributes
+      }
     )
-  } else if (shareType === 1) {
+  } else if (shareType === SHARE_TYPE.group) {
     await givenGroupExists(provider, shareWith)
     return givenGroupShareExists(
       provider,
@@ -234,9 +220,11 @@ const givenResourceIsShared = async (
       userPassword,
       resource,
       shareWith,
-      permissions,
-      expireDate,
-      attributes
+      {
+        permissions,
+        expireDate,
+        attributes
+      }
     )
   }
 }

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -64,6 +64,10 @@ const givenFolderExists = (provider, username, password, resource) => {
  * @param {sring} path
  * @param {string} shareWith
  * @param {object} optionalParams
+ * available optional parameters
+ * - permissions
+ * - expireDate
+ * - attributes
  */
 const givenUserShareExists = (
   provider,
@@ -93,6 +97,10 @@ const givenUserShareExists = (
  * @param {sring} path
  * @param {string} shareWith
  * @param {object} optionalParams
+ * available optional parameters
+ * - permissions
+ * - expireDate
+ * - attributes
  */
 const givenGroupShareExists = (
   provider,
@@ -121,6 +129,13 @@ const givenGroupShareExists = (
  * @param {sring} userPassword
  * @param {sring} path
  * @param {object} optionalParams
+ * available optional parameters
+ * - name
+ * - password
+ * - permissions
+ * - publicUpload
+ * - expireDate
+ * - attributes
  */
 const givenPublicShareExists = (
   provider,
@@ -226,6 +241,8 @@ const givenResourceIsShared = async (
         attributes
       }
     )
+  } else {
+    throw new Error(`Invalid shareType "${shareType}`)
   }
 }
 

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -50,25 +50,111 @@ const givenFolderExists = (provider, username, password, resource) => {
 }
 
 /**
- * provider state: creates a share
+ * provider state: creates a user share
  *
  * @param {object} provider
  * @param {string} username
- * @param {sring} password
- * @param {sring} resource
- * @param {sring} shareType
- * @param {sring} shareWith
+ * @param {sring} userPassword
+ * @param {sring} path
+ * @param {string} shareWith
+ * @param {number} permissions
+ * @param {sring} expireDate
+ * @param {object} attributes
  */
-const givenShareExists = async (
+const givenUserShareExists = (
   provider,
   username,
-  password,
-  resource,
-  shareType,
-  shareWith
+  userPassword,
+  path,
+  shareWith,
+  permissions,
+  expireDate,
+  attributes
 ) => {
   return provider
-    .given('resource is shared', { username, password, resource, shareType, shareWith })
+    .given('resource is shared', {
+      username,
+      userPassword,
+      path,
+      shareType: 0,
+      shareWith,
+      permissions,
+      expireDate,
+      attributes
+    })
+}
+
+/**
+ * provider state: creates a group share
+ *
+ * @param {object} provider
+ * @param {string} username
+ * @param {sring} userPassword
+ * @param {sring} path
+ * @param {string} shareWith
+ * @param {number} permissions
+ * @param {sring} expireDate
+ * @param {object} attributes
+ */
+const givenGroupShareExists = (
+  provider,
+  username,
+  userPassword,
+  path,
+  shareWith,
+  permissions,
+  expireDate,
+  attributes
+) => {
+  return provider
+    .given('resource is shared', {
+      username,
+      userPassword,
+      path,
+      shareType: 1,
+      shareWith,
+      permissions,
+      expireDate,
+      attributes
+    })
+}
+
+/**
+ * provider state: creates a public link share
+ *
+ * @param {object} provider
+ * @param {string} username
+ * @param {sring} userPassword
+ * @param {sring} path
+ * @param {boolean} publicUpload
+ * @param {number} permissions
+ * @param {sring} password public link share password
+ * @param {sring} expireDate
+ * @param {object} attributes
+ */
+const givenPublicShareExists = (
+  provider,
+  username,
+  userPassword,
+  path,
+  permissions,
+  password,
+  publicUpload,
+  expireDate,
+  attributes
+) => {
+  return provider
+    .given('resource is shared', {
+      username,
+      userPassword,
+      path,
+      shareType: 3,
+      password,
+      permissions,
+      publicUpload,
+      expireDate,
+      attributes
+    })
 }
 
 /**
@@ -93,19 +179,65 @@ const givenFileFolderIsCreated = (provider, username, password, resource, resour
  *
  * @param {object} provider
  * @param {string} username
- * @param {sring} password
+ * @param {sring} userPassword
  * @param {sring} resource
- * @param {sring} shareType
+ * @param {number} shareType
+ * @param {sring} shareWith
+ * @param {number} permissions
+ * @param {string} expireDate
+ * @param {object} attributes
+ * @param {string} password
+ * @param {boolean} publicUpload
  */
-const givenResourceIsShared = async (provider, username, password, resource, shareType) => {
+const givenResourceIsShared = async (
+  provider,
+  username,
+  userPassword,
+  resource,
+  shareType,
+  shareWith,
+  permissions,
+  expireDate,
+  attributes,
+  password,
+  publicUpload
+) => {
   if (shareType === 3) {
-    return givenShareExists(provider, username, password, resource, shareType)
+    return givenPublicShareExists(
+      provider,
+      username,
+      userPassword,
+      resource,
+      permissions,
+      password,
+      publicUpload,
+      expireDate,
+      attributes
+    )
   } else if (shareType === 0) {
-    await givenUserExists(provider, config.testUser2, config.testUser2Password)
-    return givenShareExists(provider, username, password, resource, shareType, config.testUser2)
+    await givenUserExists(provider, shareWith, config.testUser2Password)
+    return givenUserShareExists(
+      provider,
+      username,
+      userPassword,
+      resource,
+      shareWith,
+      permissions,
+      expireDate,
+      attributes
+    )
   } else if (shareType === 1) {
-    await givenGroupExists(provider, config.testGroup)
-    return givenShareExists(provider, username, password, resource, shareType, config.testGroup)
+    await givenGroupExists(provider, shareWith)
+    return givenGroupShareExists(
+      provider,
+      username,
+      userPassword,
+      resource,
+      shareWith,
+      permissions,
+      expireDate,
+      attributes
+    )
   }
 }
 
@@ -114,7 +246,9 @@ module.exports = {
   givenGroupExists,
   givenFileExists,
   givenFolderExists,
-  givenShareExists,
+  givenUserShareExists,
+  givenGroupShareExists,
+  givenPublicShareExists,
   givenFileFolderIsCreated,
   givenResourceIsShared
 }

--- a/tests/helpers/sharingHelper.js
+++ b/tests/helpers/sharingHelper.js
@@ -32,37 +32,17 @@ const getPublicFilesEndPoint = function () {
  * share a file or folder using webDAV api.
  *
  * @param {string} username
- * @param {string} userPassword
- * @param {string} path
- * @param {number} shareType
- * @param {string} shareWith
- * @param {number} permissions
- * @param {string} name
- * @param {boolean} publicUpload
  * @param {string} password
- * @param {string} expireDate
+ * @param {object} shareParams
  * @returns {*} result of the fetch request
  */
-const shareResource = function (
-  username,
-  userPassword,
-  path,
-  shareType,
-  shareWith,
-  permissions,
-  name,
-  publicUpload,
-  password,
-  expireDate
-) {
-  const params = validateParams({
-    path, shareType, shareWith, permissions, name, publicUpload, password, expireDate
-  })
+const shareResource = function (username, password, shareParams) {
+  const params = validateParams(shareParams)
   return fetch(getSharingEndPoint() + '?format=json', {
     method: 'POST',
     body: params,
     headers: {
-      authorization: getAuthHeaders(username, userPassword),
+      authorization: getAuthHeaders(username, password),
       ...applicationFormUrlEncoded
     }
   })

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -265,14 +265,8 @@ describe('provider testing', () => {
     },
     'resource is shared': (setup, parameters) => {
       if (setup) {
-        const {
-          username,
-          password,
-          resource,
-          shareType,
-          shareWith
-        } = parameters
-        const response = shareResource(username, password, resource, shareType, shareWith, parameters.permissions)
+        const { username, userPassword, ...shareParams } = parameters
+        const response = shareResource(username, userPassword, shareParams)
 
         const {
           status,
@@ -290,12 +284,12 @@ describe('provider testing', () => {
           // status 'error' and statuscode '996' means file/folder has already been shared with user or group
           // oCIS issue: https://github.com/owncloud/ocis/issues/1710
           else if (status === 'error' && statuscode === 996 && message === 'grpc create share request failed') {
-            const res = getShareInfoByPath(username, password, resource)
+            const res = getShareInfoByPath(username, userPassword, parameters.path)
             const { token } = getOCSData(res)[0]
             lastSharedToken = token
             return getOCSData(res)[0]
           } else {
-            chai.assert.fail(`sharing file/folder '${parameters.resource}' failed`)
+            chai.assert.fail(`sharing file/folder '${parameters.path}' failed`)
           }
         } else {
           chai.assert.strictEqual(status, 'ok', `sharing file/folder '${parameters.resource}' failed`)

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -292,7 +292,7 @@ describe('provider testing', () => {
             chai.assert.fail(`sharing file/folder '${parameters.path}' failed`)
           }
         } else {
-          chai.assert.strictEqual(status, 'ok', `sharing file/folder '${parameters.resource}' failed`)
+          chai.assert.strictEqual(status, 'ok', `sharing file/folder '${parameters.path}' failed`)
           const { token } = getOCSData(response)
           lastSharedToken = token
           return getOCSData(response)

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -87,8 +87,8 @@ describe('oc.publicFiles', function () {
       })
       .given('resource is shared', {
         username: testUser,
-        password: testUserPassword,
-        resource: testFolder,
+        userPassword: testUserPassword,
+        path: testFolder,
         shareType: 3,
         permissions: 15
       })
@@ -137,8 +137,8 @@ describe('oc.publicFiles', function () {
       })
       .given('resource is shared', {
         username: testUser,
-        password: testUserPassword,
-        resource: testFolder,
+        userPassword: testUserPassword,
+        path: testFolder,
         shareType: 3,
         permissions: 15
       })
@@ -589,7 +589,7 @@ describe('oc.publicFiles', function () {
             .given('provider base url is returned')
             .given('the user is recreated', { username: testUser, password: testUserPassword })
             .given('folder exists', { username: testUser, password: testUserPassword, folderName: testFolder })
-            .given('resource is shared', { username: testUser, password: testUserPassword, resource: testFolder, shareType: 3, permissions: 15 })
+            .given('resource is shared', { username: testUser, userPassword: testUserPassword, path: testFolder, shareType: 3, permissions: 15 })
             .given('file exists in last shared public share', { fileName: testFile })
             .uponReceiving(`as '${testUser}', a MOVE request to move a file in public share ${data.description}`)
             .withRequest({
@@ -628,7 +628,7 @@ describe('oc.publicFiles', function () {
             .given('provider base url is returned')
             .given('the user is recreated', { username: testUser, password: testUserPassword })
             .given('folder exists', { username: testUser, password: testUserPassword, folderName: testFolder })
-            .given('resource is shared', { username: testUser, password: testUserPassword, resource: testFolder, shareType: 3, permissions: 15 })
+            .given('resource is shared', { username: testUser, userPassword: testUserPassword, path: testFolder, shareType: 3, permissions: 15 })
             .given('folder exists in last shared public share', { folderName: 'foo' })
             .given('file exists in last shared public share', { fileName: testFile })
             .uponReceiving(`as '${testUser}', a MOVE request to move a file to subfolder in public share ${data.description}`)
@@ -664,7 +664,7 @@ describe('oc.publicFiles', function () {
             .given('provider base url is returned')
             .given('the user is recreated', { username: testUser, password: testUserPassword })
             .given('folder exists', { username: testUser, password: testUserPassword, folderName: testFolder })
-            .given('resource is shared', { username: testUser, password: testUserPassword, resource: testFolder, shareType: 3, permissions: 15 })
+            .given('resource is shared', { username: testUser, userPassword: testUserPassword, path: testFolder, shareType: 3, permissions: 15 })
             .given('folder exists in last shared public share', { folderName: 'foo' })
             .uponReceiving(`as '${testUser}', a MOVE request to move a folder to different name in public share ${data.description}`)
             .withRequest({

--- a/tests/sharingTest.js
+++ b/tests/sharingTest.js
@@ -460,7 +460,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           const provider = createProvider(false, true)
           await getCapabilitiesInteraction(provider, sharer, sharerPassword)
           await getCurrentUserInformationInteraction(provider, sharer, sharerPassword)
-          await getShareInteraction(provider, '(group share)', 1, testFolder, testFolder, 'folder')
+          await getShareInteraction(provider, '(group share)', 1, testFolder, testGroup, 'folder')
           return provider.executeTest(async () => {
             const oc = createOwncloud(sharer, sharerPassword)
             await oc.login()
@@ -483,7 +483,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
             '(group share: set read/write permission)',
             0,
             testFolder,
-            testGroup,
+            sharee,
             'folder',
             formData
           )

--- a/tests/sharingTest.js
+++ b/tests/sharingTest.js
@@ -9,7 +9,9 @@ const {
 const {
   givenUserExists,
   givenGroupExists,
-  givenShareExists,
+  givenUserShareExists,
+  givenGroupShareExists,
+  givenPublicShareExists,
   givenFileFolderIsCreated,
   givenResourceIsShared
 } = require('./helpers/providerStateHelper')
@@ -66,12 +68,13 @@ describe('Main: Currently testing file/folder sharing,', function () {
     requestName,
     shareType,
     resource,
+    shareWith,
     resourceType = 'file'
   ) {
     const { shareId, shareToken } = getShareIdToken(resource, resourceType)
     await givenUserExists(provider, sharer, sharerPassword)
     await givenFileFolderIsCreated(provider, sharer, sharerPassword, resource, resourceType)
-    await givenResourceIsShared(provider, sharer, sharerPassword, resource, shareType)
+    await givenResourceIsShared(provider, sharer, sharerPassword, resource, shareType, shareWith)
 
     resource = '/' + resource
     const body = new XmlBuilder('1.0', '', 'ocs').build(ocs => {
@@ -111,9 +114,9 @@ describe('Main: Currently testing file/folder sharing,', function () {
     await givenUserExists(provider, sharee, shareePassword)
     await givenGroupExists(provider, testGroup)
     // shares file/folder with user, group and public link
-    await givenShareExists(provider, sharer, sharerPassword, resource, 3)
-    await givenShareExists(provider, sharer, sharerPassword, resource, 0, sharee)
-    await givenShareExists(provider, sharer, sharerPassword, resource, 1, testGroup)
+    await givenPublicShareExists(provider, sharer, sharerPassword, resource)
+    await givenUserShareExists(provider, sharer, sharerPassword, resource, sharee)
+    await givenGroupShareExists(provider, sharer, sharerPassword, resource, testGroup)
 
     resource = '/' + resource
     const body = new XmlBuilder('1.0', '', 'ocs').build(ocs => {
@@ -159,12 +162,13 @@ describe('Main: Currently testing file/folder sharing,', function () {
     requestName,
     shareType,
     resource,
+    shareWith,
     resourceType
   ) => {
     const { shareId, shareToken } = getShareIdToken(resource, resourceType)
     await givenUserExists(provider, sharer, sharerPassword)
     await givenFileFolderIsCreated(provider, sharer, sharerPassword, resource, resourceType)
-    await givenResourceIsShared(provider, sharer, sharerPassword, resource, shareType)
+    await givenResourceIsShared(provider, sharer, sharerPassword, resource, shareType, shareWith)
     resource = '/' + resource
 
     const body = new XmlBuilder('1.0', '', 'ocs').build(ocs => {
@@ -199,6 +203,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
     requestName,
     shareType,
     resource,
+    shareWith,
     resourceType,
     formData,
     additionalBodyElement
@@ -207,7 +212,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
     let permissions = 1
     await givenUserExists(provider, sharer, sharerPassword)
     await givenFileFolderIsCreated(provider, sharer, sharerPassword, resource, resourceType)
-    await givenResourceIsShared(provider, sharer, sharerPassword, resource, shareType)
+    await givenResourceIsShared(provider, sharer, sharerPassword, resource, shareType, shareWith)
 
     if (formData.permissions) {
       permissions = formData.permissions
@@ -262,6 +267,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
             `check whether '${testFolder}' is shared or not (public link share)`,
             3,
             testFolder,
+            null,
             'folder'
           )
 
@@ -280,7 +286,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           const provider = createProvider(false, true)
           await getCapabilitiesInteraction(provider, sharer, sharerPassword)
           await getCurrentUserInformationInteraction(provider, sharer, sharerPassword)
-          await getShareInteraction(provider, '(public link share)', 3, testFolder, 'folder')
+          await getShareInteraction(provider, '(public link share)', 3, testFolder, null, 'folder')
           return provider.executeTest(async () => {
             const oc = createOwncloud(sharer, sharerPassword)
             await oc.login()
@@ -303,6 +309,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
             '(public link share: enable publicUpload)',
             3,
             testFolder,
+            null,
             'folder',
             formData
           )
@@ -332,6 +339,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
             '(public link share: set share password)',
             3,
             testFolder,
+            null,
             'folder',
             formData,
             additionalBodyElement
@@ -362,6 +370,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
             `check whether '${testFolder}' is shared or not (user share)`,
             0,
             testFolder,
+            sharee,
             'folder'
           )
 
@@ -380,7 +389,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           const provider = createProvider(false, true)
           await getCapabilitiesInteraction(provider, sharer, sharerPassword)
           await getCurrentUserInformationInteraction(provider, sharer, sharerPassword)
-          await getShareInteraction(provider, '(user share)', 0, testFolder, 'folder')
+          await getShareInteraction(provider, '(user share)', 0, testFolder, sharee, 'folder')
           return provider.executeTest(async () => {
             const oc = createOwncloud(sharer, sharerPassword)
             await oc.login()
@@ -403,6 +412,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
             '(user share: set read/write permission)',
             0,
             testFolder,
+            sharee,
             'folder',
             formData
           )
@@ -431,6 +441,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
             `check whether '${testFolder}' is shared or not (group share)`,
             1,
             testFolder,
+            testGroup,
             'folder'
           )
 
@@ -449,7 +460,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           const provider = createProvider(false, true)
           await getCapabilitiesInteraction(provider, sharer, sharerPassword)
           await getCurrentUserInformationInteraction(provider, sharer, sharerPassword)
-          await getShareInteraction(provider, '(group share)', 1, testFolder, 'folder')
+          await getShareInteraction(provider, '(group share)', 1, testFolder, testFolder, 'folder')
           return provider.executeTest(async () => {
             const oc = createOwncloud(sharer, sharerPassword)
             await oc.login()
@@ -472,6 +483,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
             '(group share: set read/write permission)',
             0,
             testFolder,
+            testGroup,
             'folder',
             formData
           )
@@ -580,6 +592,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
               '(user share: set max permission)',
               0,
               testFiles[i],
+              sharee,
               '',
               formData
             )
@@ -607,7 +620,8 @@ describe('Main: Currently testing file/folder sharing,', function () {
               provider,
               `check whether '${file}' is shared or not (user share)`,
               0,
-              file
+              file,
+              sharee
             )
           }
           return provider.executeTest(async () => {
@@ -631,7 +645,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
             const provider = createProvider(false, true)
             await getCapabilitiesInteraction(provider, sharer, sharerPassword)
             await getCurrentUserInformationInteraction(provider, sharer, sharerPassword)
-            await getShareInteraction(provider, '(user share)', 0, testFiles[i])
+            await getShareInteraction(provider, '(user share)', 0, testFiles[i], sharee)
 
             return provider.executeTest(async () => {
               const oc = createOwncloud(sharer, sharerPassword)
@@ -658,7 +672,8 @@ describe('Main: Currently testing file/folder sharing,', function () {
             provider,
             `check whether '${file}' is shared or not (group share)`,
             1,
-            file
+            file,
+            testGroup
           )
         }
         return provider.executeTest(async () => {
@@ -682,7 +697,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           const provider = createProvider(false, true)
           await getCapabilitiesInteraction(provider, sharer, sharerPassword)
           await getCurrentUserInformationInteraction(provider, sharer, sharerPassword)
-          await getShareInteraction(provider, '(group share)', 1, testFiles[i])
+          await getShareInteraction(provider, '(group share)', 1, testFiles[i], testGroup)
 
           return provider.executeTest(async () => {
             const oc = createOwncloud(sharer, sharerPassword)


### PR DESCRIPTION
This PR refactors `sharingHelper` and `providerStateHelper` functions to be more flexible and modular
- each function for each share (user, group, public)
- includes possible share options

closes https://github.com/owncloud/owncloud-sdk/issues/786