### PR TITLE
Bugfix propfind response cut off

### DIFF
--- a/src/dav.js
+++ b/src/dav.js
@@ -282,6 +282,19 @@ export class Dav {
           }
           continue
         }
+        if (node.constructor === Object && Object.keys(node).length !== 0) {
+          const parseChildren = (parseNode) => {
+            Object.entries(parseNode).forEach(([key, value]) => {
+              delete parseNode[key]
+              parseNode[key.split(':')[1]] = value
+              if (value.constructor === Object) {
+                parseChildren(value)
+              }
+            })
+          }
+          parseChildren(propNode)
+          return propNode
+        }
         var nsComponent = key.split(':')[0]
         var localComponent = key.split(':')[1]
         var nsValue = this.xmlNamespacesComponents[nsComponent]


### PR DESCRIPTION
We've fixed an issue where `_parsePropNode` in the dav client cut off subobjects of an object.