### PR TITLE
Respect optional quicklink param for shareFileWithLink

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "env": {
     "browser": true,
     "es6": true,
-    "jasmine": true
+    "jasmine": true,
+    "jest": true
   },
   "extends": [
     "standard"

--- a/changelog/unreleased/enhancement-quicklink
+++ b/changelog/unreleased/enhancement-quicklink
@@ -1,0 +1,8 @@
+Enhancement: Create quicklink
+
+We've added the option to create quicklinks which under the hood is the same as a link expect
+the fact that a quicklink can only exist once per item.
+
+https://github.com/owncloud/owncloud-sdk/pull/1041
+https://github.com/owncloud/web/issues/6605
+https://github.com/cs3org/reva/pull/2715

--- a/changelog/unreleased/enhancement-quicklink
+++ b/changelog/unreleased/enhancement-quicklink
@@ -1,8 +1,8 @@
 Enhancement: Create quicklink
 
-We've added the option to create quicklinks which under the hood is the same as a link expect
-the fact that a quicklink can only exist once per item.
+We've added the option to define if a share link is of type quicklink or not.
 
 https://github.com/owncloud/owncloud-sdk/pull/1041
 https://github.com/owncloud/web/issues/6605
+https://github.com/owncloud/core/pull/39167
 https://github.com/cs3org/reva/pull/2715

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,19 +4,20 @@
  */
 
 module.exports = {
-  coverageDirectory: "coverage",
+  coverageDirectory: 'coverage',
   coveragePathIgnorePatterns: [
-    "node_modules/",
-    "vendor/",
-    "tests/"
+    'node_modules/',
+    'vendor/',
+    'tests/'
   ],
-  globalSetup: "<rootDir>/jest.setup.js",
-  "setupFiles": [
-    "<rootDir>/jest.init.js"
+  globalSetup: '<rootDir>/jest.setup.js',
+  setupFiles: [
+    '<rootDir>/jest.init.js'
   ],
   testEnvironment: 'node',
   testMatch: [
+    '**/tests/*.spec.js',
     '**/tests/*Test.js',
     '**/tests/**/*Test.js'
   ]
-};
+}

--- a/src/shareManagement.js
+++ b/src/shareManagement.js
@@ -55,7 +55,6 @@ class Shares {
         postData.space_ref = optionalParams.spaceRef
         delete postData.path
       }
-
       if (optionalParams.permissions) {
         postData.permissions = optionalParams.permissions
       }
@@ -73,6 +72,9 @@ class Shares {
       }
       if (optionalParams.attributes) {
         postData.attributes = optionalParams.attributes
+      }
+      if (optionalParams.quicklink) {
+        postData.quicklink = optionalParams.quicklink
       }
     }
 

--- a/src/shareManagement.js
+++ b/src/shareManagement.js
@@ -50,6 +50,18 @@ class Shares {
       path: path
     }
 
+    const reflectClassicAttribute = (key, scope, value, exclusive = true) => {
+      const attributes = [...postData.attributes || []]
+      const current = attributes.findIndex(v => v.scope === scope && v.key === key)
+
+      if (current !== -1 && exclusive) {
+        attributes.splice(current, 1)
+      }
+
+      attributes.push({ key, scope, value })
+      postData.attributes = attributes
+    }
+
     if (optionalParams) {
       if (optionalParams.spaceRef) {
         postData.space_ref = optionalParams.spaceRef
@@ -75,11 +87,7 @@ class Shares {
       }
       if (optionalParams.quicklink) {
         postData.quicklink = optionalParams.quicklink
-        postData.attributes = [...postData.attributes || [], {
-          scope: 'files_sharing',
-          key: 'isQuickLink',
-          value: postData.quicklink
-        }]
+        reflectClassicAttribute('isQuickLink', 'files_sharing', postData.quicklink)
       }
     }
 

--- a/src/shareManagement.js
+++ b/src/shareManagement.js
@@ -75,6 +75,11 @@ class Shares {
       }
       if (optionalParams.quicklink) {
         postData.quicklink = optionalParams.quicklink
+        postData.attributes = [...postData.attributes || [], {
+          scope: 'files_sharing',
+          key: 'isQuickLink',
+          value: postData.quicklink
+        }]
       }
     }
 

--- a/tests/shareManagement.spec.js
+++ b/tests/shareManagement.spec.js
@@ -1,0 +1,75 @@
+import Shares from '../src/shareManagement.js'
+
+jest.mock('../src/xmlParser', () => ({
+  xml2js: (data) => ({ ocs: data })
+}))
+
+describe('shareManagement', () => {
+  describe('shareFileWithLink', () => {
+    it('creates a quicklink which is ocis and oc10 compliant', async () => {
+      const mr = jest.fn(async function () {
+        return { body: arguments[3] }
+      })
+      const shares = new Shares({ _makeOCSrequest: mr, _normalizePath: jest.fn(p => p) })
+
+      await shares.shareFileWithLink('/any', { quicklink: true })
+      expect(mr.mock.calls[0][3].quicklink).toBe(true)
+      expect(mr.mock.calls[0][3].attributes.length).toBe(1)
+      expect(mr.mock.calls[0][3].attributes[0].key).toBe('isQuickLink')
+      expect(mr.mock.calls[0][3].attributes[0].scope).toBe('files_sharing')
+      expect(mr.mock.calls[0][3].attributes[0].value).toBe(true)
+
+      await shares.shareFileWithLink('/any', { quicklink: false })
+      expect(mr.mock.calls[1][3].quicklink).toBeUndefined()
+      expect(mr.mock.calls[1][3].attributes).toBeUndefined()
+
+      await shares.shareFileWithLink('/any', {
+        quicklink: true,
+        attributes: [{ key: 'isQuickLink', scope: 'files_sharing', value: true }]
+      })
+      expect(mr.mock.calls[2][3].quicklink).toBe(true)
+      expect(mr.mock.calls[2][3].attributes.length).toBe(1)
+      expect(mr.mock.calls[2][3].attributes[0].key).toBe('isQuickLink')
+      expect(mr.mock.calls[2][3].attributes[0].scope).toBe('files_sharing')
+      expect(mr.mock.calls[2][3].attributes[0].value).toBe(true)
+
+      await shares.shareFileWithLink('/any', {
+        quicklink: true,
+        attributes: [{ key: 'other', scope: 'files_sharing', value: true }]
+      })
+      expect(mr.mock.calls[3][3].quicklink).toBe(true)
+      expect(mr.mock.calls[3][3].attributes.length).toBe(2)
+      expect(mr.mock.calls[3][3].attributes[0].key).toBe('other')
+      expect(mr.mock.calls[3][3].attributes[1].key).toBe('isQuickLink')
+      expect(mr.mock.calls[3][3].attributes[1].scope).toBe('files_sharing')
+      expect(mr.mock.calls[3][3].attributes[1].value).toBe(true)
+
+      await shares.shareFileWithLink('/any', {
+        quicklink: true,
+        attributes: [
+          { key: 'key_1', scope: 'scope_1', value: true },
+          { key: 'key_2', scope: 'scope_2', value: true },
+          { key: 'key_3', scope: 'scope_3', value: true },
+          { key: 'key_4', scope: 'scope_4', value: true },
+          { key: 'key_5', scope: 'scope_5', value: true }
+        ]
+      })
+      expect(mr.mock.calls[4][3].attributes.length).toBe(6)
+
+      await shares.shareFileWithLink('/any', {
+        quicklink: true,
+        attributes: [
+          { key: 'key_1', scope: 'scope_1', value: true },
+          { key: 'key_2', scope: 'scope_2', value: true },
+          { key: 'key_3', scope: 'scope_3', value: true },
+          { key: 'isQuickLink', scope: 'files_sharing', value: false },
+          { key: 'key_5', scope: 'scope_5', value: true }
+        ]
+      })
+      expect(mr.mock.calls[5][3].attributes.length).toBe(5)
+      expect(mr.mock.calls[5][3].attributes[4].key).toBe('isQuickLink')
+      expect(mr.mock.calls[5][3].attributes[4].scope).toBe('files_sharing')
+      expect(mr.mock.calls[5][3].attributes[4].value).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
[#2715](https://github.com/cs3org/reva/pull/2715) introduced a new link variant which only can exist once per resource, this is needed for [6605](https://github.com/owncloud/web/issues/6605).