### PR TITLE
Add the space_ref param for link- and user-shares

### DIFF
--- a/changelog/unreleased/enhancement-share-spaces
+++ b/changelog/unreleased/enhancement-share-spaces
@@ -8,3 +8,4 @@ This includes the following changes:
 
 https://github.com/owncloud/owncloud-sdk/pull/1013
 https://github.com/owncloud/owncloud-sdk/pull/1025
+https://github.com/owncloud/owncloud-sdk/pull/1027

--- a/src/shareManagement.js
+++ b/src/shareManagement.js
@@ -51,6 +51,11 @@ class Shares {
     }
 
     if (optionalParams) {
+      if (optionalParams.spaceRef) {
+        postData.space_ref = optionalParams.spaceRef
+        delete postData.path
+      }
+
       if (optionalParams.permissions) {
         postData.permissions = optionalParams.permissions
       }
@@ -90,7 +95,6 @@ class Shares {
    */
   shareFileWithUser (path, username, optionalParams) {
     path = this.helpers._normalizePath(path)
-    const urlParams = new URLSearchParams()
 
     let postData = {
       shareType: this.helpers.OCS_SHARE_TYPE_USER,
@@ -100,16 +104,14 @@ class Shares {
 
     if (optionalParams) {
       if (optionalParams.spaceRef) {
-        urlParams.append('space_ref', optionalParams.spaceRef)
+        postData.space_ref = optionalParams.spaceRef
         delete postData.path
       }
 
       postData = { ...postData, ...this._getOptionalParams(optionalParams) }
     }
 
-    const urlPath = urlParams.toString() ? `shares?${urlParams.toString()}` : 'shares'
-
-    return this.helpers._makeOCSrequest('POST', this.helpers.OCS_SERVICE_SHARE, urlPath, postData)
+    return this.helpers._makeOCSrequest('POST', this.helpers.OCS_SERVICE_SHARE, 'shares', postData)
       .then(data => {
         const shareData = data.data.ocs.data
         const share = new ShareInfo(shareData)
@@ -169,6 +171,11 @@ class Shares {
     }
 
     if (optionalParams) {
+      if (optionalParams.spaceRef) {
+        postData.space_ref = optionalParams.spaceRef
+        delete postData.path
+      }
+
       postData = { ...postData, ...this._getOptionalParams(optionalParams) }
     }
 
@@ -193,7 +200,7 @@ class Shares {
     let data = 'shares'
     const send = {}
 
-    if (path !== '') {
+    if (path !== '' || (optionalParams && optionalParams.spaceRef)) {
       data += '?'
 
       send.path = this.helpers._normalizePath(path)

--- a/src/shareManagement.js
+++ b/src/shareManagement.js
@@ -200,36 +200,38 @@ class Shares {
     let data = 'shares'
     const send = {}
 
-    if (path !== '' || (optionalParams && optionalParams.spaceRef)) {
-      data += '?'
-
+    if (path !== '') {
       send.path = this.helpers._normalizePath(path)
-      optionalParams = this.helpers._convertObjectToBool(optionalParams)
+    }
 
-      if (optionalParams) {
-        if (optionalParams.spaceRef) {
-          send.space_ref = optionalParams.spaceRef
-          delete send.path
-        }
+    optionalParams = this.helpers._convertObjectToBool(optionalParams)
 
-        if (optionalParams.reshares && typeof (optionalParams.reshares) === 'boolean') {
-          send.reshares = optionalParams.reshares
-        }
-
-        if (optionalParams.subfiles && typeof (optionalParams.subfiles) === 'boolean') {
-          send.subfiles = optionalParams.subfiles
-        }
-
-        /* jshint camelcase: false */
-        if (optionalParams.shared_with_me && typeof (optionalParams.shared_with_me) === 'boolean') {
-          send.shared_with_me = optionalParams.shared_with_me
-          if (optionalParams.state) {
-            send.state = optionalParams.state
-          }
-        }
-        /* jshint camelcase: true */
+    if (optionalParams) {
+      if (optionalParams.spaceRef) {
+        send.space_ref = optionalParams.spaceRef
+        delete send.path
       }
 
+      if (optionalParams.reshares && typeof (optionalParams.reshares) === 'boolean') {
+        send.reshares = optionalParams.reshares
+      }
+
+      if (optionalParams.subfiles && typeof (optionalParams.subfiles) === 'boolean') {
+        send.subfiles = optionalParams.subfiles
+      }
+
+      /* jshint camelcase: false */
+      if (optionalParams.shared_with_me && typeof (optionalParams.shared_with_me) === 'boolean') {
+        send.shared_with_me = optionalParams.shared_with_me
+        if (optionalParams.state) {
+          send.state = optionalParams.state
+        }
+      }
+      /* jshint camelcase: true */
+    }
+
+    if (Object.keys(send).length) {
+      data += '?'
       let urlString = ''
       for (const key in send) {
         urlString += '&' + encodeURIComponent(key) + '=' + encodeURIComponent(send[key])


### PR DESCRIPTION
In addition to https://github.com/owncloud/owncloud-sdk/pull/1025

Also moved the `space_ref` param for the user sharing to post params to keep that consistent with the rest. It's the preferred way for the backend as I found out.