### PR TITLE
Use custom url to avoid encoded by the webdav library

### DIFF
--- a/src/dav.js
+++ b/src/dav.js
@@ -15,6 +15,7 @@ export class Dav {
     }
 
     this.baseUrl = baseUrl
+    this.baseUrlv2 = baseUrlv2
 
     this.userName = null
 
@@ -216,16 +217,22 @@ export class Dav {
   request (method, path, headers, body, options = {}) {
     options.version = options.version || 'v1'
     const reqClient = options.version === 'v2' ? this.clientv2 : this.client
+    const reqBaseUrl = options.version === 'v2' ? this.baseUrlv2 : this.baseUrl
     delete options.version
 
+    const params = new URLSearchParams(options.query).toString()
+    const query = params ? '?' + params : ''
+    delete options.query
+
     const requestOptions = {
+      url: reqBaseUrl + path + query,
       method,
       headers,
       data: body,
       ...options
     }
     return new Promise((resolve) => {
-      return reqClient.customRequest(decodeURIComponent(path), requestOptions)
+      return reqClient.customRequest('', requestOptions)
         .then(res => {
           var resultBody = res.data
           if (res.status === 207) {

--- a/src/filesTrash.js
+++ b/src/filesTrash.js
@@ -20,9 +20,10 @@ class FilesTrash {
    * @param   {string}    path          path of the file/folder at OC instance
    * @param   {string}    depth         0: only file/folder, 1: upto 1 depth, infinity: infinite depth
    * @param   {array}     properties    Array[string] with dav properties to be requested
+   * @param   {Object}    query         Query parameters dictionary
    * @returns {Promise.<fileInfo | string | Error>}
    */
-  list (path, depth = '1', properties = undefined) {
+  list (path, depth = '1', properties = undefined, query = undefined) {
     if (properties === undefined) {
       properties = [
         '{http://owncloud.org/ns}trashbin-original-filename',
@@ -45,7 +46,10 @@ class FilesTrash {
       properties,
       depth,
       headers,
-      { version: 'v2' }
+      {
+        version: 'v2',
+        query: query
+      }
     ).then(result => {
       if (result.status !== 207) {
         return Promise.reject(this.helpers.buildHttpErrorFromDavResponse(result.status, result.body))

--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -394,6 +394,9 @@ class helpers {
       path = '/' + path
     }
 
+    // Avoid double // in urls
+    path = path.replace(/([^:])(\/\/+)/g, '$1/')
+
     return path
   }
 


### PR DESCRIPTION
We implemented the recycle bin of our EOS projects with a query parameter. This was discussed with the OCIS backend team and they will use the same way to return the recycle of spaces.

The `webdav` client encodes the path, unless if we manually set `url` in the request options. In this PR I generate the URL in the SDK instead of relying in the library.

What do you think?
Btw, to set the recycle query param we just set as the url... We could provide an extra option in this function call if you prefer.