### PR TITLE
Add X-Requested-With header to all requests

### DIFF
--- a/changelog/unreleased/bugfix-x-requested-with-header
+++ b/changelog/unreleased/bugfix-x-requested-with-header
@@ -1,0 +1,5 @@
+Bugfix: Always add X-Requested-With header
+
+We've added the `X-Requested-With` header to all requests as oC 10 is using this to determine whether it should treat certain requests as ajax requests or not (for example: ajax requests should never show an auth popup).
+
+https://github.com/owncloud/owncloud-sdk/pull/1020

--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -196,6 +196,7 @@ class helpers {
       headers.Authorization = this._authHeader
     }
     headers['X-Request-ID'] = uuidv4()
+    headers['X-Requested-With'] = 'XMLHttpRequest'
     return headers
   }
 


### PR DESCRIPTION
oC 10 uses this header to determine whether a request is an ajax
request. If we want to get rid of this, we need to make sure it's
not used anymore. For example currently it's used to determine
whether a PROPFIND on a password protected link should show
an auth popup or not.


Needed to fix https://github.com/owncloud/web/issues/5727