### PR TITLE
Restore query parameters on recycle list

### DIFF
--- a/src/filesTrash.js
+++ b/src/filesTrash.js
@@ -45,7 +45,10 @@ class FilesTrash {
       this.helpers._buildFullDAVPath(target),
       properties,
       depth,
-      headers
+      headers,
+      {
+        query: query
+      }
     ).then(result => {
       if (result.status !== 207) {
         return Promise.reject(this.helpers.buildHttpErrorFromDavResponse(result.status, result.body))
@@ -78,7 +81,6 @@ class FilesTrash {
       headers,
       null,
       {
-        version: 'v2',
         query: query
       }
     ).then(result => {

--- a/src/filesTrash.js
+++ b/src/filesTrash.js
@@ -47,7 +47,7 @@ class FilesTrash {
       depth,
       headers,
       {
-        query: query
+        query
       }
     ).then(result => {
       if (result.status !== 207) {
@@ -81,7 +81,7 @@ class FilesTrash {
       headers,
       null,
       {
-        query: query
+        query
       }
     ).then(result => {
       if ([200, 201, 204, 207].indexOf(result.status) > -1) {
@@ -120,7 +120,7 @@ class FilesTrash {
       headers,
       null,
       {
-        query: query
+        query
       }
     ).then(result => {
       if ([200, 201, 204, 207].indexOf(result.status) > -1) {


### PR DESCRIPTION
Remove no longer needed dav version option


Looks like if you removed one extra line (and one less) when removing the old dav endpoints.

(ping @pascalwengerter @kulmann)