### PR TITLE
Reject promise when network request fails in OCS

### DIFF
--- a/changelog/1.1.2_2022-02-01/bugfix-ocs-reject
+++ b/changelog/1.1.2_2022-02-01/bugfix-ocs-reject
@@ -1,0 +1,5 @@
+Bugfix: Graceful reject for failing network request in OCS
+
+When the network request inside a _makeOCSrequest failed it terminated the entire application instead of rejecting the promise. We now catch errors on the network request and reject the promise so that applications have a chance to handle the error.
+
+https://github.com/owncloud/owncloud-sdk/pull/977

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "owncloud-sdk",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "ownCloud client library for JavaScript",
   "keywords": [
     "owncloud",

--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -301,6 +301,9 @@ class helpers {
             data: tree
           })
         })
+        .catch(e => {
+          return reject(e)
+        })
     })
   }
 


### PR DESCRIPTION
branch is based on tag v1.1.1 so that we can make a v1.1.2 from it. but can be merged back to master after release to get the fix into that as well. Needs to drop the version bump again of course. Or just cherry pick the first commit to master...