### PR TITLE
Change: Move dependencies to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/owncloud/owncloud-sdk.svg?branch=master)](https://travis-ci.org/owncloud/owncloud-sdk)
-[![codecov](https://codecov.io/gh/owncloud/owncloud-sdk/branch/master/graph/badge.svg)](https://codecov.io/gh/owncloud/owncloud-sdk)
 [![docs](https://img.shields.io/badge/api_docs-online-blue.svg)](https://owncloud.github.io/owncloud-sdk/)
 
 # ownCloud JavaScript SDK

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ yarn add owncloud-sdk
 
 to add the `owncloud-sdk` to your project.
 
+If you haven't done so already, you also need to add the following `peerDependencies` to your dependencies:
+
+```
+npm install axios cross-fetch promise qs semver utf8 uuid webdav xml-js
+```
+
+or
+
+```
+yarn add axios cross-fetch promise qs semver utf8 uuid webdav xml-js
+```
+
 ## Usage
 
 ```js

--- a/changelog/unreleased/change-peerdependencies
+++ b/changelog/unreleased/change-peerdependencies
@@ -1,0 +1,9 @@
+Change: Use peerDependencies instead of dependencies
+
+In the past, we used dependencies in package.json which lead to a big bundle size and increased the possibility 
+that the same package with 2 different versions is part of the final bundle of the consuming application.
+
+From now on, dependencies that are required to use the SDK are added to the peerDependencies section in package.json. 
+The consuming application then has to add the dependency on its own and can decide which minor or bugfix version to use.
+
+https://github.com/owncloud/owncloud-sdk/pull/979

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
     "dist"
   ],
   "scripts": {
-    "depcheck": "depcheck",
     "build:docs": "jsdoc -c jsdoc.conf.json",
     "build:system": "webpack",
+    "build:system:w": "webpack --watch",
+    "depcheck": "depcheck",
     "lint": "eslint tests/**/*.js tests/*.js src/**/*.js src/*.js --color --global requirejs --global require",
     "lint-fix": "eslint tests/**/*.js tests/*.js src/**/*.js src/*.js --color --global requirejs --global require --fix",
     "test-consumer": "jest --runInBand --testPathIgnorePatterns='provider.*'",

--- a/package.json
+++ b/package.json
@@ -68,26 +68,17 @@
     "not OperaMini all",
     "not OperaMobile > 0"
   ],
-  "dependencies": {
-    "axios": "^0.25.0",
-    "cross-fetch": "^3.0.6",
-    "promise": "^8.0.3",
-    "qs": "^6.10.3",
-    "semver": "^7.3.5",
-    "utf8": "^3.0.0",
-    "uuid": "^8.2.0",
-    "webdav": "4.6.0",
-    "xml-js": "^1.6.11"
-  },
   "devDependencies": {
     "@babel/core": "^7.4.4",
     "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
     "@pact-foundation/pact": "10.0.0-beta.36",
+    "axios": "^0.25.0",
     "babel-loader": "^8.0.5",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "codecov": "^3.3.0",
+    "cross-fetch": "^3.0.6",
     "depcheck": "^1.4.3",
     "eslint": "^7.32.0",
     "eslint-config-standard": "^14.1.1",
@@ -100,10 +91,28 @@
     "jasmine-data-provider": "^2.2.0",
     "jest": "^26.6.3",
     "jsdoc": "^3.6.1",
+    "promise": "^8.0.3",
+    "qs": "^6.10.3",
+    "semver": "^7.3.5",
     "sync-fetch": "^0.3.0",
+    "utf8": "^3.0.0",
+    "uuid": "^8.2.0",
+    "webdav": "4.6.0",
     "webpack": "^4.30.0",
     "webpack-cli": "^3.3.2",
     "webpack-node-externals": "^1.7.2",
+    "xml-js": "^1.6.11",
     "xml2js": "^0.4.23"
+  },
+  "peerDependencies": {
+    "axios": "^0.25.0",
+    "cross-fetch": "^3.0.6",
+    "promise": "^8.0.3",
+    "qs": "^6.10.3",
+    "semver": "^7.3.5",
+    "utf8": "^3.0.0",
+    "uuid": "^8.2.0",
+    "webdav": "4.6.0",
+    "xml-js": "^1.6.11"
   }
 }


### PR DESCRIPTION
Suggestion to align the used versions of named packages (for the `filepicker` and `web`) and reduce the bundle size (e.g. currently, `web` ships with two different axios versions in its bundle)

Fixes #972 

~Please don't merge, we'll have to test for capability of version ranges first~ should be good to go since https://github.com/owncloud/web/pull/6287 has a green web CI with the previous breaking changes