### PR TITLE
Optional no cache for public links

### DIFF
--- a/changelog/unreleased/bugfix-no-cache-pl
+++ b/changelog/unreleased/bugfix-no-cache-pl
@@ -1,0 +1,5 @@
+Bugfix: Optional no cache for public links
+
+Adds a new  `noCache` option to the public links' `download` method, which sets the `Cache-Control: no-cache` header.
+
+https://github.com/owncloud/owncloud-sdk/pull/1079

--- a/src/publicLinkAccess.js
+++ b/src/publicLinkAccess.js
@@ -69,11 +69,17 @@ class PublicFiles {
    * @param  {string}       token    public share token - may contain the path as well
    * @param  {string|null}  path     path to a file in the share
    * @param  {string|null}  password
+   * @param  {Object}       options
    * @return {Promise<Response>}
    */
-  download (token, path = null, password = null) {
+  download (token, path = null, password = null, options = {}) {
     const headers = this.helpers.buildHeaders(false)
     const url = this.getFileUrl(token, path)
+
+    const noCache = options.noCache || false
+    if (noCache) {
+      headers['Cache-Control'] = 'no-cache'
+    }
 
     if (password) {
       headers.Authorization = 'Basic ' + Buffer.from('public:' + password).toString('base64')


### PR DESCRIPTION
Just like we added the `noCache` option to `getFileContents`, I just realized the same needs to be applied to the public links after all.

Let me know if you prefer this as a parameter or something more generic.