### PR TITLE
Return early on rejected promises

### DIFF
--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -287,10 +287,12 @@ class helpers {
           }
           if ('message' in tree) {
             reject(tree.message)
+            return
           }
           const error = self._checkOCSstatus(tree)
           if (error) {
             reject(error)
+            return
           }
           res.statusCode = res.status
           resolve({


### PR DESCRIPTION
Found two other instances of `reject`s without `return`s. Doesn't hurt to add them I guess...