### PR TITLE
Require path for FilesTrash bin class

### DIFF
--- a/changelog/unreleased/change-files-trash-pass-full-path copy
+++ b/changelog/unreleased/change-files-trash-pass-full-path copy
@@ -1,0 +1,7 @@
+Change: Pass full trash bin path to methods of FilesTrash class
+
+Since incompatibility with spaces, we changed the way how the methods of the class
+FilesTrash(filesTrash.js) need to be called.
+Now it is mandatory to pass the full webDav(v2) path of the trash bin.
+
+https://github.com/owncloud/owncloud-sdk/pull/1021

--- a/src/filesTrash.js
+++ b/src/filesTrash.js
@@ -105,7 +105,7 @@ class FilesTrash {
    */
   restore (trashBinPath, fileId, destinationPath, overWrite = false, query = undefined) {
     if (trashBinPath === undefined) {
-      return Promise.reject(new Error('No tashBinPath given for restore'))
+      return Promise.reject(new Error('No trashBinPath given for restore'))
     }
     if (fileId === undefined) {
       return Promise.reject(new Error('No fileId given for restore'))

--- a/tests/fileTrashTest.js
+++ b/tests/fileTrashTest.js
@@ -188,7 +188,7 @@ describe('oc.fileTrash', function () {
         if (!trashEnabled) {
           pending()
         }
-        return oc.fileTrash.list('').then(trashItems => {
+        return oc.fileTrash.list(`trash-bin/${testUser}/`).then(trashItems => {
           expect(trashItems.length).toEqual(1)
           expect(trashItems[0].getName()).toEqual(testUser)
         })
@@ -319,7 +319,7 @@ describe('oc.fileTrash', function () {
         return provider.executeTest(async () => {
           const oc = createOwncloud(testUser, testUserPassword)
           await oc.login()
-          return oc.fileTrash.list('').then(trashItems => {
+          return oc.fileTrash.list(`trash-bin/${testUser}/`).then(trashItems => {
             expect(trashItems.length).toEqual(2)
             expect(trashItems[1].getProperty('{http://owncloud.org/ns}trashbin-original-filename')).toEqual(testFolder)
           })
@@ -336,7 +336,7 @@ describe('oc.fileTrash', function () {
         return provider.executeTest(async () => {
           const oc = createOwncloud(testUser, testUserPassword)
           await oc.login()
-          return oc.fileTrash.list('').then(trashItems => {
+          return oc.fileTrash.list(`trash-bin/${testUser}/`).then(trashItems => {
             expect(trashItems.length).toEqual(2)
             expect(trashItems[1].getProperty('{http://owncloud.org/ns}trashbin-original-filename')).toEqual(testFolder)
             expect(trashItems[1].getProperty('{http://owncloud.org/ns}trashbin-original-location')).toEqual(testFolder)
@@ -466,8 +466,8 @@ describe('oc.fileTrash', function () {
         return provider.executeTest(async () => {
           const oc = createOwncloud(testUser, testUserPassword)
           await oc.login()
-          return oc.fileTrash.restore(deletedFolderId, originalLocation).then(() => {
-            return oc.fileTrash.list('').then(trashItems => {
+          return oc.fileTrash.restore(`trash-bin/${testUser}`, deletedFolderId, `files/${testUser}/${originalLocation}`).then(() => {
+            return oc.fileTrash.list(`trash-bin/${testUser}/`).then(trashItems => {
               expect(trashItems.length).toEqual(1)
               expect(trashItems[0].getName()).toEqual(testUser)
               return oc.files.fileInfo(`files/${testUser}/${testFolder}`).then(fileInfo => {
@@ -599,8 +599,8 @@ describe('oc.fileTrash', function () {
         return provider.executeTest(async () => {
           const oc = createOwncloud(testUser, testUserPassword)
           await oc.login()
-          return oc.fileTrash.restore(deletedFolderId, originalLocation).then(() => {
-            return oc.fileTrash.list('').then(trashItems => {
+          return oc.fileTrash.restore(`trash-bin/${testUser}`, deletedFolderId, `files/${testUser}/${originalLocation}`).then(() => {
+            return oc.fileTrash.list(`trash-bin/${testUser}/`).then(trashItems => {
               expect(trashItems.length).toEqual(1)
               expect(trashItems[0].getName()).toEqual(testUser)
               return oc.files.fileInfo(`files/${testUser}/${originalLocation}`).then(fileInfo => {
@@ -710,7 +710,7 @@ describe('oc.fileTrash', function () {
           if (!trashEnabled) {
             pending()
           }
-          return oc.fileTrash.list('').then(trashItems => {
+          return oc.fileTrash.list(`trash-bin/${testUser}/`).then(trashItems => {
             expect(trashItems.length).toEqual(2)
             expect(trashItems[1].getProperty('{http://owncloud.org/ns}trashbin-original-filename')).toEqual(testFile)
             expect(trashItems[1].getProperty('{http://owncloud.org/ns}trashbin-original-location')).toEqual(`${testFolder}/${testFile}`)
@@ -828,8 +828,8 @@ describe('oc.fileTrash', function () {
         return provider.executeTest(async () => {
           const oc = createOwncloud(testUser, testUserPassword)
           await oc.login()
-          return oc.fileTrash.restore(deletedFolderId, originalLocation).then(() => {
-            return oc.fileTrash.list('').then(trashItems => {
+          return oc.fileTrash.restore(`trash-bin/${testUser}`, deletedFolderId, `files/${testUser}/${originalLocation}`).then(() => {
+            return oc.fileTrash.list(`trash-bin/${testUser}/`).then(trashItems => {
               expect(trashItems.length).toEqual(1)
               expect(trashItems[0].getName()).toEqual(testUser)
               return oc.files.fileInfo(`files/${testUser}/${testFolder}`).then(fileInfo => {
@@ -960,8 +960,8 @@ describe('oc.fileTrash', function () {
         return provider.executeTest(async () => {
           const oc = createOwncloud(testUser, testUserPassword)
           await oc.login()
-          return oc.fileTrash.restore(deletedFolderId, originalLocation).then(() => {
-            return oc.fileTrash.list('').then(trashItems => {
+          return oc.fileTrash.restore(`trash-bin/${testUser}`, deletedFolderId, `files/${testUser}/${originalLocation}`).then(() => {
+            return oc.fileTrash.list(`trash-bin/${testUser}/`).then(trashItems => {
               expect(trashItems.length).toEqual(1)
               expect(trashItems[0].getName()).toEqual(testUser)
               return oc.files.fileInfo(`files/${testUser}/${originalLocation}`).then(fileInfo => {
@@ -1022,7 +1022,7 @@ describe('oc.fileTrash', function () {
         return provider.executeTest(async () => {
           const oc = createOwncloud(testUser, testUserPassword)
           await oc.login()
-          return oc.fileTrash.restore(deletedFolderId, 'non-existing/new-file.txt').then(() => {
+          return oc.fileTrash.restore(`trash-bin/${testUser}`, deletedFolderId, `files/${testUser}/non-existing/new-file.txt`).then(() => {
             fail('Restoring to non existing location should fail but passed')
           }).catch(error => {
             expect(error.message).toBe('The destination node is not found')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1861,11 +1861,6 @@ ansi-regex@^2.0.0, ansi-regex@^2.1.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
   integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
-ansi-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
-
 ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
@@ -1920,9 +1915,9 @@ aproba@^1.0.3, aproba@^1.1.1:
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
 are-we-there-yet@~1.1.2:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
-  integrity sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz#b15474a932adab4ff8a50d9adfa7e4e926f21146"
+  integrity sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
@@ -4910,11 +4905,6 @@ is-fullwidth-code-point@^1.0.0:
   dependencies:
     number-is-nan "^1.0.0"
 
-is-fullwidth-code-point@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-  integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
-
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
@@ -6842,9 +6832,9 @@ pino-std-serializers@^3.1.0:
   integrity sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==
 
 pino@^6.11.0, pino@^6.5.1:
-  version "6.13.4"
-  resolved "https://registry.yarnpkg.com/pino/-/pino-6.13.4.tgz#e7bd5e8292019609c841c37a3f1d73ee10bb80f7"
-  integrity sha512-g4tHSISmQJYUEKEMVdaZ+ZokWwFnTwZL5JPn+lnBVZ1BuBbrSchrXwQINknkM5+Q4fF6U9NjiI8PWwwMDHt9zA==
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-6.14.0.tgz#b745ea87a99a6c4c9b374e4f29ca7910d4c69f78"
+  integrity sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==
   dependencies:
     fast-redact "^3.0.0"
     fast-safe-stringify "^2.0.8"
@@ -7943,13 +7933,14 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
-  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^4.0.0"
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
@@ -7959,15 +7950,6 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string.prototype.trimend@^1.0.4:
   version "1.0.4"
@@ -8005,13 +7987,6 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
-  dependencies:
-    ansi-regex "^3.0.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -8863,11 +8838,11 @@ which@^2.0.1, which@^2.0.2:
     isexe "^2.0.0"
 
 wide-align@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
-  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
+  integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
   dependencies:
-    string-width "^1.0.2 || 2"
+    string-width "^1.0.2 || 2 || 3 || 4"
 
 wildcard@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Change: Pass full trash bin path to methods of FilesTrash class

Since incompatibility with spaces, we changed the way how the methods of the class
FilesTrash(filesTrash.js) need to be called.
Now it is mandatory to pass the full webDav(v2) path of the trash bin.