### PR TITLE
Reject promise when network request fails in OCS

### DIFF
--- a/changelog/1.1.2_2022-02-01/bugfix-ocs-reject
+++ b/changelog/1.1.2_2022-02-01/bugfix-ocs-reject
@@ -1,0 +1,5 @@
+Bugfix: Graceful reject for failing network request in OCS
+
+When the network request inside a _makeOCSrequest failed it terminated the entire application instead of rejecting the promise. We now catch errors on the network request and reject the promise so that applications have a chance to handle the error.
+
+https://github.com/owncloud/owncloud-sdk/pull/977

--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -300,6 +300,9 @@ class helpers {
             data: tree
           })
         })
+        .catch(e => {
+          return reject(e)
+        })
     })
   }
 


### PR DESCRIPTION
Same as #977 but without the version bump to v1.1.2 (because master already is at v2.0.0-alpha.x).