### PR TITLE
Fix settings listing

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -29,6 +29,7 @@ class SettingsValues {
     try {
       const baseUrl = this.helpers.getInstance().replace(/\/$/, '')
       const response = await SettingsClient.ValueService_ListValues({
+        client: this.helpers.axios,
         $domain: baseUrl,
         body: {
           account_uuid: accountUuid

--- a/vendor/settingsClient.js
+++ b/vendor/settingsClient.js
@@ -1,4 +1,11 @@
-/* This file is generated code. It comes from https://github.com/owncloud/ocis-settings */
+/**
+ * This file is generated code. It comes from https://github.com/owncloud/ocis/blob/master/settings/package.json#L17
+ *
+ * Since the ownCloud SDK doesn't use the global axios client directly but internally holds an instance with auth headers
+ * already injected, we manually adapted the generated code to expect a client in the list of parameters. Please make
+ * sure that these changes are manually applied if newly generated code needs to be checked in ever again (side note:
+ * generated clients from protobuf/swagger are considered deprecated at ownCloud).
+ */
 /* eslint-disable */
 import axios from 'axios'
 import qs from 'qs'
@@ -9,7 +16,7 @@ export const getDomain = () => {
 export const setDomain = ($domain) => {
   domain = $domain
 }
-export const request = (method, url, body, queryParameters, form, config) => {
+export const request = (client, method, url, body, queryParameters, form, config) => {
   method = method.toLowerCase()
   let keys = Object.keys(queryParameters)
   let queryUrl = url
@@ -18,11 +25,11 @@ export const request = (method, url, body, queryParameters, form, config) => {
   }
   // let queryUrl = url+(keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
   if (body) {
-    return axios[method](queryUrl, body, config)
+    return client[method](queryUrl, body, config)
   } else if (method === 'get') {
-    return axios[method](queryUrl, config)
+    return client[method](queryUrl, config)
   } else {
-    return axios[method](queryUrl, qs.stringify(form), config)
+    return client[method](queryUrl, qs.stringify(form), config)
   }
 }
 /*==========================================================
@@ -30,475 +37,16 @@ export const request = (method, url, body, queryParameters, form, config) => {
  ==========================================================*/
 /**
  *
- * request: RoleService_AssignRoleToUser
- * url: RoleService_AssignRoleToUserURL
- * method: RoleService_AssignRoleToUser_TYPE
- * raw_url: RoleService_AssignRoleToUser_RAW_URL
- * @param body -
- */
-export const RoleService_AssignRoleToUser = function(parameters = {}) {
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  const config = parameters.$config
-  let path = '/api/v0/settings/assignments-add'
-  let body
-  let queryParameters = {}
-  let form = {}
-  if (parameters['body'] !== undefined) {
-    body = parameters['body']
-  }
-  if (parameters['body'] === undefined) {
-    return Promise.reject(new Error('Missing required  parameter: body'))
-  }
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    });
-  }
-  return request('post', domain + path, body, queryParameters, form, config)
-}
-export const RoleService_AssignRoleToUser_RAW_URL = function() {
-  return '/api/v0/settings/assignments-add'
-}
-export const RoleService_AssignRoleToUser_TYPE = function() {
-  return 'post'
-}
-export const RoleService_AssignRoleToUserURL = function(parameters = {}) {
-  let queryParameters = {}
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  let path = '/api/v0/settings/assignments-add'
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    })
-  }
-  let keys = Object.keys(queryParameters)
-  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
-}
-/**
- *
- * request: RoleService_ListRoleAssignments
- * url: RoleService_ListRoleAssignmentsURL
- * method: RoleService_ListRoleAssignments_TYPE
- * raw_url: RoleService_ListRoleAssignments_RAW_URL
- * @param body -
- */
-export const RoleService_ListRoleAssignments = function(parameters = {}) {
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  const config = parameters.$config
-  let path = '/api/v0/settings/assignments-list'
-  let body
-  let queryParameters = {}
-  let form = {}
-  if (parameters['body'] !== undefined) {
-    body = parameters['body']
-  }
-  if (parameters['body'] === undefined) {
-    return Promise.reject(new Error('Missing required  parameter: body'))
-  }
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    });
-  }
-  return request('post', domain + path, body, queryParameters, form, config)
-}
-export const RoleService_ListRoleAssignments_RAW_URL = function() {
-  return '/api/v0/settings/assignments-list'
-}
-export const RoleService_ListRoleAssignments_TYPE = function() {
-  return 'post'
-}
-export const RoleService_ListRoleAssignmentsURL = function(parameters = {}) {
-  let queryParameters = {}
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  let path = '/api/v0/settings/assignments-list'
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    })
-  }
-  let keys = Object.keys(queryParameters)
-  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
-}
-/**
- *
- * request: RoleService_RemoveRoleFromUser
- * url: RoleService_RemoveRoleFromUserURL
- * method: RoleService_RemoveRoleFromUser_TYPE
- * raw_url: RoleService_RemoveRoleFromUser_RAW_URL
- * @param body -
- */
-export const RoleService_RemoveRoleFromUser = function(parameters = {}) {
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  const config = parameters.$config
-  let path = '/api/v0/settings/assignments-remove'
-  let body
-  let queryParameters = {}
-  let form = {}
-  if (parameters['body'] !== undefined) {
-    body = parameters['body']
-  }
-  if (parameters['body'] === undefined) {
-    return Promise.reject(new Error('Missing required  parameter: body'))
-  }
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    });
-  }
-  return request('post', domain + path, body, queryParameters, form, config)
-}
-export const RoleService_RemoveRoleFromUser_RAW_URL = function() {
-  return '/api/v0/settings/assignments-remove'
-}
-export const RoleService_RemoveRoleFromUser_TYPE = function() {
-  return 'post'
-}
-export const RoleService_RemoveRoleFromUserURL = function(parameters = {}) {
-  let queryParameters = {}
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  let path = '/api/v0/settings/assignments-remove'
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    })
-  }
-  let keys = Object.keys(queryParameters)
-  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
-}
-/**
- *
- * request: BundleService_GetBundle
- * url: BundleService_GetBundleURL
- * method: BundleService_GetBundle_TYPE
- * raw_url: BundleService_GetBundle_RAW_URL
- * @param body -
- */
-export const BundleService_GetBundle = function(parameters = {}) {
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  const config = parameters.$config
-  let path = '/api/v0/settings/bundle-get'
-  let body
-  let queryParameters = {}
-  let form = {}
-  if (parameters['body'] !== undefined) {
-    body = parameters['body']
-  }
-  if (parameters['body'] === undefined) {
-    return Promise.reject(new Error('Missing required  parameter: body'))
-  }
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    });
-  }
-  return request('post', domain + path, body, queryParameters, form, config)
-}
-export const BundleService_GetBundle_RAW_URL = function() {
-  return '/api/v0/settings/bundle-get'
-}
-export const BundleService_GetBundle_TYPE = function() {
-  return 'post'
-}
-export const BundleService_GetBundleURL = function(parameters = {}) {
-  let queryParameters = {}
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  let path = '/api/v0/settings/bundle-get'
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    })
-  }
-  let keys = Object.keys(queryParameters)
-  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
-}
-/**
- *
- * request: BundleService_SaveBundle
- * url: BundleService_SaveBundleURL
- * method: BundleService_SaveBundle_TYPE
- * raw_url: BundleService_SaveBundle_RAW_URL
- * @param body -
- */
-export const BundleService_SaveBundle = function(parameters = {}) {
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  const config = parameters.$config
-  let path = '/api/v0/settings/bundle-save'
-  let body
-  let queryParameters = {}
-  let form = {}
-  if (parameters['body'] !== undefined) {
-    body = parameters['body']
-  }
-  if (parameters['body'] === undefined) {
-    return Promise.reject(new Error('Missing required  parameter: body'))
-  }
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    });
-  }
-  return request('post', domain + path, body, queryParameters, form, config)
-}
-export const BundleService_SaveBundle_RAW_URL = function() {
-  return '/api/v0/settings/bundle-save'
-}
-export const BundleService_SaveBundle_TYPE = function() {
-  return 'post'
-}
-export const BundleService_SaveBundleURL = function(parameters = {}) {
-  let queryParameters = {}
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  let path = '/api/v0/settings/bundle-save'
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    })
-  }
-  let keys = Object.keys(queryParameters)
-  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
-}
-/**
- *
- * request: BundleService_AddSettingToBundle
- * url: BundleService_AddSettingToBundleURL
- * method: BundleService_AddSettingToBundle_TYPE
- * raw_url: BundleService_AddSettingToBundle_RAW_URL
- * @param body -
- */
-export const BundleService_AddSettingToBundle = function(parameters = {}) {
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  const config = parameters.$config
-  let path = '/api/v0/settings/bundles-add-setting'
-  let body
-  let queryParameters = {}
-  let form = {}
-  if (parameters['body'] !== undefined) {
-    body = parameters['body']
-  }
-  if (parameters['body'] === undefined) {
-    return Promise.reject(new Error('Missing required  parameter: body'))
-  }
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    });
-  }
-  return request('post', domain + path, body, queryParameters, form, config)
-}
-export const BundleService_AddSettingToBundle_RAW_URL = function() {
-  return '/api/v0/settings/bundles-add-setting'
-}
-export const BundleService_AddSettingToBundle_TYPE = function() {
-  return 'post'
-}
-export const BundleService_AddSettingToBundleURL = function(parameters = {}) {
-  let queryParameters = {}
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  let path = '/api/v0/settings/bundles-add-setting'
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    })
-  }
-  let keys = Object.keys(queryParameters)
-  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
-}
-/**
- *
- * request: BundleService_ListBundles
- * url: BundleService_ListBundlesURL
- * method: BundleService_ListBundles_TYPE
- * raw_url: BundleService_ListBundles_RAW_URL
- * @param body -
- */
-export const BundleService_ListBundles = function(parameters = {}) {
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  const config = parameters.$config
-  let path = '/api/v0/settings/bundles-list'
-  let body
-  let queryParameters = {}
-  let form = {}
-  if (parameters['body'] !== undefined) {
-    body = parameters['body']
-  }
-  if (parameters['body'] === undefined) {
-    return Promise.reject(new Error('Missing required  parameter: body'))
-  }
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    });
-  }
-  return request('post', domain + path, body, queryParameters, form, config)
-}
-export const BundleService_ListBundles_RAW_URL = function() {
-  return '/api/v0/settings/bundles-list'
-}
-export const BundleService_ListBundles_TYPE = function() {
-  return 'post'
-}
-export const BundleService_ListBundlesURL = function(parameters = {}) {
-  let queryParameters = {}
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  let path = '/api/v0/settings/bundles-list'
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    })
-  }
-  let keys = Object.keys(queryParameters)
-  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
-}
-/**
- *
- * request: BundleService_RemoveSettingFromBundle
- * url: BundleService_RemoveSettingFromBundleURL
- * method: BundleService_RemoveSettingFromBundle_TYPE
- * raw_url: BundleService_RemoveSettingFromBundle_RAW_URL
- * @param body -
- */
-export const BundleService_RemoveSettingFromBundle = function(parameters = {}) {
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  const config = parameters.$config
-  let path = '/api/v0/settings/bundles-remove-setting'
-  let body
-  let queryParameters = {}
-  let form = {}
-  if (parameters['body'] !== undefined) {
-    body = parameters['body']
-  }
-  if (parameters['body'] === undefined) {
-    return Promise.reject(new Error('Missing required  parameter: body'))
-  }
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    });
-  }
-  return request('post', domain + path, body, queryParameters, form, config)
-}
-export const BundleService_RemoveSettingFromBundle_RAW_URL = function() {
-  return '/api/v0/settings/bundles-remove-setting'
-}
-export const BundleService_RemoveSettingFromBundle_TYPE = function() {
-  return 'post'
-}
-export const BundleService_RemoveSettingFromBundleURL = function(parameters = {}) {
-  let queryParameters = {}
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  let path = '/api/v0/settings/bundles-remove-setting'
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    })
-  }
-  let keys = Object.keys(queryParameters)
-  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
-}
-/**
- *
- * request: RoleService_ListRoles
- * url: RoleService_ListRolesURL
- * method: RoleService_ListRoles_TYPE
- * raw_url: RoleService_ListRoles_RAW_URL
- * @param body -
- */
-export const RoleService_ListRoles = function(parameters = {}) {
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  const config = parameters.$config
-  let path = '/api/v0/settings/roles-list'
-  let body
-  let queryParameters = {}
-  let form = {}
-  if (parameters['body'] !== undefined) {
-    body = parameters['body']
-  }
-  if (parameters['body'] === undefined) {
-    return Promise.reject(new Error('Missing required  parameter: body'))
-  }
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    });
-  }
-  return request('post', domain + path, body, queryParameters, form, config)
-}
-export const RoleService_ListRoles_RAW_URL = function() {
-  return '/api/v0/settings/roles-list'
-}
-export const RoleService_ListRoles_TYPE = function() {
-  return 'post'
-}
-export const RoleService_ListRolesURL = function(parameters = {}) {
-  let queryParameters = {}
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  let path = '/api/v0/settings/roles-list'
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    })
-  }
-  let keys = Object.keys(queryParameters)
-  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
-}
-/**
- *
- * request: ValueService_GetValue
- * url: ValueService_GetValueURL
- * method: ValueService_GetValue_TYPE
- * raw_url: ValueService_GetValue_RAW_URL
- * @param body -
- */
-export const ValueService_GetValue = function(parameters = {}) {
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  const config = parameters.$config
-  let path = '/api/v0/settings/values-get'
-  let body
-  let queryParameters = {}
-  let form = {}
-  if (parameters['body'] !== undefined) {
-    body = parameters['body']
-  }
-  if (parameters['body'] === undefined) {
-    return Promise.reject(new Error('Missing required  parameter: body'))
-  }
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    });
-  }
-  return request('post', domain + path, body, queryParameters, form, config)
-}
-export const ValueService_GetValue_RAW_URL = function() {
-  return '/api/v0/settings/values-get'
-}
-export const ValueService_GetValue_TYPE = function() {
-  return 'post'
-}
-export const ValueService_GetValueURL = function(parameters = {}) {
-  let queryParameters = {}
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  let path = '/api/v0/settings/values-get'
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    })
-  }
-  let keys = Object.keys(queryParameters)
-  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
-}
-/**
- *
  * request: ValueService_ListValues
  * url: ValueService_ListValuesURL
  * method: ValueService_ListValues_TYPE
  * raw_url: ValueService_ListValues_RAW_URL
- * @param body -
+ * @param parameters -
  */
 export const ValueService_ListValues = function(parameters = {}) {
   const domain = parameters.$domain ? parameters.$domain : getDomain()
   const config = parameters.$config
+  const client = parameters.client || axios
   let path = '/api/v0/settings/values-list'
   let body
   let queryParameters = {}
@@ -514,7 +62,7 @@ export const ValueService_ListValues = function(parameters = {}) {
       queryParameters[parameterName] = parameters.$queryParameters[parameterName]
     });
   }
-  return request('post', domain + path, body, queryParameters, form, config)
+  return request(client, 'post', domain + path, body, queryParameters, form, config)
 }
 export const ValueService_ListValues_RAW_URL = function() {
   return '/api/v0/settings/values-list'
@@ -526,52 +74,6 @@ export const ValueService_ListValuesURL = function(parameters = {}) {
   let queryParameters = {}
   const domain = parameters.$domain ? parameters.$domain : getDomain()
   let path = '/api/v0/settings/values-list'
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    })
-  }
-  let keys = Object.keys(queryParameters)
-  return domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '')
-}
-/**
- *
- * request: ValueService_SaveValue
- * url: ValueService_SaveValueURL
- * method: ValueService_SaveValue_TYPE
- * raw_url: ValueService_SaveValue_RAW_URL
- * @param body -
- */
-export const ValueService_SaveValue = function(parameters = {}) {
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  const config = parameters.$config
-  let path = '/api/v0/settings/values-save'
-  let body
-  let queryParameters = {}
-  let form = {}
-  if (parameters['body'] !== undefined) {
-    body = parameters['body']
-  }
-  if (parameters['body'] === undefined) {
-    return Promise.reject(new Error('Missing required  parameter: body'))
-  }
-  if (parameters.$queryParameters) {
-    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-      queryParameters[parameterName] = parameters.$queryParameters[parameterName]
-    });
-  }
-  return request('post', domain + path, body, queryParameters, form, config)
-}
-export const ValueService_SaveValue_RAW_URL = function() {
-  return '/api/v0/settings/values-save'
-}
-export const ValueService_SaveValue_TYPE = function() {
-  return 'post'
-}
-export const ValueService_SaveValueURL = function(parameters = {}) {
-  let queryParameters = {}
-  const domain = parameters.$domain ? parameters.$domain : getDomain()
-  let path = '/api/v0/settings/values-save'
   if (parameters.$queryParameters) {
     Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
       queryParameters[parameterName] = parameters.$queryParameters[parameterName]


### PR DESCRIPTION
This PR hardcodes the axios instance from the helperFunctions.js (already has auth headers injected) to be used in the settings client. Added a comment about code generation and manual changes in the `settingsClient.js` to raise awareness.

This is needed if we ever want to bump the sdk in `github.com/owncloud/web` and stay compatible with the current ocis settings implementation.

If you want to test this with an ocis instance (I did), you can create a local link to the owncloud sdk in web, build web, then start ocis with web assets from your build, and check if the language gets correctly fetched from the backend on initial page load (i.e. switch language to non-default in the settings ui, go back to the files app, reload page).