### PR TITLE
Update axios version to 0.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "xml2js": "^0.4.23"
   },
   "dependencies": {
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "cross-fetch": "^3.0.6",
     "promise": "^8.0.3",
     "request": "^2.88.0",

--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -52,6 +52,14 @@ class helpers {
     return this.instance
   }
 
+  noAuth () {
+    axios.interceptors.request.use(config => {
+      config.extraReqParams = config.extraReqParams || {}
+      config.extraReqParams.dontUseDefaultAuth = true
+      return config
+    })
+  }
+
   /**
    * sets the username
    * @param   {string | null}    authHeader    authorization header; either basic or bearer or what ever
@@ -59,6 +67,10 @@ class helpers {
   setAuthorization (authHeader) {
     this._authHeader = authHeader
     axios.interceptors.request.use(config => {
+      if (config.extraReqParams && config.extraReqParams.dontUseDefaultAuth) {
+        delete config.extraReqParams.dontUseDefaultAuth
+        return config
+      }
       if (authHeader && authHeader.startsWith('Bearer ')) {
         config.headers.Authorization = authHeader
       }
@@ -295,7 +307,7 @@ class helpers {
     }
 
     const headers = {
-      authorization: this._authHeader,
+      Authorization: this._authHeader,
       'Content-Type': 'application/x-www-form-urlencoded'
     }
 

--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -61,8 +61,6 @@ class helpers {
     axios.interceptors.request.use(config => {
       if (authHeader && authHeader.startsWith('Bearer ')) {
         config.headers.Authorization = authHeader
-      } else {
-        config.headers.Authorization = undefined
       }
       return config
     })
@@ -175,7 +173,7 @@ class helpers {
     const headers = Object.assign({}, this._headers)
     headers['OCS-APIREQUEST'] = 'true'
     if (withAuthHeader) {
-      headers.authorization = this._authHeader
+      headers.Authorization = this._authHeader
     }
     if (this.atLeastVersion('10.1.0')) {
       headers['X-Request-ID'] = uuidv4()

--- a/src/publicLinkAccess.js
+++ b/src/publicLinkAccess.js
@@ -38,8 +38,11 @@ class PublicFiles {
     const headers = this.helpers.buildHeaders(false)
     const url = this.getFileSharePath(tokenAndPath)
 
+    // Dont use default bearer token for public links in web
+    // this will lead to the link not being accessible
+    this.helpers.noAuth()
     if (password) {
-      headers.authorization = 'Basic ' + Buffer.from('public:' + password).toString('base64')
+      headers.Authorization = 'Basic ' + Buffer.from('public:' + password).toString('base64')
     }
 
     if (properties.length === 0) {
@@ -74,7 +77,7 @@ class PublicFiles {
     const url = this.getFileUrl(token, path)
 
     if (password) {
-      headers.authorization = 'Basic ' + Buffer.from('public:' + password).toString('base64')
+      headers.Authorization = 'Basic ' + Buffer.from('public:' + password).toString('base64')
     }
     const init = {
       method: 'GET',
@@ -141,7 +144,7 @@ class PublicFiles {
     const url = this.getFileSharePath(token, path)
 
     if (password) {
-      headers.authorization = 'Basic ' + Buffer.from('public:' + password).toString('base64')
+      headers.Authorization = 'Basic ' + Buffer.from('public:' + password).toString('base64')
     }
 
     return this.davClient.request('MKCOL', url, headers, null, { version: 'v2' }).then(result => {
@@ -165,7 +168,7 @@ class PublicFiles {
     const url = this.getFileSharePath(token, path)
 
     if (password) {
-      headers.authorization = 'Basic ' + Buffer.from('public:' + password).toString('base64')
+      headers.Authorization = 'Basic ' + Buffer.from('public:' + password).toString('base64')
     }
 
     return this.davClient.request('DELETE', url, headers, null, { version: 'v2' }).then(result => {
@@ -196,7 +199,7 @@ class PublicFiles {
     const url = this.getFileSharePath(token, path)
 
     if (password) {
-      headers.authorization = 'Basic ' + Buffer.from('public:' + password).toString('base64')
+      headers.Authorization = 'Basic ' + Buffer.from('public:' + password).toString('base64')
     }
     const previousEntityTag = options.previousEntityTag || false
     if (previousEntityTag) {
@@ -237,7 +240,7 @@ class PublicFiles {
     const targetUrl = this.getFileUrl(target)
 
     if (password) {
-      headers.authorization = 'Basic ' + Buffer.from('public:' + password).toString('base64')
+      headers.Authorization = 'Basic ' + Buffer.from('public:' + password).toString('base64')
     }
     headers.Destination = targetUrl
     return this.davClient.request('MOVE', sourceUrl, headers, null, { version: 'v2' }).then(result => {
@@ -262,7 +265,7 @@ class PublicFiles {
     const targetUrl = this.getFileUrl(target)
 
     if (password) {
-      headers.authorization = 'Basic ' + Buffer.from('public:' + password).toString('base64')
+      headers.Authorization = 'Basic ' + Buffer.from('public:' + password).toString('base64')
     }
     headers.Destination = targetUrl
     return this.davClient.request('COPY', sourceUrl, headers, null, { version: 'v2' }).then(result => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1875,13 +1875,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-  dependencies:
-    follow-redirects "1.5.10"
-
 axios@^0.21.1:
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
@@ -3006,13 +2999,6 @@ debug@4.2.0:
   dependencies:
     ms "2.1.2"
 
-debug@=3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
 debug@^3.2.6:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
@@ -4025,13 +4011,6 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
-
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
 
 follow-redirects@^1.0.0:
   version "1.13.1"


### PR DESCRIPTION
update axios version to 0.21.1

Fix related issues with the new version
- After updating the webdav client in https://github.com/owncloud/owncloud-sdk/pull/735 (which also uses Axios in the backend), the request interceptor which was already in place (to add the authtoken in every request) also kicks in for the dav requests.
 While this is ok for regular file operations, in public link, this creates a problem since public link uses different form of auth ( eg. public:password). That was fixed in this PR

- The auth headers were added in two different forms (`authorization` and `Authorization`). Because of this, after the request interceptor adds new header the actual header sent were in the form `Authorization: Bearer <token>, Bearer <token>`
  This pr changes all auth headers to `Authorization`

- Remove `Authorization: undefined` from the interceptor as axios throws error when it's set.
