### PR TITLE
Add changelog for dropping IE support

### DIFF
--- a/changelog/unreleased/change-drop-ie-support
+++ b/changelog/unreleased/change-drop-ie-support
@@ -1,0 +1,6 @@
+Change: Drop Internet Explorer support
+
+Since it's nearing its end-of-life, we've dropped 
+polyfills for IE in favor of a smaller bundle size.
+
+https://github.com/owncloud/owncloud-sdk/pull/966


### PR DESCRIPTION
Technically this was already part of the `1.1.1` release, but better now than never 😬 