### PR TITLE
Upgrade to GitHub-native Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "22:00"
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: eslint
+    versions:
+    - 7.18.0
+    - 7.19.0
+    - 7.20.0
+    - 7.21.0
+    - 7.22.0
+    - 7.23.0
+    - 7.24.0
+  - dependency-name: webpack-node-externals
+    versions:
+    - 2.5.2
+  - dependency-name: husky
+    versions:
+    - 4.3.8
+    - 5.0.9
+    - 5.1.1
+    - 5.1.2
+    - 5.1.3
+    - 5.2.0
+  - dependency-name: webpack-cli
+    versions:
+    - 4.4.0
+    - 4.5.0
+  - dependency-name: jasmine-core
+    versions:
+    - 3.6.0
+    - 3.7.0
+  - dependency-name: jasmine
+    versions:
+    - 3.6.4
+  - dependency-name: xmldom
+    versions:
+    - 0.4.0


### PR DESCRIPTION
This is the same `dependabot.yml` as in the dependabot PR #818 

That PR #818 has some trouble running CI. IMO it does not have access to the drone repo secrets, like `pactflow_token`, and so some CI failed.