### PR TITLE
Only use response data/status when available in dav.request

### DIFF
--- a/src/dav.js
+++ b/src/dav.js
@@ -247,8 +247,8 @@ export class Dav {
           const res = error.response
 
           resolve({
-            body: res.data,
-            status: res.status,
+            body: res?.data,
+            status: res?.status,
             res
           })
         })


### PR DESCRIPTION
Without this change a TypeError is caused inside the Promise that completely breaks it.
It does not succeed and does not reject, it just breaks when there is no response data available.
This happens for CONNECTION_REFUSED errors and I can imagine this might happen as well with CORS errors.

With this change the original response can be accessed and no body or status are available (because that's what those failed requests look like to javascript)