### PR TITLE
Add handling for additional responseType 'blob'

### DIFF
--- a/changelog/unreleased/enhancement-resolve-type-blob
+++ b/changelog/unreleased/enhancement-resolve-type-blob
@@ -1,0 +1,5 @@
+Enhancement: Add blob resolveType
+
+We now support blob as resolveType for requests in addition to text and arrayBuffer.
+
+https://github.com/owncloud/owncloud-sdk/pull/1028

--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -345,6 +345,10 @@ class helpers {
               body = await res.arrayBuffer()
               break
 
+            case 'blob':
+              body = await res.blob()
+              break
+
             default:
               body = await res.text()
           }


### PR DESCRIPTION
`arrayBuffer` can be converted to a blob, but no need to do that, when we can retrieve it directly and the change is quite minimal.
