### PR TITLE
Removed `depth infinity` related test and `dav.propfind.depth_infinity` from drone

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -261,7 +261,6 @@ def setupServerAndApp():
         "commands": [
             "cd /var/www/owncloud/server/",
             "php occ config:system:set trusted_domains 1 --value=owncloud",
-            "php occ config:system:set dav.propfind.depth_infinity --value=true",
         ],
     }]
 

--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -342,35 +342,6 @@ describe('Main: Currently testing files management,', function () {
       })
     })
 
-    it('checking method : list with Infinity depth', async function () {
-      const provider = createProvider(true, true)
-      await getCapabilitiesInteraction(provider, config.testUser, config.testUserPassword)
-      await getCurrentUserInformationInteraction(
-        provider, config.testUser, config.testUserPassword
-      )
-      await listFolderContentInteraction(
-        provider,
-        'test folder, with infinity depth',
-        testFolder,
-        ['abc.txt', 'file one.txt', 'subdir/in dir.txt', 'zz+z.txt', '中文.txt'], ['subdir'], 'infinity'
-      )
-      return provider.executeTest(async () => {
-        const oc = createOwncloud(config.testUser, config.testUserPassword)
-        await oc.login()
-        return oc.files.list(`files/${config.testUser}/${testFolder}`, 'infinity')
-          .then(files => {
-            expect(typeof (files)).toBe('object')
-            expect(files.length).toEqual(7)
-            expect(files[3].getName()).toEqual('subdir')
-            expect(files[3].isDir()).toBe(true)
-            expect(files[4].getPath()).toEqual(`/files/${username}/${testFolder}/subdir/`)
-            expect(files[4].isDir()).toBe(false)
-          }).catch(error => {
-            expect(error).toBe(null)
-          })
-      })
-    })
-
     // [oCIS] request to non-existing file gives empty response body
     // https://github.com/owncloud/ocis/issues/1799
     it('checking method : list with non existent file', async function () {

--- a/tests/helpers/webdavHelper.js
+++ b/tests/helpers/webdavHelper.js
@@ -180,7 +180,7 @@ const propfind = function (path, userId, password, properties, type = 'files', f
  * @param {string} password
  * @param {number|string} depth
  */
-const getTrashBinElements = function (user, password, depth = 'infinity') {
+const getTrashBinElements = function (user, password, depth = '1') {
   const str = propfind(
     '/',
     user,


### PR DESCRIPTION
This PR removes tests related to depth `infinity` and also set to `dav.propfind.depth_infinity` is removed from CI as OC 10.10 by default does not allow to request depth=infinity in PROPFIND
Part of this issue : https://github.com/owncloud/web/issues/7029