### PR TITLE
Cache getCapabilities

### DIFF
--- a/src/owncloud.js
+++ b/src/owncloud.js
@@ -81,6 +81,7 @@ class ownCloud {
         return helpers.ocs(options)
       }
     }
+    this.cache = {}
   }
 
   /**
@@ -90,7 +91,7 @@ class ownCloud {
    */
   login () {
     const self = this
-    return this.helpers.getCapabilities()
+    return this.getCapabilities()
       .then(() => {
         return Promise.resolve(self.getCurrentUser())
       })
@@ -117,8 +118,16 @@ class ownCloud {
    * @returns {Promise.<capabilities>}    string: ownCloud version
    * @returns {Promise.<reject>}             object: capabilities
    */
-  getCapabilities () {
-    return this.helpers.getCapabilities()
+  getCapabilities (refresh = true) {
+    const self = this
+    // Expensive call, keep a cache if possible (let the client decide)
+    // Might be usefull if called in conjunction with login()
+    if (!refresh && 'capabilities' in this.cache) {
+      return new Promise((resolve) => resolve(self.cache.capabilities))
+    }
+    const promiseCapabilities = this.helpers.getCapabilities()
+    promiseCapabilities.then((capabilities) => { self.cache.capabilities = capabilities })
+    return promiseCapabilities
   }
 
   /**


### PR DESCRIPTION
Calling the capabilities endpoint is expensive. When running in CERNBox it's extremely expensive...
Since in Web we call `login()` and `getCapabilities()` one after the other, I don't see a reason to do 2 requests.

In this PR I create a cache that stores the latest retrieved value. From the web I will set `refresh` as `false`.
I implemented this way to keep the same behavior by default, but maybe the login could also take it in consideration (in case in the future we switch the order and call `getCapabilities()` first.

Let me know if you agree with this or if you prefer something else.