### PR TITLE
switch to official redis

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -232,12 +232,9 @@ def databaseService():
 
 def redisService():
     return[{
-        'name': 'redis',
-        'image': 'webhippie/redis',
-        'pull': 'always',
-        'environment': {
-            'REDIS_DATABASES': 1
-        },
+      'name': 'redis',
+      'image': 'redis:6-alpine',
+      'pull': 'always',
     }]
 
 def pactConsumerTests(uploadPact):


### PR DESCRIPTION
## Description
switch to official Redis docker image in CI

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- None

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Use only maintained docker images
