### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/changelog/unreleased/change-replace-deprecated-substr
+++ b/changelog/unreleased/change-replace-deprecated-substr
@@ -1,0 +1,7 @@
+Change: Replace deprecated String.prototype.substr()
+
+We've replaced all occurrences of the deprecated String.prototype.substr()
+function with String.prototype.slice() which works similarly but isn't
+deprecated.
+
+https://github.com/owncloud/owncloud-sdk/pull/1035

--- a/src/systemTags.js
+++ b/src/systemTags.js
@@ -52,7 +52,7 @@ class SystemTags {
         return Promise.reject(new Error('Error: ' + result.status))
       } else {
         const contentLocation = result.res.headers['content-location']
-        return Promise.resolve(parseInt(contentLocation.substr(contentLocation.lastIndexOf('/') + 1), 10))
+        return Promise.resolve(parseInt(contentLocation.slice(contentLocation.lastIndexOf('/') + 1), 10))
       }
     })
   }

--- a/tests/loginTest.js
+++ b/tests/loginTest.js
@@ -3,7 +3,7 @@ describe('Main: Currently testing Login and initLibrary,', function () {
   var config = require('./config/config.json')
 
   // CURRENT TIME
-  var timeRightNow = Math.random().toString(36).substr(2, 9)
+  var timeRightNow = Math.random().toString(36).slice(2, 11)
 
   // LIBRARY INSTANCE
   var oc


### PR DESCRIPTION

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.