### PR TITLE
Bump pact-js to 10.0.0-beta.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
     "@babel/runtime": "^7.4.4",
-    "@pact-foundation/pact": "10.0.0-beta.33",
+    "@pact-foundation/pact": "10.0.0-beta.36",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.0.5",
     "chai": "^4.2.0",

--- a/tests/appsTest.js
+++ b/tests/appsTest.js
@@ -25,8 +25,8 @@ describe('Main: Currently testing apps management,', function () {
       body = new XmlBuilder('1.0', '', 'ocs').build(ocs => {
         ocs.appendElement('meta', '', (meta) => {
           meta
-            .appendElement('status', '', 'ok')
-            .appendElement('statuscode', '', 100)
+            .appendElement('status', '', MatchersV3.equal('ok'))
+            .appendElement('statuscode', '', MatchersV3.equal(100))
             .appendElement('message', '', '')
         }).appendElement('data', '', '')
       })
@@ -66,8 +66,8 @@ describe('Main: Currently testing apps management,', function () {
         body: new XmlBuilder('1.0', '', 'ocs').build(ocs => {
           ocs.appendElement('meta', '', (meta) => {
             meta
-              .appendElement('status', '', 'ok')
-              .appendElement('statuscode', '', 100)
+              .appendElement('status', '', MatchersV3.equal('ok'))
+              .appendElement('statuscode', '', MatchersV3.equal(100))
               .appendElement('message', '', '')
           }).appendElement('data', '', (data) => {
             data.appendElement('apps', '', (apps) => {

--- a/tests/capabilitiesTest.js
+++ b/tests/capabilitiesTest.js
@@ -32,8 +32,8 @@ describe('Main: Currently testing getConfig, getVersion and getCapabilities', ()
         headers: xmlResponseHeaders,
         body: new XmlBuilder('1.0', '', 'ocs').build(ocs => {
           ocs.appendElement('meta', '', (meta) => {
-            meta.appendElement('status', '', 'ok')
-              .appendElement('statuscode', '', '100')
+            meta.appendElement('status', '', MatchersV3.equal('ok'))
+              .appendElement('statuscode', '', MatchersV3.equal('100'))
           }).appendElement('data', '', (data) => {
             data.appendElement('version', '', MatchersV3.decimal(1.7))
           })

--- a/tests/fileTrashTest.js
+++ b/tests/fileTrashTest.js
@@ -69,7 +69,7 @@ describe('oc.fileTrash', function () {
           'xmlns:oc': 'http://owncloud.org/ns'
         })
         const body = dMultistatus.appendElement('d:response', '', dResponse => {
-          dResponse.appendElement('d:href', '', '/remote.php/dav/trash-bin/' + testUser + '/')
+          dResponse.appendElement('d:href', '', MatchersV3.equal('/remote.php/dav/trash-bin/' + testUser + '/'))
             .appendElement('d:propstat', '', dPropstat => {
               dPropstat.appendElement('d:prop', '', dProp => {
                 dProp
@@ -77,7 +77,7 @@ describe('oc.fileTrash', function () {
                     dResourceType.appendElement('d:collection', '', '')
                   })
               })
-                .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
             }).appendElement('d:propstat', '', dPropstat => {
               dPropstat.appendElement('d:prop', '', dProp => {
                 dProp
@@ -86,7 +86,7 @@ describe('oc.fileTrash', function () {
                   .appendElement('oc:trashbin-delete-timestamp', '', '')
                   .appendElement('d:getcontentlength', '', '')
               })
-                .appendElement('d:status', '', 'HTTP/1.1 404 Not Found')
+                .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 404 Not Found'))
             })
         })
         if (extraBody) {
@@ -106,20 +106,20 @@ describe('oc.fileTrash', function () {
           .appendElement('d:propstat', '', dPropstat => {
             dPropstat.appendElement('d:prop', '', dProp => {
               dProp
-                .appendElement('oc:trashbin-original-filename', '', 'testFolder')
-                .appendElement('oc:trashbin-original-location', '', 'testFolder')
+                .appendElement('oc:trashbin-original-filename', '', MatchersV3.equal('testFolder'))
+                .appendElement('oc:trashbin-original-location', '', MatchersV3.equal('testFolder'))
                 .appendElement('oc:trashbin-delete-timestamp', '', MatchersV3.regex('\\d+', '1615955759'))
                 .appendElement('d:resourcetype', '', dResourceType => {
                   dResourceType.appendElement('d:collection', '', '')
                 })
             })
-              .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+              .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
           }).appendElement('d:propstat', '', dPropstat => {
             dPropstat.appendElement('d:prop', '', dProp => {
               dProp
                 .appendElement('d:getcontentlength', '', '')
             })
-              .appendElement('d:status', '', 'HTTP/1.1 404 Not Found')
+              .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 404 Not Found'))
           })
       })
     }
@@ -275,18 +275,18 @@ describe('oc.fileTrash', function () {
                   .appendElement('d:propstat', '', dPropstat => {
                     dPropstat.appendElement('d:prop', '', dProp => {
                       dProp
-                        .appendElement('oc:trashbin-original-filename', '', 'testFolder')
-                        .appendElement('oc:trashbin-original-location', '', 'testFolder')
+                        .appendElement('oc:trashbin-original-filename', '', MatchersV3.equal('testFolder'))
+                        .appendElement('oc:trashbin-original-location', '', MatchersV3.equal('testFolder'))
                         .appendElement('oc:trashbin-delete-timestamp', '', MatchersV3.regex('\\d+', '1615955759'))
                         .appendElement('d:resourcetype', '', dResourceType => {
                           dResourceType.appendElement('d:collection', '', '')
                         })
                     })
-                      .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                      .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                   }).appendElement('d:propstat', '', dPropstat => {
                     dPropstat.appendElement('d:prop', '', dProp => {
                       dProp.appendElement('d:getcontentlength')
-                    }).appendElement('d:status', '', 'HTTP/1.1 404 Not Found')
+                    }).appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 404 Not Found'))
                   })
               })
               dMultistatus.appendElement('d:response', '', dResponse => {
@@ -297,13 +297,13 @@ describe('oc.fileTrash', function () {
                   .appendElement('d:propstat', '', dPropstat => {
                     dPropstat.appendElement('d:prop', '', dProp => {
                       dProp
-                        .appendElement('oc:trashbin-original-filename', '', 'testFile.txt')
-                        .appendElement('oc:trashbin-original-location', '', 'testFolder/testFile.txt')
+                        .appendElement('oc:trashbin-original-filename', '', MatchersV3.equal('testFile.txt'))
+                        .appendElement('oc:trashbin-original-location', '', MatchersV3.equal('testFolder/testFile.txt'))
                         .appendElement('oc:trashbin-delete-timestamp', '', MatchersV3.regex('\\d+', '1615955759'))
-                        .appendElement('d:getcontentlength', '', '6')
+                        .appendElement('d:getcontentlength', '', MatchersV3.equal('6'))
                         .appendElement('d:resourcetype', '', '')
                     })
-                      .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                      .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                   })
               })
             })
@@ -436,7 +436,7 @@ describe('oc.fileTrash', function () {
                 'xmlns:oc': 'http://owncloud.org/ns'
               })
               dMultistatus.appendElement('d:response', '', dResponse => {
-                dResponse.appendElement('d:href', '', `/remote.php/webdav/${testFolder}/`)
+                dResponse.appendElement('d:href', '', MatchersV3.equal(`/remote.php/webdav/${testFolder}/`))
                   .appendElement('d:propstat', '', dPropstat => {
                     dPropstat.appendElement('d:prop', '', dProp => {
                       dProp
@@ -444,11 +444,11 @@ describe('oc.fileTrash', function () {
                         .appendElement('d:resourcetype', '', dResourceType => {
                           dResourceType.appendElement('d:collection', '', '')
                         })
-                        .appendElement('d:quota-used-bytes', '', '6')
-                        .appendElement('d:quota-available-bytes', '', '-3')
+                        .appendElement('d:quota-used-bytes', '', MatchersV3.equal('6'))
+                        .appendElement('d:quota-available-bytes', '', MatchersV3.equal('-3'))
                         .appendElement('d:getetag', '', MatchersV3.regex('[a-f0-9]+', '5f7ae781e8073'))
                     })
-                      .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                      .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                   })
               })
             })
@@ -570,7 +570,7 @@ describe('oc.fileTrash', function () {
                 'xmlns:oc': 'http://owncloud.org/ns'
               })
               dMultistatus.appendElement('d:response', '', dResponse => {
-                dResponse.appendElement('d:href', '', '/remote.php/webdav/' + testFolder + encodeURIComponent(suffix) + '/')
+                dResponse.appendElement('d:href', '', MatchersV3.equal('/remote.php/webdav/' + testFolder + encodeURIComponent(suffix) + '/'))
                   .appendElement('d:propstat', '', dPropstat => {
                     dPropstat.appendElement('d:prop', '', dProp => {
                       dProp
@@ -578,11 +578,11 @@ describe('oc.fileTrash', function () {
                         .appendElement('d:resourcetype', '', dResourceType => {
                           dResourceType.appendElement('d:collection', '', '')
                         })
-                        .appendElement('d:quota-used-bytes', '', '0')
-                        .appendElement('d:quota-available-bytes', '', '-3')
+                        .appendElement('d:quota-used-bytes', '', MatchersV3.equal('0'))
+                        .appendElement('d:quota-available-bytes', '', MatchersV3.equal('-3'))
                         .appendElement('d:getetag', '', MatchersV3.regex('[a-f0-9]', '5f7c5fdc06e47'))
                     })
-                      .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                      .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                   })
               })
             })
@@ -658,7 +658,7 @@ describe('oc.fileTrash', function () {
                 'xmlns:oc': 'http://owncloud.org/ns'
               })
               dMultistatus.appendElement('d:response', '', dResponse => {
-                dResponse.appendElement('d:href', '', '/remote.php/dav/trash-bin/' + testUser + '/')
+                dResponse.appendElement('d:href', '', MatchersV3.equal('/remote.php/dav/trash-bin/' + testUser + '/'))
                   .appendElement('d:propstat', '', dPropstat => {
                     dPropstat.appendElement('d:prop', '', dProp => {
                       dProp
@@ -666,7 +666,7 @@ describe('oc.fileTrash', function () {
                           dResourceType.appendElement('d:collection', '', '')
                         })
                     })
-                      .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                      .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                   }).appendElement('d:propstat', '', dPropstat => {
                     dPropstat.appendElement('d:prop', '', dProp => {
                       dProp
@@ -675,7 +675,7 @@ describe('oc.fileTrash', function () {
                         .appendElement('oc:trashbin-delete-timestamp', '', '')
                         .appendElement('d:getcontentlength', '', '')
                     })
-                      .appendElement('d:status', '', 'HTTP/1.1 404 Not Found')
+                      .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 404 Not Found'))
                   })
               }).appendElement('d:response', '', dResponse => {
                 dResponse.appendElement('d:href', '', MatchersV3.regex(
@@ -685,13 +685,13 @@ describe('oc.fileTrash', function () {
                   .appendElement('d:propstat', '', dPropstat => {
                     dPropstat.appendElement('d:prop', '', dProp => {
                       dProp
-                        .appendElement('oc:trashbin-original-filename', '', testFile)
-                        .appendElement('oc:trashbin-original-location', '', testFolder + '/' + testFile)
-                        .appendElement('oc:trashbin-delete-timestamp', '', MatchersV3.regex('d+', '5f7c5fdc06e47'))
-                        .appendElement('d:getcontentlength', '', '6')
+                        .appendElement('oc:trashbin-original-filename', '', MatchersV3.equal(testFile))
+                        .appendElement('oc:trashbin-original-location', '', MatchersV3.equal(testFolder + '/' + testFile))
+                        .appendElement('oc:trashbin-delete-timestamp', '', MatchersV3.equal(MatchersV3.regex('d+', '5f7c5fdc06e47')))
+                        .appendElement('d:getcontentlength', '', MatchersV3.equal('6'))
                         .appendElement('d:resourcetype', '', '')
                     })
-                      .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                      .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                   })
               })
             })
@@ -798,7 +798,7 @@ describe('oc.fileTrash', function () {
                 'xmlns:oc': 'http://owncloud.org/ns'
               })
               dMultistatus.appendElement('d:response', '', dResponse => {
-                dResponse.appendElement('d:href', '', '/remote.php/webdav/' + testFolder + '/')
+                dResponse.appendElement('d:href', '', MatchersV3.equal('/remote.php/webdav/' + testFolder + '/'))
                   .appendElement('d:propstat', '', dPropstat => {
                     dPropstat.appendElement('d:prop', '', dProp => {
                       dProp
@@ -806,11 +806,11 @@ describe('oc.fileTrash', function () {
                         .appendElement('d:resourcetype', '', dResourceType => {
                           dResourceType.appendElement('d:collection', '', '')
                         })
-                        .appendElement('d:quota-used-bytes', '', '6')
-                        .appendElement('d:quota-available-bytes', '', '-3')
+                        .appendElement('d:quota-used-bytes', '', MatchersV3.equal('6'))
+                        .appendElement('d:quota-available-bytes', '', MatchersV3.equal('-3'))
                         .appendElement('d:getetag', '', MatchersV3.regex('[a-f0-9]+', '5f7c5fdc06e47'))
                     })
-                      .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                      .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                   })
               })
             })
@@ -935,7 +935,7 @@ describe('oc.fileTrash', function () {
                 'xmlns:oc': 'http://owncloud.org/ns'
               })
               dMultistatus.appendElement('d:response', '', dResponse => {
-                dResponse.appendElement('d:href', '', '/remote.php/webdav/file%20(restored%20to%20a%20different%20location).txt')
+                dResponse.appendElement('d:href', '', MatchersV3.equal('/remote.php/webdav/file%20(restored%20to%20a%20different%20location).txt'))
                   .appendElement('d:propstat', '', dPropstat => {
                     dPropstat.appendElement('d:prop', '', dProp => {
                       dProp
@@ -943,7 +943,7 @@ describe('oc.fileTrash', function () {
                         .appendElement('d:resourcetype', '', '')
                         .appendElement('d:getetag', '', MatchersV3.regex('[a-f0-9]+', '5f7c5fdc06e47'))
                     })
-                      .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                      .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                   })
               })
             })

--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -49,18 +49,18 @@ describe('Main: Currently testing file versions management,', function () {
           dPropstat.appendElement('d:prop', '', dProp => {
             dProp
               .appendElement('d:getlastmodified', '', MatchersV3.date('E, dd MM yyyy HH:mm:ss Z', 'Thu, 08 Oct 2020 02:28:50 GMT'))
-              .appendElement('d:getcontentlength', '', contentLength)
-              .appendElement('d:resourcetype', '', '')
+              .appendElement('d:getcontentlength', '', MatchersV3.equal(contentLength))
+              .appendElement('d:resourcetype', '', MatchersV3.equal(''))
               .appendElement('d:getetag', '', MatchersV3.string('&quot;bc7012325dcc9899be7da7cabfdddb00&quot;'))
-              .appendElement('d:getcontenttype', '', 'text/plain')
+              .appendElement('d:getcontenttype', '', MatchersV3.equal('text/plain'))
           })
-            .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+            .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
         }).appendElement('d:propstat', '', dPropstat => {
           dPropstat.appendElement('d:prop', '', dProp => {
             dProp
               .appendElement('d:quota-used-bytes', '', '')
               .appendElement('d:quota-available-bytes', '', '')
-          }).appendElement('d:status', '', 'HTTP/1.1 404 Not Found')
+          }).appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 404 Not Found'))
         })
     })
   }
@@ -93,7 +93,7 @@ describe('Main: Currently testing file versions management,', function () {
           headers: applicationXmlResponseHeaders,
           body: new XmlBuilder('1.0', 'utf-8', 'd:error').build(dError => {
             dError.setAttributes({ 'xmlns:d': 'DAV:', 'xmlns:s': 'http://sabredav.org/ns' })
-            dError.appendElement('s:exception', '', 'Sabre\\DAV\\Exception\\NotFound')
+            dError.appendElement('s:exception', '', MatchersV3.equal('Sabre\\DAV\\Exception\\NotFound'))
               .appendElement('s:message', '', '')
           })
         })
@@ -174,7 +174,7 @@ describe('Main: Currently testing file versions management,', function () {
                         dResourceType.appendElement('d:collection', '', '')
                       })
                   })
-                    .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                    .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                 })
             })
             propfindFileVersionsResponse(node, 1, 14)

--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -90,7 +90,7 @@ describe('Main: Currently testing files management,', function () {
                         )
                       )
                   })
-                    .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                    .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                 })
             })
           listFolderContentResponse(items).map(item => {
@@ -170,7 +170,7 @@ describe('Main: Currently testing files management,', function () {
                   )
               }
             })
-              .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+              .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
           })
       })
     }
@@ -192,7 +192,7 @@ describe('Main: Currently testing files management,', function () {
           dPropUpdate.setAttributes({ 'xmlns:d': 'DAV:', 'xmlns:oc': 'http://owncloud.org/ns' })
           dPropUpdate.appendElement('d:set', '', dSet => {
             dSet.appendElement('d:prop', '', dProp => {
-              dProp.appendElement('oc:favorite', '', '' + value)
+              dProp.appendElement('oc:favorite', '', MatchersV3.equal('' + value))
             })
           })
         })
@@ -210,7 +210,7 @@ describe('Main: Currently testing files management,', function () {
                   dPropstat.appendElement('d:prop', '', dProp => {
                     dProp.appendElement('oc:favorite', '', '')
                   })
-                    .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                    .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                 })
             })
         })
@@ -916,9 +916,9 @@ describe('Main: Currently testing files management,', function () {
               )
                 .appendElement('d:propstat', '', dPropstat => {
                   dPropstat.appendElement('d:prop', '', dProp => {
-                    dProp.appendElement('oc:meta-path-for-user', '', `/${file}`)
+                    dProp.appendElement('oc:meta-path-for-user', '', MatchersV3.equal(`/${file}`))
                   })
-                    .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                    .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                 })
             })
           })
@@ -981,7 +981,7 @@ describe('Main: Currently testing files management,', function () {
                   dPropstat.appendElement('d:prop', '', dProp => {
                     dProp.appendElement('oc:fileid', '', MatchersV3.string('123456789'))
                   })
-                    .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                    .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                 })
             })
           })
@@ -1063,7 +1063,7 @@ describe('Main: Currently testing files management,', function () {
                       )
                     )
                   })
-                    .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                    .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                 })
             }).appendElement('d:response', '', dResponse => {
               dResponse.appendElement('d:href', '',
@@ -1078,7 +1078,7 @@ describe('Main: Currently testing files management,', function () {
                       MatchersV3.regex('text\\/plain(; charset=utf-8)?', 'text/plain')
                     )
                   })
-                    .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                    .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                 })
             })
           })
@@ -1394,7 +1394,7 @@ describe('Main: Currently testing files management,', function () {
             ocFilterFiles.appendElement('d:prop', '', dProp => {
               dProp.appendElement('oc:favorite', '', '')
             }).appendElement('oc:filter-rules', '', ocFilterRules => {
-              ocFilterRules.appendElement('oc:favorite', '', '1')
+              ocFilterRules.appendElement('oc:favorite', '', MatchersV3.equal('1'))
             })
           })
         })
@@ -1415,9 +1415,9 @@ describe('Main: Currently testing files management,', function () {
               )
                 .appendElement('d:propstat', '', dPropstat => {
                   dPropstat.appendElement('d:prop', '', dProp => {
-                    dProp.appendElement('oc:favorite', '', '1')
+                    dProp.appendElement('oc:favorite', '', MatchersV3.equal('1'))
                   })
-                    .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                    .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                 })
             })
           })
@@ -1463,7 +1463,7 @@ describe('Main: Currently testing files management,', function () {
             ocFilterFiles.appendElement('d:prop', '', dProp => {
               dProp.appendElement('oc:favorite', '', '')
             }).appendElement('oc:filter-rules', '', ocFilterRules => {
-              ocFilterRules.appendElement('oc:favorite', '', '1')
+              ocFilterRules.appendElement('oc:favorite', '', MatchersV3.equal('1'))
             })
           })
         })
@@ -1533,8 +1533,8 @@ describe('Main: Currently testing files management,', function () {
                 .appendElement('d:getlastmodified', '', '')
                 .appendElement('d:resourcetype', '', '')
             }).appendElement('oc:search', '', ocSearch => {
-              ocSearch.appendElement('oc:pattern', '', 'abc')
-                .appendElement('oc:limit', '', 30)
+              ocSearch.appendElement('oc:pattern', '', MatchersV3.equal('abc'))
+                .appendElement('oc:limit', '', MatchersV3.equal(30))
             })
           })
         })
@@ -1557,15 +1557,15 @@ describe('Main: Currently testing files management,', function () {
                 .appendElement('d:propstat', '', dPropstat => {
                   dPropstat.appendElement('d:prop', '', dProp => {
                     dProp
-                      .appendElement('oc:favorite', '', '0')
-                      .appendElement('d:getcontentlength', '', '6')
-                      .appendElement('oc:size', '', '6')
+                      .appendElement('oc:favorite', '', MatchersV3.equal('0'))
+                      .appendElement('d:getcontentlength', '', MatchersV3.equal('6'))
+                      .appendElement('oc:size', '', MatchersV3.equal('6'))
                       .appendElement('d:getlastmodified', '',
                         MatchersV3.date('EEE, d MMM yyyy HH:mm:ss z', 'Wed, 21 Oct 2020 11:20:54 GMT')
                       )
                       .appendElement('d:resourcetype', '', '')
                   })
-                    .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                    .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                 })
             })
           })
@@ -1609,9 +1609,9 @@ describe('Main: Currently testing files management,', function () {
                 .appendElement('d:propstat', '', dPropstat => {
                   dPropstat.appendElement('d:prop', '', dProp => {
                     dProp
-                      .appendElement('oc:fileid', '', fileId)
+                      .appendElement('oc:fileid', '', MatchersV3.equal(fileId))
                   })
-                    .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                    .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
                 })
             })
           })

--- a/tests/groupTest.js
+++ b/tests/groupTest.js
@@ -39,9 +39,9 @@ describe('Main: Currently testing group management,', function () {
               // TODO: adjust the following after the issue is resolved
               // https://github.com/pact-foundation/pact-js/issues/619
               data.appendElement('groups', '', (groups) => {
-                groups.appendElement('element', '', config.adminUsername)
+                groups.appendElement('element', '', MatchersV3.string(config.adminUsername))
                   .eachLike('element', '', group => {
-                    group.appendText(config.testGroup)
+                    group.appendText(MatchersV3.string(config.testGroup))
                   })
               })
             })
@@ -156,7 +156,7 @@ describe('Main: Currently testing group management,', function () {
             // https://github.com/pact-foundation/pact-js/issues/619
             data.appendElement('users', '', (users) => {
               users.eachLike('element', '', user => {
-                user.appendText(config.testUser)
+                user.appendText(MatchersV3.equal(config.testUser))
               })
             })
           })

--- a/tests/helpers/pactHelper.js
+++ b/tests/helpers/pactHelper.js
@@ -25,6 +25,13 @@ const encodeURIPath = function (path) {
   return encodeURIComponent(path).split('%2F').join('/')
 }
 
+const getMatchers = function (element) {
+  if (typeof element === 'string' || typeof element === 'number') {
+    return MatchersV3.equal(element)
+  } else {
+    return element
+  }
+}
 /**
  *
  * @param meta {XmlElement}
@@ -34,21 +41,21 @@ const encodeURIPath = function (path) {
  * @returns {string}
  */
 const ocsMeta = function (meta, status, statusCode, Message = null) {
-  return meta.appendElement('status', '', status)
-    .appendElement('statuscode', '', statusCode)
-    .appendElement('message', '', Message)
+  return meta.appendElement('status', '', getMatchers(status))
+    .appendElement('statuscode', '', getMatchers(statusCode))
+    .appendElement('message', '', getMatchers(Message))
 }
 
 const shareResponseOcsData = function (node, shareType, id, permissions, fileTarget) {
   const res = node.appendElement('id', '', MatchersV3.string(id))
-    .appendElement('share_type', '', shareType.toString())
+    .appendElement('share_type', '', MatchersV3.equal(shareType.toString()))
     .appendElement('uid_owner', '', MatchersV3.string(config.adminUsername))
     .appendElement('displayname_owner', '', MatchersV3.string(config.adminUsername))
     .appendElement('permissions', '', MatchersV3.number(permissions))
     .appendElement('uid_file_owner', '', MatchersV3.string(config.adminUsername))
     .appendElement('displayname_file_owner', '', MatchersV3.string(config.adminUsername))
-    .appendElement('path', '', fileTarget)
-    .appendElement('file_target', '', fileTarget)
+    .appendElement('path', '', MatchersV3.equal(fileTarget))
+    .appendElement('file_target', '', MatchersV3.equal(fileTarget))
     .appendElement('stime', '', MatchersV3.string(Math.floor(Date.now() / 1000)))
 
   if (shareType === 3) {
@@ -108,8 +115,8 @@ const webdavExceptionResponseBody = (exception, message) => new XmlBuilder('1.0'
   .build(dError => {
     dError.setAttributes({ 'xmlns:d': 'DAV:', 'xmlns:s': 'http://sabredav.org/ns' })
     dError
-      .appendElement('s:exception', '', `Sabre\\DAV\\Exception\\${exception}`)
-      .appendElement('s:message', '', message)
+      .appendElement('s:exception', '', MatchersV3.equal(`Sabre\\DAV\\Exception\\${exception}`))
+      .appendElement('s:message', '', MatchersV3.equal(message))
   })
 
 const webdavPath = (resource) => {
@@ -215,8 +222,8 @@ const deleteResourceInteraction = (
       headers: xmlResponseHeaders,
       body: new XmlBuilder('1.0', '', 'ocs').build(ocs => {
         ocs.appendElement('meta', '', (meta) => {
-          ocsMeta(meta, 'ok', '100')
-        }).appendElement('data', '', '')
+          ocsMeta(meta, 'ok', MatchersV3.equal('100'))
+        }).appendElement('data', '', MatchersV3.equal(''))
       })
     }
   } else {
@@ -259,11 +266,11 @@ async function getCurrentUserInformationInteraction (
       headers: applicationXmlResponseHeaders,
       body: new XmlBuilder('1.0', '', 'ocs').build(ocs => {
         ocs.appendElement('meta', '', (meta) => {
-          meta.appendElement('status', '', 'ok')
-            .appendElement('statuscode', '', '100')
-            .appendElement('message', '', 'OK')
+          meta.appendElement('status', '', MatchersV3.equal('ok'))
+            .appendElement('statuscode', '', MatchersV3.equal('100'))
+            .appendElement('message', '', MatchersV3.equal('OK'))
         }).appendElement('data', '', (data) => {
-          data.appendElement('id', '', user)
+          data.appendElement('id', '', MatchersV3.equal(user))
           data.appendElement('display-name', '', MatchersV3.regex(`(${user}|${displayName})`, user))
           data.appendElement('email', '', MatchersV3.regex(`(${user}@example\\..*)?`, ''))
         })
@@ -410,7 +417,7 @@ const createUserWithGroupMembershipInteraction = function (provider) {
         .build(ocs => {
           ocs.appendElement('meta', '', (meta) => {
             return ocsMeta(meta, 'ok', '100')
-          }).appendElement('data', '', '')
+          }).appendElement('data', '', MatchersV3.equal(''))
         })
     })
 }

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -233,7 +233,7 @@ describe('oc.publicFiles', function () {
             } else {
               body = new XmlBuilder('1.0', '', 'd:error').build(dError => {
                 dError.setAttributes({ 'xmlns:d': 'DAV:', 'xmlns:s': 'http://sabredav.org/ns' })
-                dError.appendElement('s:exception', {}, 'Sabre\\DAV\\Exception\\NotAuthenticated')
+                dError.appendElement('s:exception', {}, MatchersV3.equal('Sabre\\DAV\\Exception\\NotAuthenticated'))
               })
             }
             const status = shallGrantAccess ? 207 : 401
@@ -342,8 +342,8 @@ describe('oc.publicFiles', function () {
               resStatusCode = 401
               resBody = new XmlBuilder('1.0', '', 'd:error').build(dError => {
                 dError.setAttributes({ 'xmlns:d': 'DAV:', 'xmlns:s': 'http://sabredav.org/ns' })
-                dError.appendElement('s:exception', {}, 'Sabre\\DAV\\Exception\\NotAuthenticated')
-                  .appendElement('s:message', '', errorMessage)
+                dError.appendElement('s:exception', {}, MatchersV3.equal('Sabre\\DAV\\Exception\\NotAuthenticated'))
+                  .appendElement('s:message', '', MatchersV3.equal(errorMessage))
               })
             } else {
               respHeaders = { 'Content-Type': 'text/plain;charset=UTF-8' }
@@ -710,7 +710,7 @@ describe('oc.publicFiles', function () {
                   MatchersV3.regex('text\\/plain(; charset=utf-8)?', 'text/plain')
                 )
             })
-              .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+              .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
           }).appendElement('d:propstat', '', dPropstat => {
             dPropstat.appendElement('d:prop', '', dProp => {
               dProp
@@ -720,7 +720,7 @@ describe('oc.publicFiles', function () {
                 .appendElement('oc:public-link-share-datetime', '', '')
                 .appendElement('oc:public-link-share-owner', '', '')
             })
-              .appendElement('d:status', '', 'HTTP/1.1 404 Not Found')
+              .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 404 Not Found'))
           })
       })
     }
@@ -737,11 +737,11 @@ describe('oc.publicFiles', function () {
             .appendElement('d:propstat', '', dPropstat => {
               dPropstat.appendElement('d:prop', '', dProp => {
                 dProp
-                  .appendElement('oc:public-link-item-type', '', 'folder')
-                  .appendElement('oc:public-link-permission', '', permission)
-                  .appendElement('oc:public-link-share-owner', '', testUser)
+                  .appendElement('oc:public-link-item-type', '', MatchersV3.equal('folder'))
+                  .appendElement('oc:public-link-permission', '', MatchersV3.equal(permission))
+                  .appendElement('oc:public-link-share-owner', '', MatchersV3.equal(testUser))
               })
-                .appendElement('d:status', '', 'HTTP/1.1 200 OK')
+                .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
             })
         })
       if (permission === '1') {

--- a/tests/sharingTest.js
+++ b/tests/sharingTest.js
@@ -328,8 +328,8 @@ describe('Main: Currently testing file/folder sharing,', function () {
         it('adding password', async function () {
           const formData = { password: '1234' }
           const additionalBodyElement = {
-            share_with: '***redacted***',
-            share_with_displayname: '***redacted***'
+            share_with: MatchersV3.string('***redacted***'),
+            share_with_displayname: MatchersV3.string('***redacted***')
           }
           const provider = createProvider(false, true)
           await getCapabilitiesInteraction(provider, sharer, sharerPassword)

--- a/tests/sharingWithAttributesTest.js
+++ b/tests/sharingWithAttributesTest.js
@@ -68,9 +68,9 @@ describe('oc.shares', function () {
           })
             .appendElement('data', '', (data) => {
               shareResponseOcsData(data, 0, 7, 17, '/' + testFile)
-                .appendElement('share_with', '', shareeName)
-                .appendElement('share_with_displayname', '', shareeName)
-                .appendElement('attributes', '', shareAttributesResponse())
+                .appendElement('share_with', '', MatchersV3.equal(shareeName))
+                .appendElement('share_with_displayname', '', MatchersV3.equal(shareeName))
+                .appendElement('attributes', '', MatchersV3.equal(shareAttributesResponse()))
             })
         })
       })

--- a/tests/signedUrlIntegrationTest.js
+++ b/tests/signedUrlIntegrationTest.js
@@ -36,7 +36,7 @@ describe('Signed urls', function () {
             return ocsMeta(meta, 'ok', '100', 'OK')
           })
             .appendElement('data', '', (data) => {
-              data.appendElement('user', '', username)
+              data.appendElement('user', '', MatchersV3.equal(username))
                 .appendElement('signing-key', '',
                   MatchersV3.regex('(?:^[a-zA-Z0-9\\/\\+]+)$',
                     'YONNpClEO2GVtTDqIwaVsgLBIuDSe03wFhdwcG1WmorRK/iE8xGs7HyHNseftgb3'))

--- a/tests/userTest.js
+++ b/tests/userTest.js
@@ -205,8 +205,8 @@ describe('Main: Currently testing user management,', function () {
             // [oCIS] Different ocs status-text and status-code in oCIS and oC10
             // https://github.com/owncloud/ocis/issues/1777
             meta
-              .appendElement('status', '', 'failure')
-              .appendElement('statuscode', '', ocsStatusCode)
+              .appendElement('status', '', MatchersV3.equal('failure'))
+              .appendElement('statuscode', '', MatchersV3.equal(ocsStatusCode))
               .appendElement('message', '', MatchersV3.regex(`(${message})?`, ''))
           })
         })
@@ -304,7 +304,7 @@ describe('Main: Currently testing user management,', function () {
               // https://github.com/pact-foundation/pact-js/issues/619
               data.appendElement('groups', '', groups => {
                 groups.eachLike('element', '', group => {
-                  group.appendText(config.testGroup)
+                  group.appendText(MatchersV3.equal(config.testGroup))
                 })
               })
             })
@@ -337,7 +337,7 @@ describe('Main: Currently testing user management,', function () {
               return ocsMeta(meta, 'ok', '100')
             }).appendElement('data', '', data => {
               data.appendElement('groups', '', groups => {
-                groups.appendElement('element', '', config.testGroup)
+                groups.appendElement('element', '', MatchersV3.equal(config.testGroup))
               })
             })
           })
@@ -372,7 +372,7 @@ describe('Main: Currently testing user management,', function () {
             ocs.appendElement('meta', '', (meta) => {
               return ocsMeta(meta, 'ok', '100')
             }).appendElement('data', '', data => {
-              data.appendElement('element', '', config.testGroup)
+              data.appendElement('element', '', MatchersV3.equal(config.testGroup))
             })
           })
       )
@@ -403,14 +403,14 @@ describe('Main: Currently testing user management,', function () {
           ocs.appendElement('meta', '', (meta) => {
             return ocsMeta(meta, 'ok', '100', MatchersV3.regex('(OK)?', ''))
           }).appendElement('data', '', data => {
-            data.appendElement('enabled', '', 'true')
+            data.appendElement('enabled', '', MatchersV3.equal('true'))
               .appendElement('quota', '', quota => {
                 quota
                   .appendElement('free', '', MatchersV3.number(57800708096))
                   .appendElement('used', '', MatchersV3.number(2740027))
                   .appendElement('total', '', MatchersV3.number(57803448123))
                   .appendElement('relative', '', MatchersV3.number(0))
-                  .appendElement('definition', '', 'default')
+                  .appendElement('definition', '', MatchersV3.equal('default'))
               })
               .appendElement(
                 'email', '',
@@ -512,9 +512,9 @@ describe('Main: Currently testing user management,', function () {
         // TODO: adjust the following after the issue is resolved
         // https://github.com/pact-foundation/pact-js/issues/619
         data.appendElement('users', '', users => {
-          users.appendElement('element', '', config.adminUsername)
+          users.appendElement('element', '', MatchersV3.string(config.adminUsername))
             .eachLike('element', '', user => {
-              user.appendText(config.testUser)
+              user.appendText(MatchersV3.string(config.testUser))
             })
         })
       }
@@ -567,7 +567,7 @@ describe('Main: Currently testing user management,', function () {
       { search: config.adminUsername },
       data => {
         data.appendElement('users', '', users => {
-          users.appendElement('element', '', config.adminUsername)
+          users.appendElement('element', '', MatchersV3.equal(config.adminUsername))
         })
       }
     )
@@ -948,7 +948,7 @@ describe('Main: Currently testing user management,', function () {
             // https://github.com/pact-foundation/pact-js/issues/619
             data.appendElement('groups', '', groups => {
               groups.eachLike('element', '', group => {
-                group.appendText(config.testGroup)
+                group.appendText(MatchersV3.equal(config.testGroup))
               })
             })
           })
@@ -982,7 +982,7 @@ describe('Main: Currently testing user management,', function () {
             // https://github.com/pact-foundation/pact-js/issues/619
             data.appendElement('groups', '', groups => {
               groups.eachLike('element', '', group => {
-                group.appendText(config.testGroup)
+                group.appendText(MatchersV3.equal(config.testGroup))
               })
             })
           })
@@ -1048,11 +1048,11 @@ describe('Main: Currently testing user management,', function () {
           ocs.appendElement('meta', '', (meta) => {
             return ocsMeta(meta, 'ok', '100', MatchersV3.regex('(OK)?', ''))
           }).appendElement('data', '', data => {
-            data.appendElement('enabled', '', 'true')
+            data.appendElement('enabled', '', MatchersV3.equal('true'))
               .appendElement('quota', '', quota => {
-                quota.appendElement('definition', '', 'default')
+                quota.appendElement('definition', '', MatchersV3.equal('default'))
               })
-              .appendElement('displayname', '', 'test123')
+              .appendElement('displayname', '', MatchersV3.equal('test123'))
           })
         })
     )
@@ -1229,9 +1229,9 @@ describe('Main: Currently testing user management,', function () {
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
           ocs.appendElement('meta', '', (meta) => {
-            return ocsMeta(meta, 'ok', '100')
+            return ocsMeta(meta, 'ok', MatchersV3.equal('100'))
           }).appendElement('data', '', data => {
-            data.appendElement('element', '', config.testGroup)
+            data.appendElement('element', '', MatchersV3.equal(config.testGroup))
           })
         })
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,13 +1050,12 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@pact-foundation/pact-node@^10.11.4":
-  version "10.12.1"
-  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-node/-/pact-node-10.12.1.tgz#3c838926ddccd2025bbe64e47ccbd240dac96c34"
-  integrity sha512-fzvMfYjJTxcNCEXUEc4b8walsMkm7BovegEN8DbJsEfosSW5V94wcdLFOq1LxRD3cAwVvTzhU/Mm5+/tG3glYQ==
+"@pact-foundation/pact-core@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-core/-/pact-core-11.0.0.tgz#4423e6ff3d4401c772ca27d3866298f3d9d6929c"
+  integrity sha512-bh67xA4U1QacwKyTQmWGiYTLip15PhnSfAAAlOGvSxO1+EIUXB+qO4HlyIx3l+6uaaJ9hFa8e3KHRIJGKfDNxg==
   dependencies:
     "@types/pino" "^6.3.5"
-    "@types/q" "1.0.7"
     "@types/request" "2.48.2"
     chalk "2.3.1"
     check-types "7.3.0"
@@ -1065,7 +1064,7 @@
     mkdirp "1.0.0"
     pino "^6.11.0"
     pino-pretty "^4.1.0"
-    q "1.5.1"
+    promise-timeout "^1.3.0"
     request "2.88.0"
     rimraf "2.6.2"
     sumchecker "^2.0.2"
@@ -1075,35 +1074,31 @@
     unzipper "^0.10.10"
     url-join "^4.0.0"
 
-"@pact-foundation/pact@10.0.0-beta.33":
-  version "10.0.0-beta.33"
-  resolved "https://registry.yarnpkg.com/@pact-foundation/pact/-/pact-10.0.0-beta.33.tgz#2c2b149d39c56d65d5486089c443702e5406f481"
-  integrity sha512-JkAPDFYOOWAhQbsha9EF5Sf1OqHVUpNHIZ/1YMajk+TkKjYEH2f3Myp17ejk97WbvBMsl5q23SSJsTKI8YMESg==
+"@pact-foundation/pact@10.0.0-beta.36":
+  version "10.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact/-/pact-10.0.0-beta.36.tgz#6e32bf1116bbcc60778e6938a232f212397b3857"
+  integrity sha512-j/z6qRg/568kfH2gX5E6xyPxJCVVn4I03foNyqCEjliv+xT/eoeJe0XRPQzdNS1Hge4DG43W25Tc8p0+/h6H+A==
   dependencies:
-    "@pact-foundation/pact-node" "^10.11.4"
+    "@pact-foundation/pact-core" "^11.0.0"
     "@types/bluebird" "^3.5.20"
-    "@types/bunyan" "^1.8.3"
-    "@types/express" "^4.11.1"
-    "@types/ramda" "^0.26.43"
+    "@types/express" "^4.17.11"
     bluebird "~3.5.1"
     body-parser "^1.18.2"
-    bunyan "^1.8.13"
-    bunyan-prettystream "^0.1.3"
     cli-color "^1.1.0"
-    es6-object-assign "^1.1.0"
-    es6-promise "^4.1.1"
-    express "^4.16.3"
+    express "^4.17.1"
     graphql "^14.0.0"
     graphql-tag "^2.9.1"
     http-proxy "^1.18.1"
     http-proxy-middleware "^0.19.0"
-    lodash "^4.17.20"
+    lodash "^4.17.21"
     lodash.isfunction "3.0.8"
     lodash.isnil "4.0.0"
     lodash.isundefined "3.0.1"
     lodash.omit "^4.5.0"
     lodash.omitby "4.6.0"
     node-pre-gyp "^0.13.0"
+    pino "^6.5.1"
+    pino-pretty "^4.1.0"
     pkginfo "^0.4.1"
     popsicle "^9.2.0"
     ramda "^0.26.1"
@@ -1195,13 +1190,6 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/bunyan@^1.8.3":
-  version "1.8.6"
-  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.6.tgz#6527641cca30bedec5feb9ab527b7803b8000582"
-  integrity sha512-YiozPOOsS6bIuz31ilYqR5SlLif4TBWsousN2aCWLi5233nZSX19tFbcQUPdR7xJ8ypPyxkCGNxg0CIV5n9qxQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/caseless@*":
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
@@ -1214,22 +1202,22 @@
   dependencies:
     "@types/node" "*"
 
-"@types/express-serve-static-core@*":
-  version "4.17.17"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.17.tgz#6ba02465165b6c9c3d8db3a28def6b16fc9b70f5"
-  integrity sha512-YYlVaCni5dnHc+bLZfY908IG1+x5xuibKZMGv8srKkvtul3wUuanYvpIj9GXXoWkQbaAdR+kgX46IETKUALWNQ==
+"@types/express-serve-static-core@^4.17.18":
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.20.tgz#44caee029f2c26c46711da5e845cdc12167ad72d"
+  integrity sha512-8qqFN4W53IEWa9bdmuVrUcVkFemQWnt5DKPQ/oa8xKDYgtjCr2OO6NX5TIK49NLFr3mPYU2cLh92DQquC3oWWQ==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
     "@types/range-parser" "*"
 
-"@types/express@^4.11.1":
-  version "4.17.9"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.9.tgz#f5f2df6add703ff28428add52bdec8a1091b0a78"
-  integrity sha512-SDzEIZInC4sivGIFY4Sz1GG6J9UObPwCInYJjko2jzOf/Imx/dlpume6Xxwj1ORL82tBbmN4cPDIDkLbWHk9hw==
+"@types/express@^4.17.11":
+  version "4.17.12"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.12.tgz#4bc1bf3cd0cfe6d3f6f2853648b40db7d54de350"
+  integrity sha512-pTYas6FrP15B1Oa0bkN5tQMNqOcVXa9j4FTFtO8DWI9kppKib+6NJtfTOOLcwxuuYvcX2+dVG6et1SxW/Kc17Q==
   dependencies:
     "@types/body-parser" "*"
-    "@types/express-serve-static-core" "*"
+    "@types/express-serve-static-core" "^4.17.18"
     "@types/qs" "*"
     "@types/serve-static" "*"
 
@@ -1318,22 +1306,10 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.5.tgz#b6ab3bba29e16b821d84e09ecfaded462b816b00"
   integrity sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==
 
-"@types/q@1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@types/q/-/q-1.0.7.tgz#afd4c610f16f6386d320e0738ec38ba7d3431917"
-  integrity sha512-0WS7XU7sXzQ7J1nbnMKKYdjrrFoO3YtZYgUzeV8JFXffPnHfvSJQleR70I8BOAsOm14i4dyaAZ3YzqIl1YhkXQ==
-
 "@types/qs@*":
   version "6.9.5"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.5.tgz#434711bdd49eb5ee69d90c1d67c354a9a8ecb18b"
   integrity sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==
-
-"@types/ramda@^0.26.43":
-  version "0.26.44"
-  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.26.44.tgz#70bb06f5ae60809dc83a3d804505ee3123443738"
-  integrity sha512-s0cj9rylWw+Ax/AnttCQzMrLZGq/OxAIZgrkRLK1QHJIF6Qabd0//acMCFM6+Xb8Bi8p8PkT2fqpaQveRju/kA==
-  dependencies:
-    ts-toolbelt "^6.3.3"
 
 "@types/range-parser@*":
   version "1.2.3"
@@ -2317,21 +2293,6 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-bunyan-prettystream@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/bunyan-prettystream/-/bunyan-prettystream-0.1.3.tgz#6c3b713266f6ad32007c7b6ab1e998a245349d98"
-  integrity sha1-bDtxMmb2rTIAfHtqsemYokU0nZg=
-
-bunyan@^1.8.13:
-  version "1.8.14"
-  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.14.tgz#3d8c1afea7de158a5238c7cb8a66ab6b38dd45b4"
-  integrity sha512-LlahJUxXzZLuw/hetUQJmRgZ1LF6+cr5TPpRj6jf327AsiIq2jhYEH4oqUUkVKTor+9w2BT3oxVwhzE5lw9tcg==
-  optionalDependencies:
-    dtrace-provider "~0.8"
-    moment "^2.19.3"
-    mv "~2"
-    safe-json-stringify "~1"
-
 bytes@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
@@ -3183,13 +3144,6 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
-dtrace-provider@~0.8:
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.8.tgz#2996d5490c37e1347be263b423ed7b297fb0d97e"
-  integrity sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==
-  dependencies:
-    nan "^2.14.0"
-
 duplexer2@~0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
@@ -3349,16 +3303,6 @@ es6-iterator@^2.0.3, es6-iterator@~2.0.3:
     d "1"
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
-
-es6-object-assign@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
-  integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
-
-es6-promise@^4.1.1:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
-  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
 
 es6-symbol@^3.1.1, es6-symbol@~3.1.3:
   version "3.1.3"
@@ -3723,7 +3667,7 @@ expect@^26.6.2:
     jest-message-util "^26.6.2"
     jest-regex-util "^26.0.0"
 
-express@^4.16.3:
+express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
   integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
@@ -4247,17 +4191,6 @@ glob@7.1.6, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^6.0.1:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
-  integrity sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -5907,10 +5840,15 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4:
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.4:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@4.0.0, log-symbols@^4.0.0:
   version "4.0.0"
@@ -6171,7 +6109,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -6227,7 +6165,7 @@ mkdirp@1.0.0:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.0.tgz#8487b07699b70c9b06fce47b3ce28d8176c13c75"
   integrity sha512-4Pb+8NJ5DdvaWD797hKOM28wMXsObb4HppQdIwKUHFiB69ICZ4wktOE+qsGGBy7GtwgYNizp0R9KEy4zKYBLMg==
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -6269,11 +6207,6 @@ mocha@^8.2.1:
     yargs "13.3.2"
     yargs-parser "13.1.2"
     yargs-unparser "2.0.0"
-
-moment@^2.19.3:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -6317,16 +6250,7 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-mv@~2:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
-  integrity sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=
-  dependencies:
-    mkdirp "~0.5.1"
-    ncp "~2.0.0"
-    rimraf "~2.4.0"
-
-nan@^2.12.1, nan@^2.14.0:
+nan@^2.12.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
@@ -6357,11 +6281,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
-
-ncp@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
-  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
 needle@^2.2.1:
   version "2.5.2"
@@ -6993,6 +6912,18 @@ pino@^6.11.0:
     quick-format-unescaped "4.0.1"
     sonic-boom "^1.0.2"
 
+pino@^6.5.1:
+  version "6.11.3"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-6.11.3.tgz#0c02eec6029d25e6794fdb6bbea367247d74bc29"
+  integrity sha512-drPtqkkSf0ufx2gaea3TryFiBHdNIdXKf5LN0hTM82SXI4xVIve2wLwNg92e1MT6m3jASLu6VO7eGY6+mmGeyw==
+  dependencies:
+    fast-redact "^3.0.0"
+    fast-safe-stringify "^2.0.7"
+    flatstr "^1.0.12"
+    pino-std-serializers "^3.1.0"
+    quick-format-unescaped "^4.0.3"
+    sonic-boom "^1.0.2"
+
 pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
@@ -7083,6 +7014,11 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
+promise-timeout@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/promise-timeout/-/promise-timeout-1.3.0.tgz#d1c78dd50a607d5f0a5207410252a3a0914e1014"
+  integrity sha512-5yANTE0tmi5++POym6OgtFmwfDvOXABD9oj/jLQr5GPEyuNEb7jH4wbbANJceJid49jwhi1RddxnhnEAb/doqg==
+
 promise@^8.0.3:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
@@ -7168,11 +7104,6 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-q@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
-  integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
-
 qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
@@ -7202,6 +7133,11 @@ quick-format-unescaped@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz#437a5ea1a0b61deb7605f8ab6a8fd3858dbeb701"
   integrity sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==
+
+quick-format-unescaped@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz#6d6b66b8207aa2b35eef12be1421bb24c428f652"
+  integrity sha512-MaL/oqh02mhEo5m5J2rwsVL23Iw2PEaGVHgT2vFt8AAsr0lfvQA5dpXo9TPu0rz7tSBdUPgkbam0j/fj5ZM8yg==
 
 ramda@^0.26.1:
   version "0.26.1"
@@ -7601,13 +7537,6 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
-rimraf@~2.4.0:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
-  integrity sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=
-  dependencies:
-    glob "^6.0.1"
-
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
@@ -7649,11 +7578,6 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, 
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
-safe-json-stringify@~1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz#356e44bc98f1f93ce45df14bcd7c01cda86e0afd"
-  integrity sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -8574,11 +8498,6 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
-
-ts-toolbelt@^6.3.3:
-  version "6.15.5"
-  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
-  integrity sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"


### PR DESCRIPTION
Bump pact-js to 10.0.0-beta.36

- Use matchers  in XmlBuilder instead of string literals