### PR TITLE
Emit OC-Etag

### DIFF
--- a/changelog/unreleased/enhancement-send-oc-etag
+++ b/changelog/unreleased/enhancement-send-oc-etag
@@ -1,0 +1,5 @@
+Enhancement: send oc-etag on putFileContents and getFileContents methods
+
+Due to server encoding, the ETag might differ from OC-ETag, therefore we emit both.
+
+https://github.com/owncloud/owncloud-sdk/pull/1067

--- a/src/fileManagement.js
+++ b/src/fileManagement.js
@@ -91,7 +91,7 @@ class Files {
           body: body,
           headers: {
             ETag: response.headers.get('etag'),
-            'OC-ETag': response.headers.get('OC-ETag'),
+            'OC-ETag': response.headers.get('oc-etag'),
             'OC-FileId': response.headers.get('oc-fileid')
           }
         })

--- a/src/fileManagement.js
+++ b/src/fileManagement.js
@@ -173,7 +173,7 @@ class Files {
       if ([200, 201, 204, 207].indexOf(result.status) > -1) {
         return Promise.resolve({
           ETag: result.res.headers.etag,
-          'OC-ETag': result.res.headers['OC-ETag'],
+          'OC-ETag': result.res.headers['oc-etag'],
           'OC-FileId': result.res.headers['oc-fileid']
         })
       } else {

--- a/src/fileManagement.js
+++ b/src/fileManagement.js
@@ -91,6 +91,7 @@ class Files {
           body: body,
           headers: {
             ETag: response.headers.get('etag'),
+            'OC-ETag': response.headers.get('OC-ETag'),
             'OC-FileId': response.headers.get('oc-fileid')
           }
         })
@@ -172,6 +173,7 @@ class Files {
       if ([200, 201, 204, 207].indexOf(result.status) > -1) {
         return Promise.resolve({
           ETag: result.res.headers.etag,
+          'OC-ETag': result.res.headers['OC-ETag'],
           'OC-FileId': result.res.headers['oc-fileid']
         })
       } else {


### PR DESCRIPTION
Enhancement: send oc-etag on putFileContents and getFileContents methods

Due to server encoding, the ETag might differ from OC-ETag, therefore we emit both.