### PR TITLE
[tests-only] Refactor tests to use users from user config

### DIFF
--- a/tests/appsTest.js
+++ b/tests/appsTest.js
@@ -2,7 +2,9 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 describe('Main: Currently testing apps management,', function () {
   const nonExistentApp = 'nonExistentApp123'
-  const { adminUsername: username } = require('./config/config.json')
+  const {
+    admin: { username: adminUsername }
+  } = require('./config/users.json')
 
   // PACT setup
   const {
@@ -32,7 +34,7 @@ describe('Main: Currently testing apps management,', function () {
       })
     }
     return provider
-      .uponReceiving(`as '${username}', a ${method} request to ${action} an app`)
+      .uponReceiving(`as '${adminUsername}', a ${method} request to ${action} an app`)
       .withRequest({
         method,
         path: MatchersV3.regex(
@@ -50,7 +52,7 @@ describe('Main: Currently testing apps management,', function () {
 
   const getAppsInteraction = (provider, query) => {
     return provider
-      .uponReceiving(`as '${username}', a GET request to get all apps`)
+      .uponReceiving(`as '${adminUsername}', a GET request to get all apps`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(

--- a/tests/capabilitiesTest.js
+++ b/tests/capabilitiesTest.js
@@ -2,7 +2,9 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 describe('Main: Currently testing getConfig, getVersion and getCapabilities', () => {
   let oc
-  const { adminUsername: username } = require('./config/config.json')
+  const {
+    admin: { username: adminUsername }
+  } = require('./config/users.json')
 
   const {
     createProvider,
@@ -18,7 +20,7 @@ describe('Main: Currently testing getConfig, getVersion and getCapabilities', ()
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)
     await provider
-      .uponReceiving(`as '${username}', a GET request to get server config`)
+      .uponReceiving(`as '${adminUsername}', a GET request to get server config`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(

--- a/tests/config/config.drone.json
+++ b/tests/config/config.drone.json
@@ -1,13 +1,6 @@
 {
     "pactMockHost": "http://localhost",
     "pactMockPort": 1234,
-    "adminUsername": "admin",
-    "adminPassword": "admin",
-    "adminDisplayName": "Admin",
-    "testUser": "test123",
-    "testUserPassword": "test123",
-    "testUser2": "testABC",
-    "testUser2Password": "testABC",
     "testGroup": "testGroup",
     "nonExistentUser": "thisUserShouldNotExist",
     "nonExistentGroup": "thisGroupShouldNotExist",

--- a/tests/config/config.sample.json
+++ b/tests/config/config.sample.json
@@ -1,13 +1,6 @@
 {
     "pactMockHost": "http://127.0.0.1",
     "pactMockPort": 1234,
-    "adminUsername": "admin",
-    "adminPassword": "admin",
-    "adminDisplayName": "Admin",
-    "testUser": "test123",
-    "testUserPassword": "test123",
-    "testUser2": "testABC",
-    "testUser2Password": "testABC",
     "testGroup": "testGroup",
     "nonExistentUser": "thisUserShouldNotExist",
     "nonExistentGroup": "thisGroupShouldNotExist",

--- a/tests/config/users.json
+++ b/tests/config/users.json
@@ -5,16 +5,16 @@
     "displayname": "Admin",
     "email": "admin@example.com"
   },
-  "Alice": {
-    "username": "Alice",
+  "testUser1": {
+    "username": "testUser1",
     "password": "1234",
-    "displayname": "Alice Hansen",
-    "email": "alice@example.com"
+    "displayname": "Test User1",
+    "email": "testUser1@example.com"
   },
-  "Brian": {
-    "username": "Brian",
+  "testUser2": {
+    "username": "testUser2",
     "password": "1234",
-    "displayname": "Brian Murphy",
-    "email": "brian@example.com"
+    "displayname": "Test User2",
+    "email": "testUser2@example.com"
   }
 }

--- a/tests/config/users.json
+++ b/tests/config/users.json
@@ -1,0 +1,20 @@
+{
+  "admin": {
+    "username": "admin",
+    "password": "admin",
+    "displayname": "Admin",
+    "email": "admin@example.com"
+  },
+  "Alice": {
+    "username": "Alice",
+    "password": "1234",
+    "displayname": "Alice Hansen",
+    "email": "alice@example.com"
+  },
+  "Brian": {
+    "username": "Brian",
+    "password": "1234",
+    "displayname": "Brian Murphy",
+    "email": "brian@example.com"
+  }
+}

--- a/tests/fileTrashTest.js
+++ b/tests/fileTrashTest.js
@@ -108,8 +108,8 @@ describe('oc.fileTrash', function () {
           .appendElement('d:propstat', '', dPropstat => {
             dPropstat.appendElement('d:prop', '', dProp => {
               dProp
-                .appendElement('oc:trashbin-original-filename', '', MatchersV3.equal('testFolder'))
-                .appendElement('oc:trashbin-original-location', '', MatchersV3.equal('testFolder'))
+                .appendElement('oc:trashbin-original-filename', '', MatchersV3.equal(testFolder))
+                .appendElement('oc:trashbin-original-location', '', MatchersV3.equal(testFolder))
                 .appendElement('oc:trashbin-delete-timestamp', '', MatchersV3.regex('\\d+', '1615955759'))
                 .appendElement('d:resourcetype', '', dResourceType => {
                   dResourceType.appendElement('d:collection', '', '')
@@ -274,8 +274,8 @@ describe('oc.fileTrash', function () {
                   .appendElement('d:propstat', '', dPropstat => {
                     dPropstat.appendElement('d:prop', '', dProp => {
                       dProp
-                        .appendElement('oc:trashbin-original-filename', '', MatchersV3.equal('testFolder'))
-                        .appendElement('oc:trashbin-original-location', '', MatchersV3.equal('testFolder'))
+                        .appendElement('oc:trashbin-original-filename', '', MatchersV3.equal(testFolder))
+                        .appendElement('oc:trashbin-original-location', '', MatchersV3.equal(testFolder))
                         .appendElement('oc:trashbin-delete-timestamp', '', MatchersV3.regex('\\d+', '1615955759'))
                         .appendElement('d:resourcetype', '', dResourceType => {
                           dResourceType.appendElement('d:collection', '', '')
@@ -296,8 +296,8 @@ describe('oc.fileTrash', function () {
                   .appendElement('d:propstat', '', dPropstat => {
                     dPropstat.appendElement('d:prop', '', dProp => {
                       dProp
-                        .appendElement('oc:trashbin-original-filename', '', MatchersV3.equal('testFile.txt'))
-                        .appendElement('oc:trashbin-original-location', '', MatchersV3.equal('testFolder/testFile.txt'))
+                        .appendElement('oc:trashbin-original-filename', '', MatchersV3.equal(testFile))
+                        .appendElement('oc:trashbin-original-location', '', MatchersV3.equal(`${testFolder}/${testFile}`))
                         .appendElement('oc:trashbin-delete-timestamp', '', MatchersV3.regex('\\d+', '1615955759'))
                         .appendElement('d:getcontentlength', '', MatchersV3.equal('6'))
                         .appendElement('d:resourcetype', '', '')
@@ -841,6 +841,7 @@ describe('oc.fileTrash', function () {
 
     describe('and when this deleted file is restored to a different location', function () {
       const originalLocation = 'file (restored to a different location).txt'
+      const urlEncodedFile = encodeURIComponent(originalLocation)
 
       const MoveFromTrashbinToDifferentLocation = provider => {
         return provider
@@ -867,7 +868,7 @@ describe('oc.fileTrash', function () {
             ),
             headers: {
               authorization: getAuthHeaders(username, password),
-              Destination: mockServerBaseUrl + 'remote.php/dav/files/' + username + '/file%20(restored%20to%20a%20different%20location).txt'
+              Destination: `${mockServerBaseUrl}remote.php/dav/files/${username}/${urlEncodedFile}`
             }
           })
           .willRespondWith({
@@ -916,7 +917,7 @@ describe('oc.fileTrash', function () {
             method: 'PROPFIND',
             path: MatchersV3.regex(
               `.*\\/remote\\.php\\/dav\\/files\\/${username}\\/.*`,
-              `/remote.php/dav/files/${username}/file%20(restored%20to%20a%20different%20location).txt/`
+              `/remote.php/dav/files/${username}/${urlEncodedFile}/`
             ),
             headers: { authorization: getAuthHeaders(username, password), ...applicationXmlResponseHeaders },
             body: filesListXmlRequestBody
@@ -931,7 +932,7 @@ describe('oc.fileTrash', function () {
                 'xmlns:oc': 'http://owncloud.org/ns'
               })
               dMultistatus.appendElement('d:response', '', dResponse => {
-                dResponse.appendElement('d:href', '', MatchersV3.equal(`/remote.php/dav/files/${username}/file%20(restored%20to%20a%20different%20location).txt`))
+                dResponse.appendElement('d:href', '', MatchersV3.equal(`/remote.php/dav/files/${username}/${urlEncodedFile}`))
                   .appendElement('d:propstat', '', dPropstat => {
                     dPropstat.appendElement('d:prop', '', dProp => {
                       dProp

--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -6,7 +6,7 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 describe('Main: Currently testing file versions management,', function () {
   const config = require('./config/config.json')
   const {
-    Alice: { username, password }
+    testUser1: { username: testUser, password: testUserPassword }
   } = require('./config/users.json')
 
   const {
@@ -72,21 +72,21 @@ describe('Main: Currently testing file versions management,', function () {
   describe('file versions of non existing file', () => {
     it('retrieves file versions of not existing file', async function () {
       const provider = createProvider(false, true)
-      await getCapabilitiesInteraction(provider, username, password)
-      await getCurrentUserInformationInteraction(provider, username, password)
+      await getCapabilitiesInteraction(provider, testUser, testUserPassword)
+      await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
       await provider
         .given('the user is recreated', {
-          username,
-          password
+          username: testUser,
+          password: testUserPassword
         })
-        .uponReceiving(`as '${username}', a PROPFIND request to get file versions of non existent file`)
+        .uponReceiving(`as '${testUser}', a PROPFIND request to get file versions of non existent file`)
         .withRequest({
           method: 'PROPFIND',
           path: MatchersV3.regex(
             '.*\\/remote\\.php\\/dav\\/meta\\/42\\/v',
             '/remote.php/dav/meta/42/v'
           ),
-          headers: { authorization: getAuthHeaders(username, password), ...applicationXmlResponseHeaders },
+          headers: { authorization: getAuthHeaders(testUser, testUserPassword), ...applicationXmlResponseHeaders },
           body: new XmlBuilder('1.0', '', 'd:propfind').build(dPropfind => {
             dPropfind.setAttributes({ 'xmlns:d': 'DAV:', 'xmlns:oc': 'http://owncloud.org/ns' })
             dPropfind.appendElement('d:prop', '', '')
@@ -102,7 +102,7 @@ describe('Main: Currently testing file versions management,', function () {
           })
         })
       return provider.executeTest(async () => {
-        const oc = createOwncloud(username, password)
+        const oc = createOwncloud(testUser, testUserPassword)
         await oc.login()
         return oc.fileVersions.listVersions(42).then(versions => {
           expect(versions).toBe(null)
@@ -117,44 +117,44 @@ describe('Main: Currently testing file versions management,', function () {
   describe('file versions for existing files', () => {
     const PropfindFileVersionOfExistentFiles = provider => {
       return provider.given('the user is recreated', {
-        username,
-        password
+        username: testUser,
+        password: testUserPassword
       })
         .given('file exists', {
           fileName: versionedFile,
-          username,
-          password
+          username: testUser,
+          password: testUserPassword
         })
         .given('the client waits', { delay: 2000 })
       // re-upload the same file to create a new version
         .given('file exists', {
           fileName: versionedFile,
-          username,
-          password,
+          username: testUser,
+          password: testUserPassword,
           content: fileInfo.versions[0].content
         })
         .given('the client waits', { delay: 2000 })
         .given('file exists', {
           fileName: versionedFile,
-          username,
-          password,
+          username: testUser,
+          password: testUserPassword,
           content: fileInfo.versions[1].content
         })
         .given('the client waits', { delay: 2000 })
         .given('file version link is returned', {
           fileName: versionedFile,
-          username,
-          password,
+          username: testUser,
+          password: testUserPassword,
           number: 1
         })
-        .uponReceiving(`as '${username}', a PROPFIND request to get file versions of existent file`)
+        .uponReceiving(`as '${testUser}', a PROPFIND request to get file versions of existent file`)
         .withRequest({
           method: 'PROPFIND',
           path: MatchersV3.fromProviderState(
             '/remote.php/dav/meta/${fileId}/v', /* eslint-disable-line no-template-curly-in-string */
             `/remote.php/dav/meta/${fileInfo.id}/v`
           ),
-          headers: { authorization: getAuthHeaders(username, password), ...applicationXmlResponseHeaders },
+          headers: { authorization: getAuthHeaders(testUser, testUserPassword), ...applicationXmlResponseHeaders },
           body: new XmlBuilder('1.0', '', 'd:propfind').build(dPropfind => {
             dPropfind.setAttributes({ 'xmlns:d': 'DAV:', 'xmlns:oc': 'http://owncloud.org/ns' })
             dPropfind.appendElement('d:prop', '', '')
@@ -188,43 +188,43 @@ describe('Main: Currently testing file versions management,', function () {
     }
     const getFileVersionContents = async (provider, i) => {
       await provider.given('the user is recreated', {
-        username,
-        password
+        username: testUser,
+        password: testUserPassword
       }).given('file exists', {
         fileName: versionedFile,
-        username,
-        password
+        username: testUser,
+        password: testUserPassword
       })
         .given('the client waits', { delay: 2000 })
         .given('file exists', {
           fileName: versionedFile,
-          username,
-          password,
+          username: testUser,
+          password: testUserPassword,
           content: fileInfo.versions[0].content
         })
         .given('the client waits', { delay: 2000 })
         .given('file exists', {
           fileName: versionedFile,
-          username,
-          password,
+          username: testUser,
+          password: testUserPassword,
           content: fileInfo.versions[1].content
         })
         .given('the client waits', { delay: 2000 })
         .given('file version link is returned', {
           fileName: versionedFile,
-          username,
-          password,
+          username: testUser,
+          password: testUserPassword,
           number: i + 1
         })
       await provider
-        .uponReceiving(`as '${username}', a GET request to get file version ${i} contents`)
+        .uponReceiving(`as '${testUser}', a GET request to get file version ${i} contents`)
         .withRequest({
           method: 'GET',
           path: MatchersV3.fromProviderState(
             '\${versionLink}', // eslint-disable-line no-useless-escape,no-template-curly-in-string
               `/remote.php/dav/meta/${fileInfo.id}/v/${fileInfo.versions[i].versionId}`
           ),
-          headers: { authorization: getAuthHeaders(username, password) }
+          headers: { authorization: getAuthHeaders(testUser, testUserPassword) }
         })
         .willRespondWith({
           status: 200,
@@ -244,13 +244,13 @@ describe('Main: Currently testing file versions management,', function () {
       // https://github.com/pact-foundation/pact-js/issues/604
       for (let i = 0; i < fileInfo.versions.length; i++) {
         const provider = createProvider(true, true)
-        await getCapabilitiesInteraction(provider, username, password)
-        await getCurrentUserInformationInteraction(provider, username, password)
+        await getCapabilitiesInteraction(provider, testUser, testUserPassword)
+        await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
         await PropfindFileVersionOfExistentFiles(provider)
         await getFileVersionContents(provider, i)
 
         await provider.executeTest(async () => {
-          const oc = createOwncloud(username, password)
+          const oc = createOwncloud(testUser, testUserPassword)
           await oc.login()
           await oc.fileVersions.listVersions(fileInfo.id).then(versions => {
             expect(versions.length).toEqual(2)
@@ -265,36 +265,36 @@ describe('Main: Currently testing file versions management,', function () {
     })
 
     it('restore file version', async function () {
-      const destinationWebDavPath = createDavPath(username, versionedFile)
+      const destinationWebDavPath = createDavPath(testUser, versionedFile)
       const provider = createProvider()
-      await getCapabilitiesInteraction(provider, username, password)
-      await getCurrentUserInformationInteraction(provider, username, password)
+      await getCapabilitiesInteraction(provider, testUser, testUserPassword)
+      await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
       await provider
         .given('the user is recreated', {
-          username,
-          password
+          username: testUser,
+          password: testUserPassword
         })
         .given('file exists', {
           fileName: versionedFile,
-          username,
-          password
+          username: testUser,
+          password: testUserPassword
         })
         // re-upload the same file to create a new version
         .given('file exists', {
           fileName: versionedFile,
-          username,
-          password
+          username: testUser,
+          password: testUserPassword
         })
         .given('file version link is returned', {
           fileName: versionedFile,
-          username,
-          password,
+          username: testUser,
+          password: testUserPassword,
           number: 1
         })
         .given('provider base url is returned')
 
       await provider
-        .uponReceiving(`as '${username}', a COPY request to restore file versions`)
+        .uponReceiving(`as '${testUser}', a COPY request to restore file versions`)
         .withRequest({
           method: 'COPY',
           path: MatchersV3.fromProviderState(
@@ -302,7 +302,7 @@ describe('Main: Currently testing file versions management,', function () {
             `/remote.php/dav/meta/${fileInfo.id}/v/${fileInfo.versions[0].versionId}`
           ),
           headers: {
-            authorization: getAuthHeaders(username, password),
+            authorization: getAuthHeaders(testUser, testUserPassword),
             Destination: MatchersV3.fromProviderState(
               `\${providerBaseURL}${destinationWebDavPath}`,
               `${mockServerBaseUrl}${destinationWebDavPath}`
@@ -314,7 +314,7 @@ describe('Main: Currently testing file versions management,', function () {
         })
 
       return provider.executeTest(async () => {
-        const oc = createOwncloud(username, password)
+        const oc = createOwncloud(testUser, testUserPassword)
         await oc.login()
         return oc.fileVersions.restoreFileVersion(fileInfo.id, fileInfo.versions[0].versionId, versionedFile).then(status => {
           expect(status).toBe(true)

--- a/tests/groupTest.js
+++ b/tests/groupTest.js
@@ -2,7 +2,10 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 describe('Main: Currently testing group management,', function () {
   const config = require('./config/config.json')
-  const username = config.adminUsername
+  const {
+    admin: { username: adminUsername },
+    Alice
+  } = require('./config/users.json')
   let provider = null
 
   const {
@@ -19,7 +22,7 @@ describe('Main: Currently testing group management,', function () {
     await provider
       .given('group exists', { groupName: 'admin' })
       .given('group exists', { groupName: config.testGroup })
-      .uponReceiving(`as '${username}', a GET request to get all groups`)
+      .uponReceiving(`as '${adminUsername}', a GET request to get all groups`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -39,7 +42,7 @@ describe('Main: Currently testing group management,', function () {
               // TODO: adjust the following after the issue is resolved
               // https://github.com/pact-foundation/pact-js/issues/619
               data.appendElement('groups', '', (groups) => {
-                groups.appendElement('element', '', MatchersV3.string(config.adminUsername))
+                groups.appendElement('element', '', MatchersV3.string(adminUsername))
                   .eachLike('element', '', group => {
                     group.appendText(MatchersV3.string(config.testGroup))
                   })
@@ -59,7 +62,7 @@ describe('Main: Currently testing group management,', function () {
     }
 
     await provider
-      .uponReceiving(`as '${username}', a DELETE request to delete a group '${group}'`)
+      .uponReceiving(`as '${adminUsername}', a DELETE request to delete a group '${group}'`)
       .withRequest({
         method: 'DELETE',
         path: MatchersV3.regex(
@@ -134,9 +137,9 @@ describe('Main: Currently testing group management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await provider
       .given('group exists', { groupName: config.testGroup })
-      .given('the user is recreated', { username: config.testUser, password: config.testUserPassword })
-      .given('user is added to group', { username: config.testUser, groupName: config.testGroup })
-      .uponReceiving(`as '${username}', a GET request to get all members of existing group`)
+      .given('the user is recreated', { username: Alice.username, password: Alice.password })
+      .given('user is added to group', { username: Alice.username, groupName: config.testGroup })
+      .uponReceiving(`as '${adminUsername}', a GET request to get all members of existing group`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -156,7 +159,7 @@ describe('Main: Currently testing group management,', function () {
             // https://github.com/pact-foundation/pact-js/issues/619
             data.appendElement('users', '', (users) => {
               users.eachLike('element', '', user => {
-                user.appendText(MatchersV3.equal(config.testUser))
+                user.appendText(MatchersV3.equal(Alice.username))
               })
             })
           })
@@ -167,7 +170,7 @@ describe('Main: Currently testing group management,', function () {
       await oc.login()
       return oc.groups.getGroupMembers(config.testGroup).then(data => {
         expect(typeof (data)).toBe('object')
-        expect(data.indexOf(config.testUser)).toBeGreaterThan(-1)
+        expect(data.indexOf(Alice.username)).toBeGreaterThan(-1)
       }).catch(error => {
         expect(error).toBe(null)
       })
@@ -204,7 +207,7 @@ describe('Main: Currently testing group management,', function () {
     const headers = { ...validAdminAuthHeaders, ...{ 'Content-Type': 'application/x-www-form-urlencoded' } }
     await provider
       .given('group does not exist', { groupName: config.testGroup })
-      .uponReceiving(`as '${username}', a POST request to create a group`)
+      .uponReceiving(`as '${adminUsername}', a POST request to create a group`)
       .withRequest({
         method: 'POST',
         path: MatchersV3.regex(

--- a/tests/groupTest.js
+++ b/tests/groupTest.js
@@ -4,7 +4,7 @@ describe('Main: Currently testing group management,', function () {
   const config = require('./config/config.json')
   const {
     admin: { username: adminUsername },
-    Alice
+    testUser1: { username: testUser, password: testUserPassword }
   } = require('./config/users.json')
   let provider = null
 
@@ -137,8 +137,8 @@ describe('Main: Currently testing group management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await provider
       .given('group exists', { groupName: config.testGroup })
-      .given('the user is recreated', { username: Alice.username, password: Alice.password })
-      .given('user is added to group', { username: Alice.username, groupName: config.testGroup })
+      .given('the user is recreated', { username: testUser, password: testUserPassword })
+      .given('user is added to group', { username: testUser, groupName: config.testGroup })
       .uponReceiving(`as '${adminUsername}', a GET request to get all members of existing group`)
       .withRequest({
         method: 'GET',
@@ -159,7 +159,7 @@ describe('Main: Currently testing group management,', function () {
             // https://github.com/pact-foundation/pact-js/issues/619
             data.appendElement('users', '', (users) => {
               users.eachLike('element', '', user => {
-                user.appendText(MatchersV3.equal(Alice.username))
+                user.appendText(MatchersV3.equal(testUser))
               })
             })
           })
@@ -170,7 +170,7 @@ describe('Main: Currently testing group management,', function () {
       await oc.login()
       return oc.groups.getGroupMembers(config.testGroup).then(data => {
         expect(typeof (data)).toBe('object')
-        expect(data.indexOf(Alice.username)).toBeGreaterThan(-1)
+        expect(data.indexOf(testUser)).toBeGreaterThan(-1)
       }).catch(error => {
         expect(error).toBe(null)
       })

--- a/tests/helpers/pactHelper.js
+++ b/tests/helpers/pactHelper.js
@@ -4,7 +4,7 @@ const config = require('../config/config.json')
 
 const {
   admin: { username: adminUsername, password: adminPassword },
-  Alice
+  testUser1: { username: testUser, password: testUserPassword }
 } = require('../config/users.json')
 
 const adminPasswordHash = Buffer.from(adminUsername + ':' + adminPassword, 'binary').toString('base64')
@@ -387,7 +387,7 @@ const createUserInteraction = function (provider) {
         ...validAdminAuthHeaders,
         ...applicationFormUrlEncoded
       },
-      body: `password=${Alice.password}&userid=${Alice.username}`
+      body: `password=${testUserPassword}&userid=${testUser}`
     }).willRespondWith({
       status: 200,
       headers: xmlResponseHeaders
@@ -408,7 +408,7 @@ const createUserWithGroupMembershipInteraction = function (provider) {
         ...validAdminAuthHeaders,
         ...applicationFormUrlEncoded
       },
-      body: 'password=' + Alice.password + '&userid=' + Alice.username + '&groups%5B0%5D=' + config.testGroup
+      body: 'password=' + testUserPassword + '&userid=' + testUser + '&groups%5B0%5D=' + config.testGroup
     })
     .willRespondWith({
       status: 200,
@@ -427,8 +427,8 @@ const deleteUserInteraction = function (provider) {
     .withRequest({
       method: 'DELETE',
       path: MatchersV3.regex(
-        '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + Alice.username + '$',
-        '/ocs/v1.php/cloud/users/' + Alice.username
+        '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + testUser + '$',
+        '/ocs/v1.php/cloud/users/' + testUser
       ),
       headers: validAdminAuthHeaders
     }).willRespondWith({

--- a/tests/helpers/pactHelper.js
+++ b/tests/helpers/pactHelper.js
@@ -1,6 +1,7 @@
 import { MatchersV3, PactV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 const config = require('../config/config.json')
+const { getDisplayNameForUser } = require('../helpers/userHelper')
 
 const {
   admin: { username: adminUsername, password: adminPassword },
@@ -253,7 +254,7 @@ const deleteResourceInteraction = (
 async function getCurrentUserInformationInteraction (
   provider, user = adminUsername, password = adminPassword
 ) {
-  const displayName = user[0].toUpperCase() + user.slice(1)
+  const displayName = getDisplayNameForUser(user)
   if (user !== adminUsername) {
     provider.given('the user is recreated', { username: user, password: password })
   }

--- a/tests/helpers/pactHelper.js
+++ b/tests/helpers/pactHelper.js
@@ -1,7 +1,13 @@
 import { MatchersV3, PactV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 const config = require('../config/config.json')
-var adminPasswordHash = Buffer.from(config.adminUsername + ':' + config.adminPassword, 'binary').toString('base64')
+
+const {
+  admin: { username: adminUsername, password: adminPassword },
+  Alice
+} = require('../config/users.json')
+
+const adminPasswordHash = Buffer.from(adminUsername + ':' + adminPassword, 'binary').toString('base64')
 
 const path = require('path')
 const OwnCloud = require('../../src/owncloud')
@@ -49,11 +55,11 @@ const ocsMeta = function (meta, status, statusCode, Message = null) {
 const shareResponseOcsData = function (node, shareType, id, permissions, fileTarget) {
   const res = node.appendElement('id', '', MatchersV3.string(id))
     .appendElement('share_type', '', MatchersV3.equal(shareType.toString()))
-    .appendElement('uid_owner', '', MatchersV3.string(config.adminUsername))
-    .appendElement('displayname_owner', '', MatchersV3.string(config.adminUsername))
+    .appendElement('uid_owner', '', MatchersV3.string(adminUsername))
+    .appendElement('displayname_owner', '', MatchersV3.string(adminUsername))
     .appendElement('permissions', '', MatchersV3.number(permissions))
-    .appendElement('uid_file_owner', '', MatchersV3.string(config.adminUsername))
-    .appendElement('displayname_file_owner', '', MatchersV3.string(config.adminUsername))
+    .appendElement('uid_file_owner', '', MatchersV3.string(adminUsername))
+    .appendElement('displayname_file_owner', '', MatchersV3.string(adminUsername))
     .appendElement('path', '', MatchersV3.equal(fileTarget))
     .appendElement('file_target', '', MatchersV3.includes(fileTarget))
     .appendElement('stime', '', MatchersV3.string(Math.floor(Date.now() / 1000)))
@@ -150,7 +156,7 @@ const sanitizeUrl = (url) => {
   return url.replace(/([^:])\/{2,}/g, '$1/')
 }
 
-const createOwncloud = function (username = config.adminUsername, password = config.adminPassword) {
+const createOwncloud = function (username = adminUsername, password = adminPassword) {
   const oc = new OwnCloud({
     baseUrl: getMockServerBaseUrl(),
     auth: {
@@ -166,10 +172,10 @@ const createOwncloud = function (username = config.adminUsername, password = con
 // https://github.com/owncloud/ocis/issues/1282
 const getContentsOfFileInteraction = (
   provider, file,
-  user = config.adminUsername,
-  password = config.adminPassword
+  user = adminUsername,
+  password = adminPassword
 ) => {
-  if (user !== config.adminUsername) {
+  if (user !== adminUsername) {
     provider.given('the user is recreated', { username: user, password: password })
   }
   if (file !== config.nonExistentFile) {
@@ -199,10 +205,10 @@ const getContentsOfFileInteraction = (
 
 const deleteResourceInteraction = (
   provider, resource, type = 'folder',
-  user = config.adminUsername, password = config.adminPassword
+  user = adminUsername, password = adminPassword
 ) => {
   let response
-  if (user !== config.adminUsername) {
+  if (user !== adminUsername) {
     provider.given('the user is recreated', { username: user, password: password })
   }
   if (resource.includes('nonExistent')) {
@@ -245,10 +251,10 @@ const deleteResourceInteraction = (
 }
 
 async function getCurrentUserInformationInteraction (
-  provider, user = config.adminUsername, password = config.adminPassword
+  provider, user = adminUsername, password = adminPassword
 ) {
   const displayName = user[0].toUpperCase() + user.slice(1)
-  if (user !== config.adminUsername) {
+  if (user !== adminUsername) {
     provider.given('the user is recreated', { username: user, password: password })
   }
   await provider
@@ -279,9 +285,9 @@ async function getCurrentUserInformationInteraction (
 }
 
 async function getCapabilitiesInteraction (
-  provider, user = config.adminUsername, password = config.adminPassword
+  provider, user = adminUsername, password = adminPassword
 ) {
-  if (user !== config.adminUsername) {
+  if (user !== adminUsername) {
     provider.given('the user is recreated', { username: user, password: password })
   }
   await provider
@@ -340,7 +346,7 @@ async function getCapabilitiesInteraction (
 
 // [OCIS] HTTP 401 Unauthorized responses don't contain a body
 // https://github.com/owncloud/ocis/issues/1293
-const getCapabilitiesWithInvalidAuthInteraction = function (provider, username = config.adminUsername, password = config.invalidPassword) {
+const getCapabilitiesWithInvalidAuthInteraction = function (provider, username = adminUsername, password = config.invalidPassword) {
   return provider.uponReceiving(`as '${username}', a GET request to get capabilities with invalid auth`)
     .withRequest({
       method: 'GET',
@@ -370,7 +376,7 @@ const getCapabilitiesWithInvalidAuthInteraction = function (provider, username =
 }
 
 const createUserInteraction = function (provider) {
-  provider.uponReceiving(`as '${config.adminUsername}', a POST request to create a user`)
+  provider.uponReceiving(`as '${adminUsername}', a POST request to create a user`)
     .withRequest({
       method: 'POST',
       path: MatchersV3.regex(
@@ -381,7 +387,7 @@ const createUserInteraction = function (provider) {
         ...validAdminAuthHeaders,
         ...applicationFormUrlEncoded
       },
-      body: `password=${config.testUserPassword}&userid=${config.testUser}`
+      body: `password=${Alice.password}&userid=${Alice.username}`
     }).willRespondWith({
       status: 200,
       headers: xmlResponseHeaders
@@ -391,7 +397,7 @@ const createUserInteraction = function (provider) {
 const createUserWithGroupMembershipInteraction = function (provider) {
   return provider
     .given('group exists', { groupName: config.testGroup })
-    .uponReceiving(`as '${config.adminUsername}', a POST request to create a user with group membership`)
+    .uponReceiving(`as '${adminUsername}', a POST request to create a user with group membership`)
     .withRequest({
       method: 'POST',
       path: MatchersV3.regex(
@@ -402,7 +408,7 @@ const createUserWithGroupMembershipInteraction = function (provider) {
         ...validAdminAuthHeaders,
         ...applicationFormUrlEncoded
       },
-      body: 'password=' + config.testUserPassword + '&userid=' + config.testUser + '&groups%5B0%5D=' + config.testGroup
+      body: 'password=' + Alice.password + '&userid=' + Alice.username + '&groups%5B0%5D=' + config.testGroup
     })
     .willRespondWith({
       status: 200,
@@ -417,12 +423,12 @@ const createUserWithGroupMembershipInteraction = function (provider) {
 }
 
 const deleteUserInteraction = function (provider) {
-  provider.uponReceiving(`as '${config.adminUsername}', a DELETE request to delete a user`)
+  provider.uponReceiving(`as '${adminUsername}', a DELETE request to delete a user`)
     .withRequest({
       method: 'DELETE',
       path: MatchersV3.regex(
-        '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + config.testUser + '$',
-        '/ocs/v1.php/cloud/users/' + config.testUser
+        '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + Alice.username + '$',
+        '/ocs/v1.php/cloud/users/' + Alice.username
       ),
       headers: validAdminAuthHeaders
     }).willRespondWith({
@@ -440,9 +446,9 @@ const deleteUserInteraction = function (provider) {
 }
 
 const createFolderInteraction = function (
-  provider, folderName, user = config.adminUsername, password = config.adminPassword
+  provider, folderName, user = adminUsername, password = adminPassword
 ) {
-  if (user !== config.adminUsername) {
+  if (user !== adminUsername) {
     provider.given('the user is recreated', { username: user, password: password })
   }
 
@@ -475,9 +481,9 @@ const createFolderInteraction = function (
     })
 }
 
-const updateFileInteraction = function (provider, file, user = config.adminUsername, password = config.adminPassword
+const updateFileInteraction = function (provider, file, user = adminUsername, password = adminPassword
 ) {
-  if (user !== config.adminUsername) {
+  if (user !== adminUsername) {
     provider.given('the user is recreated', { username: user, password: password })
   }
   if (!file.includes('nonExistent')) {

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -1,5 +1,3 @@
-const config = require('../config/config.json')
-
 const SHARE_TYPE = Object.freeze({
   user: 0,
   group: 1,
@@ -214,7 +212,7 @@ const givenResourceIsShared = async (
       }
     )
   } else if (shareType === SHARE_TYPE.user) {
-    await givenUserExists(provider, shareWith, config.testUser2Password)
+    await givenUserExists(provider, shareWith)
     return givenUserShareExists(
       provider,
       username,

--- a/tests/helpers/userHelper.js
+++ b/tests/helpers/userHelper.js
@@ -1,29 +1,4 @@
-/** TODO:
- Refactor this to use separate user config.json
- and remove users from config.json
-*/
-const config = require('../config/config.json')
-
-const users = {
-  admin: {
-    username: config.adminUsername,
-    password: config.adminPassword,
-    displayname: config.adminDisplayName,
-    email: 'admin@example.com'
-  },
-  [config.testUser]: {
-    username: config.testUser,
-    password: config.testUserPassword,
-    displayname: config.testUser,
-    email: `${config.testUser}@example.com`
-  },
-  [config.testUser2]: {
-    username: config.testUser2,
-    password: config.testUser2Password,
-    displayname: config.testUser2,
-    email: `${config.testUser2}@example.com`
-  }
-}
+const users = require('../config/users.json')
 
 exports.getPasswordForUser = function (username) {
   return users[username].password

--- a/tests/loginTest.js
+++ b/tests/loginTest.js
@@ -1,6 +1,9 @@
 describe('Main: Currently testing Login and initLibrary,', function () {
   var OwnCloud = require('../src/owncloud')
   var config = require('./config/config.json')
+  const {
+    admin: { username: adminUsername, password: adminPassword }
+  } = require('./config/users.json')
 
   // CURRENT TIME
   var timeRightNow = Math.random().toString(36).slice(2, 11)
@@ -10,6 +13,7 @@ describe('Main: Currently testing Login and initLibrary,', function () {
 
   // TESTING CONFIGS
   var nonExistentUser = 'nonExistentUser' + timeRightNow
+  const invalidPassword = config.invalidPassword + timeRightNow
 
   // PACT setup
   const {
@@ -49,7 +53,7 @@ describe('Main: Currently testing Login and initLibrary,', function () {
 
   it('checking method : login with wrong username and password', async function () {
     const provider = createProvider(false, true)
-    await getCapabilitiesWithInvalidAuthInteraction(provider, nonExistentUser, 'config.adminPassword' + timeRightNow)
+    await getCapabilitiesWithInvalidAuthInteraction(provider, nonExistentUser, invalidPassword)
 
     return provider.executeTest(async () => {
       oc = new OwnCloud({
@@ -57,7 +61,7 @@ describe('Main: Currently testing Login and initLibrary,', function () {
         auth: {
           basic: {
             username: nonExistentUser,
-            password: 'config.adminPassword' + timeRightNow
+            password: invalidPassword
           }
         }
       })
@@ -72,15 +76,15 @@ describe('Main: Currently testing Login and initLibrary,', function () {
 
   it('checking method : login with correct username only', async function () {
     const provider = createProvider(false, true)
-    await getCapabilitiesWithInvalidAuthInteraction(provider, config.adminUsername, 'config.adminPassword' + timeRightNow)
+    await getCapabilitiesWithInvalidAuthInteraction(provider, adminUsername, invalidPassword)
 
     return provider.executeTest(async () => {
       oc = new OwnCloud({
         baseUrl: mockServerBaseUrl,
         auth: {
           basic: {
-            username: config.adminUsername,
-            password: 'config.adminPassword' + timeRightNow
+            username: adminUsername,
+            password: invalidPassword
           }
         }
       })
@@ -93,7 +97,7 @@ describe('Main: Currently testing Login and initLibrary,', function () {
     })
   })
 
-  it('checking method : login with correct config.adminUsername and config.adminPassword', async function () {
+  it('checking method : login with correct username and password', async function () {
     const provider = createProvider()
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)
@@ -102,14 +106,14 @@ describe('Main: Currently testing Login and initLibrary,', function () {
         baseUrl: mockServerBaseUrl,
         auth: {
           basic: {
-            username: config.adminUsername,
-            password: config.adminPassword
+            username: adminUsername,
+            password: adminPassword
           }
         }
       })
 
       return oc.login().then(status => {
-        expect(status).toEqual({ id: config.adminUsername, 'display-name': config.adminUsername, email: {} })
+        expect(status).toEqual({ id: adminUsername, 'display-name': adminUsername, email: {} })
       }).catch(error => {
         fail(error)
       })

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -1,4 +1,4 @@
-const config = require('./config/config.json')
+const { testContent } = require('./config/config.json')
 const {
   getOCSMeta,
   getOCSData
@@ -133,7 +133,7 @@ describe('provider testing', () => {
     },
     'file exists': (setup, parameters) => {
       const dirname = path.dirname(parameters.fileName)
-      const content = parameters.content || config.testContent
+      const content = parameters.content || testContent
       if (setup) {
         if (dirname !== '' && dirname !== '/' && dirname !== '.') {
           const results = createFolderRecursive(

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -13,7 +13,7 @@ describe('oc.publicFiles', function () {
     testFileEtag
   } = require('./config/config.json')
   const {
-    Alice: { username, password }
+    testUser1: { username: testUser, password: testUserPassword }
   } = require('./config/users.json')
   const using = require('jasmine-data-provider')
 
@@ -62,20 +62,20 @@ describe('oc.publicFiles', function () {
       headers = getPublicLinkAuthHeader(password)
     }
     return provider
-      .given('the user is recreated', { username, password })
+      .given('the user is recreated', { username: testUser, password: testUserPassword })
       .given('folder exists', {
-        username,
-        password,
+        username: testUser,
+        password: testUserPassword,
         folderName: testFolder
       })
       .given('resource is shared', {
-        username,
-        userPassword: password,
+        username: testUser,
+        userPassword: testUserPassword,
         path: testFolder,
         shareType: 3,
         permissions: 15
       })
-      .uponReceiving(`as '${username}', a ${method} request to ${description}`)
+      .uponReceiving(`as '${testUser}', a ${method} request to ${description}`)
       .withRequest({
         method: method,
         path: MatchersV3.fromProviderState(
@@ -112,15 +112,15 @@ describe('oc.publicFiles', function () {
       }
     }
     await provider
-      .given('the user is recreated', { username, password })
+      .given('the user is recreated', { username: testUser, password: testUserPassword })
       .given('folder exists', {
-        username,
-        password,
+        username: testUser,
+        password: testUserPassword,
         folderName: testFolder
       })
       .given('resource is shared', {
-        username,
-        userPassword: password,
+        username: testUser,
+        userPassword: testUserPassword,
         path: testFolder,
         shareType: 3,
         permissions: 15
@@ -131,7 +131,7 @@ describe('oc.publicFiles', function () {
     }
 
     return provider
-      .uponReceiving(`as '${username}', a ${method} request to ${description}`)
+      .uponReceiving(`as '${testUser}', a ${method} request to ${description}`)
       .withRequest({
         method: method,
         path: MatchersV3.fromProviderState(
@@ -167,7 +167,7 @@ describe('oc.publicFiles', function () {
       }
     }, function (data, description) {
       it('shall work with ' + description, function () {
-        const oc = createOwncloud(username, password)
+        const oc = createOwncloud(testUser, testUserPassword)
         expect(oc.publicFiles.getFileUrl(data.token, data.path))
           .toBe(mockServerBaseUrl + data.expected)
       })
@@ -211,12 +211,12 @@ describe('oc.publicFiles', function () {
           } else {
             provider = createProvider(false, true)
           }
-          await getCapabilitiesInteraction(provider, username, password)
-          await getCurrentUserInformationInteraction(provider, username, password)
+          await getCapabilitiesInteraction(provider, testUser, testUserPassword)
+          await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
 
           const listContentsOfPublicLinkInteraction = async (provider, options) => {
             const { passwordWhenListing, shallGrantAccess } = options
-            let description = `as ${username}, a PROPFIND request to list contents of public link folder`
+            let description = `as ${testUser}, a PROPFIND request to list contents of public link folder`
             if (passwordWhenListing) {
               if (shallGrantAccess) {
                 description += ' with valid password "' + passwordWhenListing + '"'
@@ -244,14 +244,14 @@ describe('oc.publicFiles', function () {
             }
             const status = shallGrantAccess ? 207 : 401
 
-            await givenUserExists(provider, username, password)
+            await givenUserExists(provider, testUser, testUserPassword)
             for (let fileNum = 0; fileNum < testFiles.length; fileNum++) {
-              await givenFileExists(provider, username, password, testFolder + '/' + testFiles[fileNum])
+              await givenFileExists(provider, testUser, testUserPassword, testFolder + '/' + testFiles[fileNum])
             }
             if (data.shareParams.password) {
-              await givenPublicShareExists(provider, username, password, testFolder, { password: data.shareParams.password })
+              await givenPublicShareExists(provider, testUser, testUserPassword, testFolder, { password: data.shareParams.password })
             } else {
-              await givenPublicShareExists(provider, username, password, testFolder)
+              await givenPublicShareExists(provider, testUser, testUserPassword, testFolder)
             }
             return provider
               .uponReceiving(description)
@@ -287,7 +287,7 @@ describe('oc.publicFiles', function () {
 
           await listContentsOfPublicLinkInteraction(provider, data)
           return provider.executeTest(async () => {
-            const oc = createOwncloud(username, password)
+            const oc = createOwncloud(testUser, testUserPassword)
             await oc.login()
 
             return oc.publicFiles.list(shareTokenOfPublicLinkFolder, data.passwordWhenListing).then(files => {
@@ -298,7 +298,7 @@ describe('oc.publicFiles', function () {
                 expect(files[0].getName()).toBe(shareTokenOfPublicLinkFolder)
                 expect(files[0].getPath()).toBe('/')
                 expect(files[0].getProperty(oc.publicFiles.PUBLIC_LINK_ITEM_TYPE)).toBe('folder')
-                expect(files[0].getProperty(oc.publicFiles.PUBLIC_LINK_SHARE_OWNER)).toBe(username)
+                expect(files[0].getProperty(oc.publicFiles.PUBLIC_LINK_SHARE_OWNER)).toBe(testUser)
                 expect(files[0].getProperty(oc.publicFiles.PUBLIC_LINK_PERMISSION)).toBe('1')
 
                 // test folder elements
@@ -359,7 +359,7 @@ describe('oc.publicFiles', function () {
             if (passwordWhenListing) {
               headers = getPublicLinkAuthHeader(data.passwordWhenListing)
             }
-            let description = `as ${username}, a ${method} request to download files from a public shared folder`
+            let description = `as ${testUser}, a ${method} request to download files from a public shared folder`
             if (passwordWhenListing) {
               if (shallGrantAccess) {
                 description += ' with valid password "' + passwordWhenListing + '"'
@@ -374,12 +374,12 @@ describe('oc.publicFiles', function () {
               }
             }
 
-            await givenUserExists(provider, username, password)
-            await givenFileExists(provider, username, password, testFolder + '/' + testFiles[2])
+            await givenUserExists(provider, testUser, testUserPassword)
+            await givenFileExists(provider, testUser, testUserPassword, testFolder + '/' + testFiles[2])
             if (data.shareParams.password) {
-              await givenPublicShareExists(provider, username, password, testFolder, { password: data.shareParams.password })
+              await givenPublicShareExists(provider, testUser, testUserPassword, testFolder, { password: data.shareParams.password })
             } else {
-              await givenPublicShareExists(provider, username, password, testFolder)
+              await givenPublicShareExists(provider, testUser, testUserPassword, testFolder)
             }
             return provider
               .uponReceiving(description)
@@ -395,12 +395,12 @@ describe('oc.publicFiles', function () {
           } else {
             provider = createProvider(false, true)
           }
-          await getCapabilitiesInteraction(provider, username, password)
-          await getCurrentUserInformationInteraction(provider, username, password)
+          await getCapabilitiesInteraction(provider, testUser, testUserPassword)
+          await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
           await getFileFromPublicLinkInteraction(provider, data)
 
           return provider.executeTest(async () => {
-            const oc = createOwncloud(username, password)
+            const oc = createOwncloud(testUser, testUserPassword)
             await oc.login()
             await oc.publicFiles.download(
               shareTokenOfPublicLinkFolder,
@@ -449,8 +449,8 @@ describe('oc.publicFiles', function () {
       describe(description, function () {
         it('should create a folder', async function () {
           const provider = createProvider()
-          await getCapabilitiesInteraction(provider, username, password)
-          await getCurrentUserInformationInteraction(provider, username, password)
+          await getCapabilitiesInteraction(provider, testUser, testUserPassword)
+          await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
           await folderInPublicShareInteraction(
             provider,
             'create a folder in public share' + ' ' + data.description,
@@ -460,7 +460,7 @@ describe('oc.publicFiles', function () {
           )
 
           return provider.executeTest(async () => {
-            const oc = createOwncloud(username, password)
+            const oc = createOwncloud(testUser, testUserPassword)
             await oc.login()
 
             return oc.publicFiles.createFolder(shareTokenOfPublicLinkFolder, 'foo', data.shareParams.password).then((response) => {
@@ -472,8 +472,8 @@ describe('oc.publicFiles', function () {
         })
         it('should get content of a file', async function () {
           const provider = createProvider()
-          await getCapabilitiesInteraction(provider, username, password)
-          await getCurrentUserInformationInteraction(provider, username, password)
+          await getCapabilitiesInteraction(provider, testUser, testUserPassword)
+          await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
 
           await publicShareContentInteraction(
             provider,
@@ -486,7 +486,7 @@ describe('oc.publicFiles', function () {
           )
 
           return provider.executeTest(async () => {
-            const oc = createOwncloud(username, password)
+            const oc = createOwncloud(testUser, testUserPassword)
             await oc.login()
 
             try {
@@ -501,8 +501,8 @@ describe('oc.publicFiles', function () {
 
         it('should update a file', async function () {
           const provider = createProvider()
-          await getCapabilitiesInteraction(provider, username, password)
-          await getCurrentUserInformationInteraction(provider, username, password)
+          await getCapabilitiesInteraction(provider, testUser, testUserPassword)
+          await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
           await publicShareContentInteraction(
             provider,
             'update content of public share' + ' ' + data.description + ' and content lorem',
@@ -513,7 +513,7 @@ describe('oc.publicFiles', function () {
             data.shareParams.password
           )
           return provider.executeTest(async () => {
-            const oc = createOwncloud(username, password)
+            const oc = createOwncloud(testUser, testUserPassword)
             await oc.login()
             try {
               const options = {
@@ -532,15 +532,15 @@ describe('oc.publicFiles', function () {
           const target = shareTokenOfPublicLinkFolder + '/lorem123456.txt'
 
           const provider = createProvider()
-          await getCapabilitiesInteraction(provider, username, password)
-          await getCurrentUserInformationInteraction(provider, username, password)
+          await getCapabilitiesInteraction(provider, testUser, testUserPassword)
+          await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
           await provider
             .given('provider base url is returned')
-            .given('the user is recreated', { username, password })
-            .given('folder exists', { username, password, folderName: testFolder })
-            .given('resource is shared', { username, userPassword: password, path: testFolder, shareType: 3, permissions: 15 })
+            .given('the user is recreated', { username: testUser, password: testUserPassword })
+            .given('folder exists', { username: testUser, password: testUserPassword, folderName: testFolder })
+            .given('resource is shared', { username: testUser, userPassword: testUserPassword, path: testFolder, shareType: 3, permissions: 15 })
             .given('file exists in last shared public share', { fileName: testFile })
-            .uponReceiving(`as '${username}', a MOVE request to move a file in public share ${data.description}`)
+            .uponReceiving(`as '${testUser}', a MOVE request to move a file in public share ${data.description}`)
             .withRequest({
               method: 'MOVE',
               path: MatchersV3.fromProviderState(
@@ -557,7 +557,7 @@ describe('oc.publicFiles', function () {
             .willRespondWith(moveResourceResponse)
 
           return provider.executeTest(async () => {
-            const oc = createOwncloud(username, password)
+            const oc = createOwncloud(testUser, testUserPassword)
             await oc.login()
             return oc.publicFiles.move(source, target, data.shareParams.password)
               .catch(error => {
@@ -571,16 +571,16 @@ describe('oc.publicFiles', function () {
           const target = shareTokenOfPublicLinkFolder + '/foo/lorem.txt'
 
           const provider = createProvider()
-          await getCapabilitiesInteraction(provider, username, password)
-          await getCurrentUserInformationInteraction(provider, username, password)
+          await getCapabilitiesInteraction(provider, testUser, testUserPassword)
+          await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
           await provider
             .given('provider base url is returned')
-            .given('the user is recreated', { username, password })
-            .given('folder exists', { username, password, folderName: testFolder })
-            .given('resource is shared', { username, userPassword: password, path: testFolder, shareType: 3, permissions: 15 })
+            .given('the user is recreated', { username: testUser, password: testUserPassword })
+            .given('folder exists', { username: testUser, password: testUserPassword, folderName: testFolder })
+            .given('resource is shared', { username: testUser, userPassword: testUserPassword, path: testFolder, shareType: 3, permissions: 15 })
             .given('folder exists in last shared public share', { folderName: 'foo' })
             .given('file exists in last shared public share', { fileName: testFile })
-            .uponReceiving(`as '${username}', a MOVE request to move a file to subfolder in public share ${data.description}`)
+            .uponReceiving(`as '${testUser}', a MOVE request to move a file to subfolder in public share ${data.description}`)
             .withRequest({
               method: 'MOVE',
               path: MatchersV3.fromProviderState(
@@ -597,7 +597,7 @@ describe('oc.publicFiles', function () {
             .willRespondWith(moveResourceResponse)
 
           return provider.executeTest(async () => {
-            const oc = createOwncloud(username, password)
+            const oc = createOwncloud(testUser, testUserPassword)
             await oc.login()
             return oc.publicFiles.move(source, target, data.shareParams.password).catch(error => {
               fail(error)
@@ -607,15 +607,15 @@ describe('oc.publicFiles', function () {
 
         it('should move a folder', async function () {
           const provider = createProvider()
-          await getCapabilitiesInteraction(provider, username, password)
-          await getCurrentUserInformationInteraction(provider, username, password)
+          await getCapabilitiesInteraction(provider, testUser, testUserPassword)
+          await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
           await provider
             .given('provider base url is returned')
-            .given('the user is recreated', { username, password })
-            .given('folder exists', { username, password, folderName: testFolder })
-            .given('resource is shared', { username, userPassword: password, path: testFolder, shareType: 3, permissions: 15 })
+            .given('the user is recreated', { username: testUser, password: testUserPassword })
+            .given('folder exists', { username: testUser, password: testUserPassword, folderName: testFolder })
+            .given('resource is shared', { username: testUser, userPassword: testUserPassword, path: testFolder, shareType: 3, permissions: 15 })
             .given('folder exists in last shared public share', { folderName: 'foo' })
-            .uponReceiving(`as '${username}', a MOVE request to move a folder to different name in public share ${data.description}`)
+            .uponReceiving(`as '${testUser}', a MOVE request to move a folder to different name in public share ${data.description}`)
             .withRequest({
               method: 'MOVE',
               path: MatchersV3.fromProviderState(
@@ -630,7 +630,7 @@ describe('oc.publicFiles', function () {
               }
             }).willRespondWith(moveResourceResponse)
           return provider.executeTest(async () => {
-            const oc = createOwncloud(username, password)
+            const oc = createOwncloud(testUser, testUserPassword)
             await oc.login()
             const source = shareTokenOfPublicLinkFolder + '/' + 'foo'
             const target = shareTokenOfPublicLinkFolder + '/' + 'bar'
@@ -645,18 +645,18 @@ describe('oc.publicFiles', function () {
 
         it('should get fileInfo of shared folder', async function () {
           const provider = createProvider(true, true)
-          await getCapabilitiesInteraction(provider, username, password)
-          await getCurrentUserInformationInteraction(provider, username, password)
+          await getCapabilitiesInteraction(provider, testUser, testUserPassword)
+          await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
 
-          await givenUserExists(provider, username, password)
-          await givenFolderExists(provider, username, password, testFolder)
+          await givenUserExists(provider, testUser, testUserPassword)
+          await givenFolderExists(provider, testUser, testUserPassword, testFolder)
           if (data.shareParams.password) {
-            await givenPublicShareExists(provider, username, password, testFolder, { password: data.shareParams.password, permissions: 15 })
+            await givenPublicShareExists(provider, testUser, testUserPassword, testFolder, { password: data.shareParams.password, permissions: 15 })
           } else {
-            await givenPublicShareExists(provider, username, password, testFolder, { permissions: 15 })
+            await givenPublicShareExists(provider, testUser, testUserPassword, testFolder, { permissions: 15 })
           }
           await provider
-            .uponReceiving(`as '${username}', a PROPFIND request to get file info of public share ${data.description}`)
+            .uponReceiving(`as '${testUser}', a PROPFIND request to get file info of public share ${data.description}`)
             .withRequest({
               method: 'PROPFIND',
               path: publicLinkShareTokenPath,
@@ -683,7 +683,7 @@ describe('oc.publicFiles', function () {
             })
 
           return provider.executeTest(async () => {
-            const oc = createOwncloud(username, password)
+            const oc = createOwncloud(testUser, testUserPassword)
             await oc.login()
             const sharedFolder = shareTokenOfPublicLinkFolder
             const folder = await oc.publicFiles.getFileInfo(
@@ -750,7 +750,7 @@ describe('oc.publicFiles', function () {
                 dProp
                   .appendElement('oc:public-link-item-type', '', MatchersV3.equal('folder'))
                   .appendElement('oc:public-link-permission', '', MatchersV3.equal(permission))
-                  .appendElement('oc:public-link-share-owner', '', MatchersV3.equal(username))
+                  .appendElement('oc:public-link-share-owner', '', MatchersV3.equal(testUser))
               })
                 .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
             })

--- a/tests/requestsOcsTest.js
+++ b/tests/requestsOcsTest.js
@@ -1,8 +1,10 @@
 import { MatchersV3 } from '@pact-foundation/pact/v3'
 
 describe('Main: Currently testing low level OCS', function () {
-  const config = require('./config/config.json')
-  const username = config.adminUsername
+  const {
+    admin: { username: adminUsername },
+    Alice
+  } = require('./config/users.json')
 
   const {
     getCapabilitiesInteraction,
@@ -55,7 +57,7 @@ describe('Main: Currently testing low level OCS', function () {
     await getCurrentUserInformationInteraction(provider)
 
     await provider
-      .uponReceiving(`as '${username}', a PUT request to update an unknown user using OCS`)
+      .uponReceiving(`as '${adminUsername}', a PUT request to update an unknown user using OCS`)
       .withRequest({
         method: 'PUT',
         path: MatchersV3.regex(
@@ -100,18 +102,17 @@ describe('Main: Currently testing low level OCS', function () {
     https://github.com/owncloud/ocis/issues/1702
   */
   it('checking : PUT email', async function () {
-    const { testUser, testUserPassword } = config
     const provider = createProvider(false, true)
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)
     await provider
-      .given('the user is recreated', { username: testUser, password: testUserPassword })
-      .uponReceiving(`as '${username}', a PUT request to update a user using OCS`)
+      .given('the user is recreated', { username: Alice.username, password: Alice.password })
+      .uponReceiving(`as '${adminUsername}', a PUT request to update a user using OCS`)
       .withRequest({
         method: 'PUT',
         path: MatchersV3.regex(
           '.*\\/ocs\\/v2\\.php\\/cloud\\/users\\/.+',
-          '/ocs/v2.php/cloud/users/' + testUser
+          '/ocs/v2.php/cloud/users/' + Alice.username
         ),
         query: { format: 'json' },
         headers: {
@@ -143,7 +144,7 @@ describe('Main: Currently testing low level OCS', function () {
       return oc.requests.ocs({
         method: 'PUT',
         service: 'cloud',
-        action: 'users/' + testUser,
+        action: 'users/' + Alice.username,
         data: { key: 'email', value: 'foo@bar.net' }
       }).then(response => {
         expect(response.ok).toBe(true)

--- a/tests/requestsOcsTest.js
+++ b/tests/requestsOcsTest.js
@@ -3,7 +3,7 @@ import { MatchersV3 } from '@pact-foundation/pact/v3'
 describe('Main: Currently testing low level OCS', function () {
   const {
     admin: { username: adminUsername },
-    Alice
+    testUser1: { username: testUser, password: testUserPassword }
   } = require('./config/users.json')
 
   const {
@@ -106,13 +106,13 @@ describe('Main: Currently testing low level OCS', function () {
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)
     await provider
-      .given('the user is recreated', { username: Alice.username, password: Alice.password })
+      .given('the user is recreated', { username: testUser, password: testUserPassword })
       .uponReceiving(`as '${adminUsername}', a PUT request to update a user using OCS`)
       .withRequest({
         method: 'PUT',
         path: MatchersV3.regex(
           '.*\\/ocs\\/v2\\.php\\/cloud\\/users\\/.+',
-          '/ocs/v2.php/cloud/users/' + Alice.username
+          '/ocs/v2.php/cloud/users/' + testUser
         ),
         query: { format: 'json' },
         headers: {
@@ -144,7 +144,7 @@ describe('Main: Currently testing low level OCS', function () {
       return oc.requests.ocs({
         method: 'PUT',
         service: 'cloud',
-        action: 'users/' + Alice.username,
+        action: 'users/' + testUser,
         data: { key: 'email', value: 'foo@bar.net' }
       }).then(response => {
         expect(response.ok).toBe(true)

--- a/tests/shareRecipientTest.js
+++ b/tests/shareRecipientTest.js
@@ -3,8 +3,8 @@ import { MatchersV3 } from '@pact-foundation/pact/v3'
 describe('Main: Currently testing share recipient,', function () {
   var config = require('./config/config.json')
   const {
-    testUser1: { username: sharer, password: sharerPassword },
-    testUser2: { username: receiver, password: receiverPassword }
+    testUser1: { username: sharer, password: sharerPassword, displayname: sharerDisplayname },
+    testUser2: { username: receiver, password: receiverPassword, displayname: receiverDisplayname }
   } = require('./config/users.json')
 
   const {
@@ -41,7 +41,10 @@ describe('Main: Currently testing share recipient,', function () {
             meta: { status: 'ok', statuscode: 200, message: 'OK' },
             data: {
               exact: { users: [], groups: [], remotes: [] },
-              users: [{ label: sharer, value: { shareType: 0, shareWith: sharer } }, { label: receiver, value: { shareType: 0, shareWith: receiver } }],
+              users: [
+                { label: MatchersV3.regex(`(${sharerDisplayname}|${sharer})`, sharer), value: { shareType: 0, shareWith: sharer } },
+                { label: MatchersV3.regex(`(${receiverDisplayname}|${receiver})`, receiver), value: { shareType: 0, shareWith: receiver } }
+              ],
               groups: [{ label: config.testGroup, value: { shareType: 1, shareWith: config.testGroup } }],
               remotes: []
             }

--- a/tests/shareRecipientTest.js
+++ b/tests/shareRecipientTest.js
@@ -3,8 +3,8 @@ import { MatchersV3 } from '@pact-foundation/pact/v3'
 describe('Main: Currently testing share recipient,', function () {
   var config = require('./config/config.json')
   const {
-    Alice: { username: sharer, password: sharerPassword },
-    Brian: { username: receiver, password: receiverPassword }
+    testUser1: { username: sharer, password: sharerPassword },
+    testUser2: { username: receiver, password: receiverPassword }
   } = require('./config/users.json')
 
   const {

--- a/tests/shareRecipientTest.js
+++ b/tests/shareRecipientTest.js
@@ -2,6 +2,10 @@ import { MatchersV3 } from '@pact-foundation/pact/v3'
 
 describe('Main: Currently testing share recipient,', function () {
   var config = require('./config/config.json')
+  const {
+    Alice: { username: sharer, password: sharerPassword },
+    Brian: { username: receiver, password: receiverPassword }
+  } = require('./config/users.json')
 
   const {
     getAuthHeaders,
@@ -10,11 +14,6 @@ describe('Main: Currently testing share recipient,', function () {
     createOwncloud,
     createProvider
   } = require('./helpers/pactHelper.js')
-
-  const sharer = config.testUser
-  const sharerPassword = config.testUserPassword
-  const receiver = config.testUser2
-  const receiverPassword = config.testUser2Password
 
   const getShareesInteraction = (provider, folder = config.testFolder) => {
     provider

--- a/tests/sharingTest.js
+++ b/tests/sharingTest.js
@@ -28,8 +28,8 @@ describe('Main: Currently testing file/folder sharing,', function () {
     testFolderId: testFolderShareID
   } = require('./config/config.json')
   const {
-    Alice: { username: sharer, password: sharerPassword },
-    Brian: { username: sharee, password: shareePassword }
+    testUser1: { username: sharer, password: sharerPassword },
+    testUser2: { username: sharee, password: shareePassword }
   } = require('./config/users.json')
 
   const {

--- a/tests/sharingWithAttributesTest.js
+++ b/tests/sharingWithAttributesTest.js
@@ -3,8 +3,8 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 describe('oc.shares', function () {
   const { testFile } = require('./config/config.json')
   const {
-    Alice: { username: sharer, password: sharerPassword },
-    Brian: { username: receiver, password: receiverPassword }
+    testUser1: { username: sharer, password: sharerPassword },
+    testUser2: { username: receiver, password: receiverPassword }
   } = require('./config/users.json')
 
   const {

--- a/tests/sharingWithAttributesTest.js
+++ b/tests/sharingWithAttributesTest.js
@@ -1,7 +1,11 @@
 import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 describe('oc.shares', function () {
-  const config = require('./config/config.json')
+  const { testFile } = require('./config/config.json')
+  const {
+    Alice: { username: sharer, password: sharerPassword },
+    Brian: { username: receiver, password: receiverPassword }
+  } = require('./config/users.json')
 
   const {
     xmlResponseHeaders,
@@ -15,16 +19,12 @@ describe('oc.shares', function () {
     getAuthHeaders
   } = require('./helpers/pactHelper.js')
 
-  // TESTING CONFIGS
-  const { testUser, testUserPassword, testFile } = config
   const shareAttributes = {
     attributes: [
       { scope: 'ownCloud', key: 'read', value: 'true' },
       { scope: 'ownCloud', key: 'share', value: 'true' }
     ]
   }
-  const shareeName = config.testUser2
-  const shareePassword = config.testUser2Password
 
   const shareAttributesResponse = () => {
     const response = []
@@ -37,10 +37,10 @@ describe('oc.shares', function () {
 
   const sharingWithAttributes = (provider) => {
     return provider
-      .given('the user is recreated', { username: testUser, password: testUserPassword })
-      .given('the user is recreated', { username: shareeName, password: shareePassword })
-      .given('file exists', { username: testUser, password: testUserPassword, fileName: testFile, testContent: 'a test file' })
-      .uponReceiving(`as '${testUser}', a POST request to share a file with permissions in attributes`)
+      .given('the user is recreated', { username: sharer, password: sharerPassword })
+      .given('the user is recreated', { username: receiver, password: receiverPassword })
+      .given('file exists', { username: sharer, password: sharerPassword, fileName: testFile, testContent: 'a test file' })
+      .uponReceiving(`as '${sharer}', a POST request to share a file with permissions in attributes`)
       .withRequest({
         method: 'POST',
         path: MatchersV3.regex(
@@ -48,10 +48,10 @@ describe('oc.shares', function () {
           '/ocs/v1.php/apps/files_sharing/api/v1/shares'
         ),
         headers: {
-          authorization: getAuthHeaders(testUser, testUserPassword),
+          authorization: getAuthHeaders(sharer, sharerPassword),
           ...applicationFormUrlEncoded
         },
-        body: 'shareType=0&shareWith=' + shareeName + '&path=%2F' + testFile +
+        body: 'shareType=0&shareWith=' + receiver + '&path=%2F' + testFile +
           '&attributes%5B0%5D%5Bscope%5D=' + shareAttributes.attributes[0].scope +
           '&attributes%5B0%5D%5Bkey%5D=' + shareAttributes.attributes[0].key +
           '&attributes%5B0%5D%5Bvalue%5D=' + shareAttributes.attributes[0].value +
@@ -68,8 +68,8 @@ describe('oc.shares', function () {
           })
             .appendElement('data', '', (data) => {
               shareResponseOcsData(data, 0, 7, 17, '/' + testFile)
-                .appendElement('share_with', '', MatchersV3.equal(shareeName))
-                .appendElement('share_with_displayname', '', MatchersV3.equal(shareeName))
+                .appendElement('share_with', '', MatchersV3.equal(receiver))
+                .appendElement('share_with_displayname', '', MatchersV3.equal(receiver))
                 .appendElement('attributes', '', MatchersV3.equal(shareAttributesResponse()))
             })
         })
@@ -78,14 +78,14 @@ describe('oc.shares', function () {
 
   it('shall share with permissions in attributes', async function () {
     const provider = createProvider(false, true)
-    await getCapabilitiesInteraction(provider, testUser, testUserPassword)
-    await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
+    await getCapabilitiesInteraction(provider, sharer, sharerPassword)
+    await getCurrentUserInformationInteraction(provider, sharer, sharerPassword)
     await sharingWithAttributes(provider)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(testUser, testUserPassword)
+      const oc = createOwncloud(sharer, sharerPassword)
       await oc.login()
-      return oc.shares.shareFileWithUser(testFile, shareeName, shareAttributes).then(share => {
+      return oc.shares.shareFileWithUser(testFile, receiver, shareAttributes).then(share => {
         expect(share.getPermissions()).toBe(17)
       })
     })

--- a/tests/signedUrlIntegrationTest.js
+++ b/tests/signedUrlIntegrationTest.js
@@ -2,6 +2,9 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 describe('Signed urls', function () {
   var config = require('./config/config.json')
+  const {
+    Alice: { username, password }
+  } = require('./config/users.json')
 
   const fetch = require('node-fetch')
   const {
@@ -85,17 +88,17 @@ describe('Signed urls', function () {
 
   it('should allow file download with a signUrl', async function () {
     const provider = createProvider()
-    await getCapabilitiesInteraction(provider, config.testUser, config.testUserPassword)
+    await getCapabilitiesInteraction(provider, username, password)
     // eslint-disable-next-line no-sequences
-    await getCurrentUserInformationInteraction(provider, config.testUser, config.testUserPassword)
-    await getSigningKeyInteraction(provider, config.testUser, config.testUserPassword)
-    await downloadWithSignedURLInteraction(provider, config.testUser, config.testUserPassword)
+    await getCurrentUserInformationInteraction(provider, username, password)
+    await getSigningKeyInteraction(provider, username, password)
+    await downloadWithSignedURLInteraction(provider, username, password)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(config.testUser, config.testUserPassword)
+      const oc = createOwncloud(username, password)
       await oc.login()
 
-      const url = oc.files.getFileUrl(`files/${config.testUser}/${config.testFolder}/${config.testFile}`)
+      const url = oc.files.getFileUrl(`files/${username}/${config.testFolder}/${config.testFile}`)
       const signedUrl = await oc.signUrl(url)
       const response = await fetch(signedUrl)
       expect(response.ok).toEqual(true)

--- a/tests/signedUrlIntegrationTest.js
+++ b/tests/signedUrlIntegrationTest.js
@@ -3,7 +3,7 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 describe('Signed urls', function () {
   var config = require('./config/config.json')
   const {
-    Alice: { username, password }
+    testUser1: { username: testUser, password: testUserPassword }
   } = require('./config/users.json')
 
   const fetch = require('node-fetch')
@@ -88,17 +88,17 @@ describe('Signed urls', function () {
 
   it('should allow file download with a signUrl', async function () {
     const provider = createProvider()
-    await getCapabilitiesInteraction(provider, username, password)
+    await getCapabilitiesInteraction(provider, testUser, testUserPassword)
     // eslint-disable-next-line no-sequences
-    await getCurrentUserInformationInteraction(provider, username, password)
-    await getSigningKeyInteraction(provider, username, password)
-    await downloadWithSignedURLInteraction(provider, username, password)
+    await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
+    await getSigningKeyInteraction(provider, testUser, testUserPassword)
+    await downloadWithSignedURLInteraction(provider, testUser, testUserPassword)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(username, password)
+      const oc = createOwncloud(testUser, testUserPassword)
       await oc.login()
 
-      const url = oc.files.getFileUrl(`files/${username}/${config.testFolder}/${config.testFile}`)
+      const url = oc.files.getFileUrl(`files/${testUser}/${config.testFolder}/${config.testFile}`)
       const signedUrl = await oc.signUrl(url)
       const response = await fetch(signedUrl)
       expect(response.ok).toEqual(true)

--- a/tests/signedUrlTest.js
+++ b/tests/signedUrlTest.js
@@ -1,6 +1,8 @@
 describe('Main: Currently testing url signing,', function () {
   var OwnCloud = require('../src/owncloud')
-  var config = require('./config/config.json')
+  const {
+    admin: { username: adminUsername, password: adminPassword }
+  } = require('./config/users.json')
 
   const { getMockServerBaseUrl } = require('./helpers/pactHelper.js')
   const mockServerBaseUrl = getMockServerBaseUrl()
@@ -33,8 +35,8 @@ describe('Main: Currently testing url signing,', function () {
       baseUrl: mockServerBaseUrl,
       auth: {
         basic: {
-          username: config.adminUsername,
-          password: config.adminPassword
+          username: adminUsername,
+          password: adminPassword
         }
       },
       signingKey: '1234567890',

--- a/tests/unauthorized/appsTest.js
+++ b/tests/unauthorized/appsTest.js
@@ -2,7 +2,7 @@ import { MatchersV3 } from '@pact-foundation/pact/v3'
 
 describe('Unauthorized: Currently testing apps management,', function () {
   const config = require('../config/config.json')
-  const username = config.adminUsername
+  const { admin: { username: adminUsername } } = require('../config/users.json')
 
   const {
     unauthorizedXmlResponseBody,
@@ -25,7 +25,7 @@ describe('Unauthorized: Currently testing apps management,', function () {
 
   const getAppsInvalidAuthInteraction = async (provider, query) => {
     return provider
-      .uponReceiving(`as '${username}', a GET request to get all apps with invalid auth`)
+      .uponReceiving(`as '${adminUsername}', a GET request to get all apps with invalid auth`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -40,7 +40,7 @@ describe('Unauthorized: Currently testing apps management,', function () {
 
   const appRequestInvalidAuthInteraction = async (provider, requestName, method, app) => {
     return provider
-      .uponReceiving(`as '${username}', a ${method} request to ${requestName} with invalid auth`)
+      .uponReceiving(`as '${adminUsername}', a ${method} request to ${requestName} with invalid auth`)
       .withRequest({
         method: method,
         path: MatchersV3.regex(
@@ -59,7 +59,7 @@ describe('Unauthorized: Currently testing apps management,', function () {
     await getAppsInvalidAuthInteraction(provider, { filter: 'enabled' })
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
@@ -80,7 +80,7 @@ describe('Unauthorized: Currently testing apps management,', function () {
     await appRequestInvalidAuthInteraction(provider, 'enable app', 'POST', 'files')
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
@@ -101,7 +101,7 @@ describe('Unauthorized: Currently testing apps management,', function () {
     await appRequestInvalidAuthInteraction(provider, 'disable app', 'DELETE', 'files')
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {

--- a/tests/unauthorized/capabilitiesTest.js
+++ b/tests/unauthorized/capabilitiesTest.js
@@ -1,5 +1,6 @@
 describe('Unauthorized: Currently testing getConfig, getVersion and getCapabilities', function () {
   const config = require('../config/config.json')
+  const { admin: { username: adminUsername } } = require('../config/users.json')
 
   const {
     getCapabilitiesWithInvalidAuthInteraction,
@@ -12,7 +13,7 @@ describe('Unauthorized: Currently testing getConfig, getVersion and getCapabilit
     await getCapabilitiesWithInvalidAuthInteraction(provider)
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {

--- a/tests/unauthorized/filesTest.js
+++ b/tests/unauthorized/filesTest.js
@@ -3,6 +3,7 @@
 
 describe('Unauthorized: Currently testing files management,', function () {
   const config = require('../config/config.json')
+  const { admin: { username: adminUsername } } = require('../config/users.json')
 
   const {
     getCapabilitiesWithInvalidAuthInteraction,
@@ -26,7 +27,7 @@ describe('Unauthorized: Currently testing files management,', function () {
     await getCapabilitiesWithInvalidAuthInteraction(provider)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
@@ -45,7 +46,7 @@ describe('Unauthorized: Currently testing files management,', function () {
     await getCapabilitiesWithInvalidAuthInteraction(provider)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
@@ -68,7 +69,7 @@ describe('Unauthorized: Currently testing files management,', function () {
     await getCapabilitiesWithInvalidAuthInteraction(provider)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
@@ -88,7 +89,7 @@ describe('Unauthorized: Currently testing files management,', function () {
     await getCapabilitiesWithInvalidAuthInteraction(provider)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
@@ -108,7 +109,7 @@ describe('Unauthorized: Currently testing files management,', function () {
     await getCapabilitiesWithInvalidAuthInteraction(provider)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
@@ -127,7 +128,7 @@ describe('Unauthorized: Currently testing files management,', function () {
     await getCapabilitiesWithInvalidAuthInteraction(provider)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
 
       await oc.login().then(() => {
         fail('not expected to log in')
@@ -147,7 +148,7 @@ describe('Unauthorized: Currently testing files management,', function () {
     await getCapabilitiesWithInvalidAuthInteraction(provider)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
 
       await oc.login().then(() => {
         fail('not expected to log in')

--- a/tests/unauthorized/groupTest.js
+++ b/tests/unauthorized/groupTest.js
@@ -5,7 +5,7 @@ import { MatchersV3 } from '@pact-foundation/pact/v3'
 
 describe('Unauthorized: Currently testing group management,', function () {
   const config = require('../config/config.json')
-  const username = config.adminUsername
+  const { admin: { username: adminUsername } } = require('../config/users.json')
 
   const {
     unauthorizedXmlResponseBody,
@@ -28,7 +28,7 @@ describe('Unauthorized: Currently testing group management,', function () {
 
   const groupsInteraction = (provider, requestName, method) => {
     return provider
-      .uponReceiving(`as '${username}', a ${method} request to ${requestName} with invalid auth`)
+      .uponReceiving(`as '${adminUsername}', a ${method} request to ${requestName} with invalid auth`)
       .withRequest({
         method: method,
         path: MatchersV3.regex(
@@ -42,7 +42,7 @@ describe('Unauthorized: Currently testing group management,', function () {
 
   const deleteGroupInteraction = (provider) => {
     return provider
-      .uponReceiving(`as '${username}', a DELETE request to delete a group with invalid auth`)
+      .uponReceiving(`as '${adminUsername}', a DELETE request to delete a group with invalid auth`)
       .withRequest({
         method: 'DELETE',
         path: MatchersV3.regex(
@@ -56,7 +56,7 @@ describe('Unauthorized: Currently testing group management,', function () {
 
   const getGroupMembersInteraction = (provider) => {
     return provider
-      .uponReceiving(`as '${username}', a GET request to get members of a group with invalid auth`)
+      .uponReceiving(`as '${adminUsername}', a GET request to get members of a group with invalid auth`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -75,7 +75,7 @@ describe('Unauthorized: Currently testing group management,', function () {
     await groupsInteraction(provider, 'get all groups', 'GET')
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
 
       await oc.login().then(() => {
         fail('not expected to log in')
@@ -98,7 +98,7 @@ describe('Unauthorized: Currently testing group management,', function () {
     await groupsInteraction(provider, 'create a group', 'POST')
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
 
       await oc.login().then(() => {
         fail('not expected to log in')
@@ -121,7 +121,7 @@ describe('Unauthorized: Currently testing group management,', function () {
     await groupsInteraction(provider, 'check group existence', 'GET')
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
 
       await oc.login().then(() => {
         fail('not expected to log in')
@@ -144,7 +144,7 @@ describe('Unauthorized: Currently testing group management,', function () {
     await deleteGroupInteraction(provider)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
 
       await oc.login().then(() => {
         fail('not expected to log in')
@@ -167,7 +167,7 @@ describe('Unauthorized: Currently testing group management,', function () {
     await getGroupMembersInteraction(provider)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
 
       await oc.login().then(() => {
         fail('not expected to log in')

--- a/tests/unauthorized/sharingTest.js
+++ b/tests/unauthorized/sharingTest.js
@@ -9,7 +9,10 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     testGroup,
     invalidPassword
   } = require('../config/config.json')
-  const { admin: { username: adminUsername }, Alice } = require('../config/users.json')
+  const {
+    admin: { username: adminUsername },
+    testUser1: { username: testUser }
+  } = require('../config/users.json')
 
   const {
     invalidAuthHeader,
@@ -112,7 +115,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
         expect(err).toBe('Unauthorized')
       })
 
-      return oc.shares.shareFileWithUser(testFile, Alice.username).then(share => {
+      return oc.shares.shareFileWithUser(testFile, testUser).then(share => {
         expect(share).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')

--- a/tests/unauthorized/sharingTest.js
+++ b/tests/unauthorized/sharingTest.js
@@ -4,7 +4,12 @@
 const { MatchersV3 } = require('@pact-foundation/pact/v3')
 
 describe('Unauthorized: Currently testing file/folder sharing,', function () {
-  const config = require('../config/config.json')
+  const {
+    testFile,
+    testGroup,
+    invalidPassword
+  } = require('../config/config.json')
+  const { admin: { username: adminUsername }, Alice } = require('../config/users.json')
 
   const {
     invalidAuthHeader,
@@ -13,15 +18,6 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     createOwncloud,
     createProvider
   } = require('../helpers/pactHelper.js')
-
-  // TESTING CONFIGS
-  const {
-    testUser,
-    testFile,
-    testGroup,
-    adminUsername: username,
-    invalidPassword
-  } = config
 
   const invalidAuthHeaderObject = {
     authorization: invalidAuthHeader
@@ -82,10 +78,10 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     const provider = createProvider(false, true)
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await createShareInteraction(provider, `as '${username}', a POST request to create public link share with invalid auth`)
+    await createShareInteraction(provider, `as '${adminUsername}', a POST request to create public link share with invalid auth`)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(username, invalidPassword)
+      const oc = createOwncloud(adminUsername, invalidPassword)
 
       await oc.login().then(() => {
         fail('not expected to log in')
@@ -105,10 +101,10 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     const provider = createProvider(false, true)
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await createShareInteraction(provider, `as '${username}', a POST request to share a file to a user with invalid auth`)
+    await createShareInteraction(provider, `as '${adminUsername}', a POST request to share a file to a user with invalid auth`)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(username, invalidPassword)
+      const oc = createOwncloud(adminUsername, invalidPassword)
 
       await oc.login().then(() => {
         fail('not expected to log in')
@@ -116,7 +112,7 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
         expect(err).toBe('Unauthorized')
       })
 
-      return oc.shares.shareFileWithUser(testFile, testUser).then(share => {
+      return oc.shares.shareFileWithUser(testFile, Alice.username).then(share => {
         expect(share).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -128,10 +124,10 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     const provider = createProvider(false, true)
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await createShareInteraction(provider, `as '${username}', a POST request to share a file to a group with invalid auth`)
+    await createShareInteraction(provider, `as '${adminUsername}', a POST request to share a file to a group with invalid auth`)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(username, invalidPassword)
+      const oc = createOwncloud(adminUsername, invalidPassword)
 
       await oc.login().then(() => {
         fail('not expected to log in')
@@ -153,10 +149,10 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     const provider = createProvider(false, true)
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await getSharesInteraction(provider, `as '${username}', a GET request to check whether a file is shared or not with invalid auth`, testFile)
+    await getSharesInteraction(provider, `as '${adminUsername}', a GET request to check whether a file is shared or not with invalid auth`, testFile)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(username, invalidPassword)
+      const oc = createOwncloud(adminUsername, invalidPassword)
 
       await oc.login().then(() => {
         fail('not expected to log in')
@@ -176,10 +172,10 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     const provider = createProvider(false, true)
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await getShareInteraction(provider, `as '${username}', a GET request to get single share of a file with invalid auth`, 'GET')
+    await getShareInteraction(provider, `as '${adminUsername}', a GET request to get single share of a file with invalid auth`, 'GET')
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(username, invalidPassword)
+      const oc = createOwncloud(adminUsername, invalidPassword)
 
       await oc.login().then(() => {
         fail('not expected to log in')
@@ -199,10 +195,10 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     const provider = createProvider(false, true)
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await getSharesInteraction(provider, `as '${username}', a GET request to get shares of a file with invalid auth`, testFile)
+    await getSharesInteraction(provider, `as '${adminUsername}', a GET request to get shares of a file with invalid auth`, testFile)
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(username, invalidPassword)
+      const oc = createOwncloud(adminUsername, invalidPassword)
 
       await oc.login().then(() => {
         fail('not expected to log in')
@@ -222,10 +218,10 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     const provider = createProvider(false, true)
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await getShareInteraction(provider, `as '${username}', a PUT request to update a share with invalid auth`, 'PUT')
+    await getShareInteraction(provider, `as '${adminUsername}', a PUT request to update a share with invalid auth`, 'PUT')
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(username, invalidPassword)
+      const oc = createOwncloud(adminUsername, invalidPassword)
 
       await oc.login().then(() => {
         fail('not expected to log in')
@@ -245,10 +241,10 @@ describe('Unauthorized: Currently testing file/folder sharing,', function () {
     const provider = createProvider(false, true)
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
-    await getShareInteraction(provider, `as '${username}', a DELETE request to delete a share with invalid auth`, 'DELETE')
+    await getShareInteraction(provider, `as '${adminUsername}', a DELETE request to delete a share with invalid auth`, 'DELETE')
 
     return provider.executeTest(async () => {
-      const oc = createOwncloud(username, invalidPassword)
+      const oc = createOwncloud(adminUsername, invalidPassword)
 
       await oc.login().then(() => {
         fail('not expected to log in')

--- a/tests/unauthorized/userTest.js
+++ b/tests/unauthorized/userTest.js
@@ -7,22 +7,20 @@ describe('Unauthorized: Currently testing user management,', function () {
   // CURRENT TIME
   var timeRightNow = new Date().getTime()
   var config = require('../config/config.json')
-  const username = config.adminUsername
+  const { admin: { username: adminUsername }, Alice } = require('../config/users.json')
 
   const {
     invalidAuthHeader,
     xmlResponseHeaders,
     getCapabilitiesWithInvalidAuthInteraction,
-    createOwncloud
-  } = require('../helpers/pactHelper.js')
-  const {
+    createOwncloud,
     unauthorizedXmlResponseBody,
     createProvider
   } = require('../helpers/pactHelper.js')
 
   const invalidAuthInteraction = (provider, requestName, method, path, query) => {
     return provider
-      .uponReceiving(`as '${username}', a ${method} request to ${requestName} with invalid auth`)
+      .uponReceiving(`as '${adminUsername}', a ${method} request to ${requestName} with invalid auth`)
       .withRequest({
         method: method,
         path: path,
@@ -39,8 +37,8 @@ describe('Unauthorized: Currently testing user management,', function () {
   }
 
   const adminUserEndpointPath = MatchersV3.regex(
-    '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + config.adminUsername + '$',
-    '/ocs/v1.php/cloud/users/' + config.adminUsername
+    '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + adminUsername + '$',
+    '/ocs/v1.php/cloud/users/' + adminUsername
   )
 
   const usersEndpointPath = MatchersV3.regex(
@@ -49,18 +47,18 @@ describe('Unauthorized: Currently testing user management,', function () {
   )
 
   const groupsEndpointPath = MatchersV3.regex(
-    '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + config.testUser + '\\/groups$',
-    '/ocs/v1.php/cloud/users/' + config.testUser + '/groups'
+    '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + Alice.username + '\\/groups$',
+    '/ocs/v1.php/cloud/users/' + Alice.username + '/groups'
   )
 
   const subadminsUserEndpointPath = MatchersV3.regex(
-    '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + config.testUser + '\\/subadmins$',
-    '/ocs/v1.php/cloud/users/' + config.testUser + '/subadmins'
+    '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + Alice.username + '\\/subadmins$',
+    '/ocs/v1.php/cloud/users/' + Alice.username + '/subadmins'
   )
 
   const testUserEndpointPath = MatchersV3.regex(
-    '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + config.testUser + '$',
-    '/ocs/v1.php/cloud/users/' + config.testUser
+    '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + Alice.username + '$',
+    '/ocs/v1.php/cloud/users/' + Alice.username
   )
 
   const nonExistingUserEndpoint = MatchersV3.regex(
@@ -78,13 +76,13 @@ describe('Unauthorized: Currently testing user management,', function () {
     await invalidAuthInteraction(provider, 'admin user', 'GET', adminUserEndpointPath)
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.getUser(config.adminUsername).then(data => {
+      return oc.users.getUser(adminUsername).then(data => {
         expect(data).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -99,7 +97,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     await invalidAuthInteraction(provider, 'create a user', 'POST', usersEndpointPath)
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
@@ -120,7 +118,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     await invalidAuthInteraction(provider, 'search users', 'GET', usersEndpointPath)
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
@@ -136,19 +134,19 @@ describe('Unauthorized: Currently testing user management,', function () {
 
   it('checking method : userExists', async function () {
     const provider = createProvider(false, true)
-    const query = { search: config.adminUsername }
+    const query = { search: adminUsername }
 
     await getCapabilitiesWithInvalidAuthInteraction(provider)
     await invalidAuthInteraction(provider, 'check user existence', 'GET', usersEndpointPath, query)
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.userExists(config.adminUsername).then(status => {
+      return oc.users.userExists(adminUsername).then(status => {
         expect(status).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -163,13 +161,13 @@ describe('Unauthorized: Currently testing user management,', function () {
     await invalidAuthInteraction(provider, 'edit user', 'PUT', testUserEndpointPath)
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.setUserAttribute(config.testUser, 'email', 'asd@a.com').then(data => {
+      return oc.users.setUserAttribute(Alice.username, 'email', 'asd@a.com').then(data => {
         expect(data).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -184,13 +182,13 @@ describe('Unauthorized: Currently testing user management,', function () {
     await invalidAuthInteraction(provider, 'add user to a group', 'POST', groupsEndpointPath)
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.addUserToGroup(config.testUser, config.testGroup).then(status => {
+      return oc.users.addUserToGroup(Alice.username, config.testGroup).then(status => {
         expect(status).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -205,13 +203,13 @@ describe('Unauthorized: Currently testing user management,', function () {
     await invalidAuthInteraction(provider, 'get users of a group', 'GET', groupsEndpointPath)
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.getUserGroups(config.testUser).then(data => {
+      return oc.users.getUserGroups(Alice.username).then(data => {
         expect(data).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -226,13 +224,13 @@ describe('Unauthorized: Currently testing user management,', function () {
     await invalidAuthInteraction(provider, 'check user existence in a group', 'GET', groupsEndpointPath)
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.userIsInGroup(config.testUser, config.testGroup).then(status => {
+      return oc.users.userIsInGroup(Alice.username, config.testGroup).then(status => {
         expect(status).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -247,13 +245,13 @@ describe('Unauthorized: Currently testing user management,', function () {
     await invalidAuthInteraction(provider, 'normal user', 'GET', testUserEndpointPath)
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.getUser(config.testUser).then(data => {
+      return oc.users.getUser(Alice.username).then(data => {
         expect(data).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -268,13 +266,13 @@ describe('Unauthorized: Currently testing user management,', function () {
     await invalidAuthInteraction(provider, 'remove user from a group', 'DELETE', groupsEndpointPath)
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.removeUserFromGroup(config.testUser, config.testGroup).then(status => {
+      return oc.users.removeUserFromGroup(Alice.username, config.testGroup).then(status => {
         expect(status).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -289,13 +287,13 @@ describe('Unauthorized: Currently testing user management,', function () {
     await invalidAuthInteraction(provider, 'add a user to subadmin group', 'POST', subadminsUserEndpointPath)
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.addUserToSubadminGroup(config.testUser, config.testGroup).then(status => {
+      return oc.users.addUserToSubadminGroup(Alice.username, config.testGroup).then(status => {
         expect(status).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -310,13 +308,13 @@ describe('Unauthorized: Currently testing user management,', function () {
     await invalidAuthInteraction(provider, 'get users of subadmin group', 'GET', subadminsUserEndpointPath)
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.getUserSubadminGroups(config.testUser).then(data => {
+      return oc.users.getUserSubadminGroups(Alice.username).then(data => {
         expect(data).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -331,13 +329,13 @@ describe('Unauthorized: Currently testing user management,', function () {
     await invalidAuthInteraction(provider, 'check user existence in subadmin group', 'GET', subadminsUserEndpointPath)
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.userIsInSubadminGroup(config.testUser, config.testGroup).then(status => {
+      return oc.users.userIsInSubadminGroup(Alice.username, config.testGroup).then(status => {
         expect(status).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -352,7 +350,7 @@ describe('Unauthorized: Currently testing user management,', function () {
     await invalidAuthInteraction(provider, 'delete a non-existent user', 'DELETE', nonExistingUserEndpoint)
 
     await provider.executeTest(async () => {
-      const oc = createOwncloud(config.adminUsername, config.invalidPassword)
+      const oc = createOwncloud(adminUsername, config.invalidPassword)
       await oc.login().then(() => {
         fail('not expected to log in')
       }).catch((err) => {

--- a/tests/unauthorized/userTest.js
+++ b/tests/unauthorized/userTest.js
@@ -7,7 +7,10 @@ describe('Unauthorized: Currently testing user management,', function () {
   // CURRENT TIME
   var timeRightNow = new Date().getTime()
   var config = require('../config/config.json')
-  const { admin: { username: adminUsername }, Alice } = require('../config/users.json')
+  const {
+    admin: { username: adminUsername },
+    testUser1: { username: testUser }
+  } = require('../config/users.json')
 
   const {
     invalidAuthHeader,
@@ -47,18 +50,18 @@ describe('Unauthorized: Currently testing user management,', function () {
   )
 
   const groupsEndpointPath = MatchersV3.regex(
-    '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + Alice.username + '\\/groups$',
-    '/ocs/v1.php/cloud/users/' + Alice.username + '/groups'
+    '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + testUser + '\\/groups$',
+    '/ocs/v1.php/cloud/users/' + testUser + '/groups'
   )
 
   const subadminsUserEndpointPath = MatchersV3.regex(
-    '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + Alice.username + '\\/subadmins$',
-    '/ocs/v1.php/cloud/users/' + Alice.username + '/subadmins'
+    '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + testUser + '\\/subadmins$',
+    '/ocs/v1.php/cloud/users/' + testUser + '/subadmins'
   )
 
   const testUserEndpointPath = MatchersV3.regex(
-    '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + Alice.username + '$',
-    '/ocs/v1.php/cloud/users/' + Alice.username
+    '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + testUser + '$',
+    '/ocs/v1.php/cloud/users/' + testUser
   )
 
   const nonExistingUserEndpoint = MatchersV3.regex(
@@ -167,7 +170,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.setUserAttribute(Alice.username, 'email', 'asd@a.com').then(data => {
+      return oc.users.setUserAttribute(testUser, 'email', 'asd@a.com').then(data => {
         expect(data).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -188,7 +191,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.addUserToGroup(Alice.username, config.testGroup).then(status => {
+      return oc.users.addUserToGroup(testUser, config.testGroup).then(status => {
         expect(status).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -209,7 +212,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.getUserGroups(Alice.username).then(data => {
+      return oc.users.getUserGroups(testUser).then(data => {
         expect(data).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -230,7 +233,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.userIsInGroup(Alice.username, config.testGroup).then(status => {
+      return oc.users.userIsInGroup(testUser, config.testGroup).then(status => {
         expect(status).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -251,7 +254,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.getUser(Alice.username).then(data => {
+      return oc.users.getUser(testUser).then(data => {
         expect(data).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -272,7 +275,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.removeUserFromGroup(Alice.username, config.testGroup).then(status => {
+      return oc.users.removeUserFromGroup(testUser, config.testGroup).then(status => {
         expect(status).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -293,7 +296,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.addUserToSubadminGroup(Alice.username, config.testGroup).then(status => {
+      return oc.users.addUserToSubadminGroup(testUser, config.testGroup).then(status => {
         expect(status).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -314,7 +317,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.getUserSubadminGroups(Alice.username).then(data => {
+      return oc.users.getUserSubadminGroups(testUser).then(data => {
         expect(data).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')
@@ -335,7 +338,7 @@ describe('Unauthorized: Currently testing user management,', function () {
       }).catch((err) => {
         expect(err).toBe('Unauthorized')
       })
-      return oc.users.userIsInSubadminGroup(Alice.username, config.testGroup).then(status => {
+      return oc.users.userIsInSubadminGroup(testUser, config.testGroup).then(status => {
         expect(status).toBe(null)
       }).catch(error => {
         expect(error).toMatch('Unauthorized')

--- a/tests/userTest.js
+++ b/tests/userTest.js
@@ -2,7 +2,10 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 
 describe('Main: Currently testing user management,', function () {
   var config = require('./config/config.json')
-  const adminDisplayName = config.adminDisplayName
+  const {
+    admin: { username: adminUsername, displayname: adminDisplayName },
+    Alice
+  } = require('./config/users.json')
 
   // PACT setup
   const {
@@ -17,12 +20,12 @@ describe('Main: Currently testing user management,', function () {
   } = require('./helpers/pactHelper.js')
   const { validAdminAuthHeaders, xmlResponseHeaders, applicationFormUrlEncoded } = require('./helpers/pactHelper.js')
   const getUserInformationInteraction = async function (provider, requestName, username, responseBody) {
-    if (username !== config.adminUsername && username !== config.nonExistentUser) {
+    if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
-        .given('the user is recreated', { username: username, password: config.testUserPassword })
+        .given('the user is recreated', { username: username, password: Alice.password })
     }
     return provider
-      .uponReceiving(`as '${config.adminUsername}', a GET request to ${requestName}`)
+      .uponReceiving(`as '${adminUsername}', a GET request to ${requestName}`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -40,8 +43,8 @@ describe('Main: Currently testing user management,', function () {
 
   const getUsersInteraction = function (provider, requestName, query, bodyData) {
     return provider
-      .given('the user is recreated', { username: config.testUser, password: config.testUserPassword })
-      .uponReceiving(`as '${config.adminUsername}', a GET request to ${requestName}`)
+      .given('the user is recreated', { username: Alice.username, password: Alice.password })
+      .uponReceiving(`as '${adminUsername}', a GET request to ${requestName}`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -64,13 +67,13 @@ describe('Main: Currently testing user management,', function () {
   }
 
   const changeUserAttributeInteraction = async function (provider, requestName, username, requestBody, response) {
-    if (username !== config.adminUsername && username !== config.nonExistentUser) {
+    if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
-        .given('the user is recreated', { username: username, password: config.testUserPassword })
+        .given('the user is recreated', { username: username, password: Alice.password })
     }
 
     return provider
-      .uponReceiving(`as '${config.adminUsername}', a PUT request to set user attribute of ${requestName}`)
+      .uponReceiving(`as '${adminUsername}', a PUT request to set user attribute of ${requestName}`)
       .withRequest({
         method: 'PUT',
         path: MatchersV3.regex(
@@ -100,9 +103,9 @@ describe('Main: Currently testing user management,', function () {
       ocsStatusCode = 103
       message = 'The requested user could not be found'
     }
-    if (username !== config.adminUsername && username !== config.nonExistentUser) {
+    if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
-        .given('the user is recreated', { username: username, password: config.testUserPassword })
+        .given('the user is recreated', { username: username, password: Alice.password })
     }
     if (group !== config.nonExistentGroup) {
       await provider
@@ -110,7 +113,7 @@ describe('Main: Currently testing user management,', function () {
     }
 
     return provider
-      .uponReceiving(`as '${config.adminUsername}', a POST request to ${requestName}`)
+      .uponReceiving(`as '${adminUsername}', a POST request to ${requestName}`)
       .withRequest({
         method: 'POST',
         path: MatchersV3.regex(
@@ -144,14 +147,14 @@ describe('Main: Currently testing user management,', function () {
   }
 
   const getGroupOfUserInteraction = async function (provider, requestName, username, responseBody) {
-    if (username !== config.validAdminAuthHeaders && username !== config.nonExistentUser) {
+    if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
-        .given('the user is recreated', { username: username, password: config.testUserPassword })
+        .given('the user is recreated', { username: username, password: Alice.password })
         .given('group exists', { groupName: config.testGroup })
         .given('user is added to group', { username: username, groupName: config.testGroup })
     }
     return provider
-      .uponReceiving(`as '${config.adminUsername}', a GET request to get groups of ${requestName}`)
+      .uponReceiving(`as '${adminUsername}', a GET request to get groups of ${requestName}`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -174,16 +177,16 @@ describe('Main: Currently testing user management,', function () {
       ocsStatusCode = 103
       message = 'The requested user could not be found'
     }
-    if (username !== config.adminUsername && username !== config.nonExistentUser) {
+    if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
-        .given('the user is recreated', { username: username, password: config.testUserPassword })
+        .given('the user is recreated', { username: username, password: Alice.password })
     }
     if (group !== config.nonExistentGroup) {
       await provider
         .given('group exists', { groupName: group })
     }
     return provider
-      .uponReceiving(`as '${config.adminUsername}', a DELETE request to remove ${requestName}`)
+      .uponReceiving(`as '${adminUsername}', a DELETE request to remove ${requestName}`)
       .withRequest({
         method: 'DELETE',
         path: MatchersV3.regex(
@@ -214,16 +217,16 @@ describe('Main: Currently testing user management,', function () {
   }
 
   const addUserToSubAdminGroupInteraction = async function (provider, requestName, username, group, responseOcsMeta) {
-    if (username !== config.adminUsername && username !== config.nonExistentUser) {
+    if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
-        .given('the user is recreated', { username: username, password: config.testUserPassword })
+        .given('the user is recreated', { username: username, password: Alice.password })
     }
     if (group !== config.nonExistentGroup) {
       await provider
         .given('group exists', { groupName: group })
     }
     return provider
-      .uponReceiving(`as '${config.adminUsername}', a POST request to make ${requestName}`)
+      .uponReceiving(`as '${adminUsername}', a POST request to make ${requestName}`)
       .withRequest({
         method: 'POST',
         path: MatchersV3.regex(
@@ -247,14 +250,14 @@ describe('Main: Currently testing user management,', function () {
   }
 
   const getUsersSubAdminGroupsInteraction = async function (provider, requestName, username, responseBody) {
-    if (username !== config.adminUsername && username !== config.nonExistentUser) {
+    if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
-        .given('the user is recreated', { username: username, password: config.testUserPassword })
+        .given('the user is recreated', { username: username, password: Alice.password })
         .given('group exists', { groupName: config.testGroup })
         .given('user is made group subadmin', { username: username, groupName: config.testGroup })
     }
     return provider
-      .uponReceiving(`as '${config.adminUsername}', a GET request to get subadmin groups of ${requestName}`)
+      .uponReceiving(`as '${adminUsername}', a GET request to get subadmin groups of ${requestName}`)
       .withRequest({
         method: 'GET',
         path: MatchersV3.regex(
@@ -286,7 +289,7 @@ describe('Main: Currently testing user management,', function () {
     )
   }
 
-  describe('added testUser to testGroup,', function () {
+  describe('add user to group,', function () {
     it('checking method : getUserGroups with an existent user', async function () {
       const provider = createProvider(false, true)
       await getCapabilitiesInteraction(provider)
@@ -294,7 +297,7 @@ describe('Main: Currently testing user management,', function () {
       await getGroupOfUserInteraction(
         provider,
         'existent user',
-        config.testUser,
+        Alice.username,
         new XmlBuilder('1.0', '', 'ocs')
           .build(ocs => {
             ocs.appendElement('meta', '', (meta) => {
@@ -313,7 +316,7 @@ describe('Main: Currently testing user management,', function () {
       return provider.executeTest(async () => {
         const oc = createOwncloud()
         await oc.login()
-        return oc.users.getUserGroups(config.testUser).then(data => {
+        return oc.users.getUserGroups(Alice.username).then(data => {
           expect(typeof (data)).toEqual('object')
           expect(data.indexOf(config.testGroup)).toBeGreaterThan(-1)
         }).catch(error => {
@@ -330,7 +333,7 @@ describe('Main: Currently testing user management,', function () {
       await getGroupOfUserInteraction(
         provider,
         'existent user',
-        config.testUser,
+        Alice.username,
         new XmlBuilder('1.0', '', 'ocs')
           .build(ocs => {
             ocs.appendElement('meta', '', (meta) => {
@@ -346,7 +349,7 @@ describe('Main: Currently testing user management,', function () {
       return provider.executeTest(async () => {
         const oc = createOwncloud()
         await oc.login()
-        return oc.users.userIsInGroup(config.testUser, config.testGroup).then(status => {
+        return oc.users.userIsInGroup(Alice.username, config.testGroup).then(status => {
           expect(status).toBe(true)
         }).catch(error => {
           expect(error).toBe(null)
@@ -357,7 +360,7 @@ describe('Main: Currently testing user management,', function () {
 
   // [oCIS] subadmin endpoint not implemented
   // https://github.com/owncloud/product/issues/289
-  describe('made testUser as testGroup subAdmin', function () {
+  describe('made user as group subAdmin', function () {
     it('checking method : getUserSubadminGroups with an existent user', async function () {
       const provider = createProvider(false, true)
       await getCapabilitiesInteraction(provider)
@@ -366,7 +369,7 @@ describe('Main: Currently testing user management,', function () {
       await getUsersSubAdminGroupsInteraction(
         provider,
         'an existent user',
-        config.testUser,
+        Alice.username,
         new XmlBuilder('1.0', '', 'ocs')
           .build(ocs => {
             ocs.appendElement('meta', '', (meta) => {
@@ -380,7 +383,7 @@ describe('Main: Currently testing user management,', function () {
       return provider.executeTest(async () => {
         const oc = createOwncloud()
         await oc.login()
-        return oc.users.getUserSubadminGroups(config.testUser).then(data => {
+        return oc.users.getUserSubadminGroups(Alice.username).then(data => {
           expect(typeof (data)).toEqual('object')
           expect(data.indexOf(config.testGroup)).toBeGreaterThan(-1)
         }).catch(error => {
@@ -397,7 +400,7 @@ describe('Main: Currently testing user management,', function () {
     await getUserInformationInteraction(
       provider,
       'get user information of an existing user',
-      config.adminUsername,
+      adminUsername,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
           ocs.appendElement('meta', '', (meta) => {
@@ -415,15 +418,15 @@ describe('Main: Currently testing user management,', function () {
               .appendElement(
                 'email', '',
                 MatchersV3.regex(
-                  `(${config.adminUsername}@example.org)?`,
-                  `${config.adminUsername}@example.org`
+                  `(${adminUsername}@example.org)?`,
+                  `${adminUsername}@example.org`
                 )
               )
               .appendElement(
                 'displayname', '',
                 MatchersV3.regex(
-                  `(${config.adminUsername}|${adminDisplayName})`,
-                  config.adminUsername
+                  `(${adminUsername}|${adminDisplayName})`,
+                  adminUsername
                 )
               )
           })
@@ -433,9 +436,9 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.getUser(config.adminUsername).then(data => {
+      return oc.users.getUser(adminUsername).then(data => {
         expect(typeof (data)).toEqual('object')
-        expect(data.displayname).toEqual(config.adminUsername)
+        expect(data.displayname).toEqual(adminUsername)
       }).catch(error => {
         expect(error).toBe(null)
       })
@@ -470,9 +473,9 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.createUser(config.testUser, config.testUserPassword).then(data => {
+      return oc.users.createUser(Alice.username, Alice.password).then(data => {
         expect(data).toEqual(true)
-        return oc.users.deleteUser(config.testUser)
+        return oc.users.deleteUser(Alice.username)
       }).then(status => {
         expect(status).toBe(true)
       }).catch(error => {
@@ -485,7 +488,7 @@ describe('Main: Currently testing user management,', function () {
   // [oCIS] email is needed for oCIS to create users
   it('checking method : createUser with groups', async function () {
     const provider = createProvider(false, true)
-    await provider.given('user doesn\'t exist', { username: config.testUser })
+    await provider.given('user doesn\'t exist', { username: Alice.username })
 
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)
@@ -494,7 +497,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.createUser(config.testUser, config.testUserPassword, [config.testGroup]).then((data) => {
+      return oc.users.createUser(Alice.username, Alice.password, [config.testGroup]).then((data) => {
         expect(data).toEqual(true)
       }).catch((error) => {
         expect(error).toBe(null)
@@ -514,9 +517,9 @@ describe('Main: Currently testing user management,', function () {
         // TODO: adjust the following after the issue is resolved
         // https://github.com/pact-foundation/pact-js/issues/619
         data.appendElement('users', '', users => {
-          users.appendElement('element', '', MatchersV3.string(config.adminUsername))
+          users.appendElement('element', '', MatchersV3.string(adminUsername))
             .eachLike('element', '', user => {
-              user.appendText(MatchersV3.string(config.testUser))
+              user.appendText(MatchersV3.string(Alice.username))
             })
         })
       }
@@ -527,8 +530,8 @@ describe('Main: Currently testing user management,', function () {
       await oc.login()
       return oc.users.searchUsers('').then(data => {
         expect(typeof (data)).toEqual('object')
-        expect(data.indexOf(config.adminUsername)).toBeGreaterThan(-1)
-        expect(data.indexOf(config.testUser)).toBeGreaterThan(-1)
+        expect(data.indexOf(adminUsername)).toBeGreaterThan(-1)
+        expect(data.indexOf(Alice.username)).toBeGreaterThan(-1)
       }).catch(error => {
         expect(error).toBe(null)
       })
@@ -566,10 +569,10 @@ describe('Main: Currently testing user management,', function () {
     await getUsersInteraction(
       provider,
       'check user existence with existing user',
-      { search: config.adminUsername },
+      { search: adminUsername },
       data => {
         data.appendElement('users', '', users => {
-          users.appendElement('element', '', MatchersV3.equal(config.adminUsername))
+          users.appendElement('element', '', MatchersV3.equal(adminUsername))
         })
       }
     )
@@ -577,7 +580,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.userExists(config.adminUsername).then(status => {
+      return oc.users.userExists(adminUsername).then(status => {
         expect(status).toBe(true)
       }).catch(error => {
         expect(error).toBe(null)
@@ -615,15 +618,15 @@ describe('Main: Currently testing user management,', function () {
     await provider
       .given(
         'the user is recreated',
-        { username: config.testUser, password: config.testUserPassword }
+        { username: Alice.username, password: Alice.password }
       )
-      .uponReceiving(`as '${config.adminUsername}' a PUT request to enable an existing user`)
+      .uponReceiving(`as '${adminUsername}' a PUT request to enable an existing user`)
       .withRequest({
         headers: validAdminAuthHeaders,
         method: 'PUT',
         path: MatchersV3.regex(
-          '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + config.testUser + '\\/enable',
-          '/ocs/v1.php/cloud/users/' + config.testUser + '/enable'
+          '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + Alice.username + '\\/enable',
+          '/ocs/v1.php/cloud/users/' + Alice.username + '/enable'
         )
       }).willRespondWith({
         status: 200,
@@ -639,7 +642,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.enableUser(config.testUser).then((status) => {
+      return oc.users.enableUser(Alice.username).then((status) => {
         expect(status).toBe(true)
       }).catch(error => {
         expect(error).toBe(null)
@@ -654,15 +657,15 @@ describe('Main: Currently testing user management,', function () {
     await provider
       .given(
         'the user is recreated',
-        { username: config.testUser, password: config.testUserPassword }
+        { username: Alice.username, password: Alice.password }
       )
-      .uponReceiving(`as '${config.adminUsername}' a PUT request to disable an existing user`)
+      .uponReceiving(`as '${adminUsername}' a PUT request to disable an existing user`)
       .withRequest({
         headers: validAdminAuthHeaders,
         method: 'PUT',
         path: MatchersV3.regex(
-          '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + config.testUser + '\\/disable',
-          '/ocs/v1.php/cloud/users/' + config.testUser + '/disable'
+          '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + Alice.username + '\\/disable',
+          '/ocs/v1.php/cloud/users/' + Alice.username + '/disable'
         )
       }).willRespondWith({
         status: 200,
@@ -678,7 +681,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.disableUser(config.testUser).then((status) => {
+      return oc.users.disableUser(Alice.username).then((status) => {
         expect(status).toBe(true)
       }).catch(error => {
         expect(error).toBe(null)
@@ -690,7 +693,7 @@ describe('Main: Currently testing user management,', function () {
     const provider = createProvider(false, true)
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)
-    await provider.uponReceiving(`as '${config.adminUsername}' a PUT request to enable a non-existing user`)
+    await provider.uponReceiving(`as '${adminUsername}' a PUT request to enable a non-existing user`)
       .withRequest({
         headers: validAdminAuthHeaders,
         method: 'PUT',
@@ -725,7 +728,7 @@ describe('Main: Currently testing user management,', function () {
     const provider = createProvider(false, true)
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)
-    await provider.uponReceiving(`as '${config.adminUsername}' a PUT request to  disable a non-existing user`)
+    await provider.uponReceiving(`as '${adminUsername}' a PUT request to  disable a non-existing user`)
       .withRequest({
         headers: validAdminAuthHeaders,
         method: 'PUT',
@@ -763,7 +766,7 @@ describe('Main: Currently testing user management,', function () {
     await changeUserAttributeInteraction(
       provider,
       'an existent user, attribute is allowed',
-      config.testUser,
+      Alice.username,
       'key=email&value=asd%40a.com',
       meta => {
         ocsMeta(meta, 'ok', 100, MatchersV3.regex('(OK)?', ''))
@@ -773,7 +776,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.setUserAttribute(config.testUser, 'email', 'asd@a.com').then(data => {
+      return oc.users.setUserAttribute(Alice.username, 'email', 'asd@a.com').then(data => {
         expect(data).toEqual(true)
       }).catch(error => {
         expect(error).toBe(null)
@@ -789,7 +792,7 @@ describe('Main: Currently testing user management,', function () {
     await changeUserAttributeInteraction(
       provider,
       'an existent user, attribute is not allowed',
-      config.testUser,
+      Alice.username,
       'key=email&value=%C3%83%C2%A4%C3%83%C2%B6%C3%83%C2%BC%C3%83%C2%A4%C3%83%C2%A4_sfsdf%2B%24%25%2F)%25%26%3D',
       meta => {
         // [oCIS] Different ocs status-text and status-code in oCIS and oC10
@@ -806,7 +809,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.setUserAttribute(config.testUser, 'email', 'äöüää_sfsdf+$%/)%&=')
+      return oc.users.setUserAttribute(Alice.username, 'email', 'äöüää_sfsdf+$%/)%&=')
         .then(status => {
           expect(status).toBe(null)
         }).catch(error => {
@@ -859,14 +862,14 @@ describe('Main: Currently testing user management,', function () {
     await addUserToGroupInteraction(
       provider,
       'add existent user in a non existent group',
-      config.testUser,
+      Alice.username,
       config.nonExistentGroup
     )
 
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.addUserToGroup(config.testUser, config.nonExistentGroup)
+      return oc.users.addUserToGroup(Alice.username, config.nonExistentGroup)
         .then(status => {
           expect(status).toBe(null)
         }).catch(error => {
@@ -940,7 +943,7 @@ describe('Main: Currently testing user management,', function () {
     await getGroupOfUserInteraction(
       provider,
       'existent user and group that user isn\'t part of',
-      config.testUser,
+      Alice.username,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
           ocs.appendElement('meta', '', (meta) => {
@@ -959,7 +962,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.userIsInGroup(config.testUser, 'admin').then(status => {
+      return oc.users.userIsInGroup(Alice.username, 'admin').then(status => {
         expect(status).toEqual(false)
       }).catch(error => {
         expect(error).toBe(null)
@@ -974,7 +977,7 @@ describe('Main: Currently testing user management,', function () {
     await getGroupOfUserInteraction(
       provider,
       'existent user and nonexistant group',
-      config.testUser,
+      Alice.username,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
           ocs.appendElement('meta', '', (meta) => {
@@ -993,7 +996,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.userIsInGroup(config.testUser, config.nonExistentGroup)
+      return oc.users.userIsInGroup(Alice.username, config.nonExistentGroup)
         .then(status => {
           expect(status).toEqual(false)
         }).catch(error => {
@@ -1042,8 +1045,8 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await getUserInformationInteraction(
       provider,
-      `get user attribute of an existent user '${config.testUser}'`,
-      config.testUser,
+      `get user attribute of an existent user '${Alice.username}'`,
+      Alice.username,
 
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
@@ -1054,16 +1057,16 @@ describe('Main: Currently testing user management,', function () {
               .appendElement('quota', '', quota => {
                 quota.appendElement('definition', '', MatchersV3.equal('default'))
               })
-              .appendElement('displayname', '', MatchersV3.equal('test123'))
+              .appendElement('displayname', '', MatchersV3.equal(Alice.username))
           })
         })
     )
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.getUser(config.testUser).then(data => {
+      return oc.users.getUser(Alice.username).then(data => {
         expect(typeof (data)).toEqual('object')
-        expect(data.displayname).toEqual(config.testUser)
+        expect(data.displayname).toEqual(Alice.username)
       }).catch(error => {
         expect(error).toBe(null)
       })
@@ -1094,13 +1097,13 @@ describe('Main: Currently testing user management,', function () {
     await removeUserFromGroupInteraction(
       provider,
       'existent user from a non-existent group',
-      config.testUser,
+      Alice.username,
       config.nonExistentGroup
     )
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.removeUserFromGroup(config.testUser, config.nonExistentGroup)
+      return oc.users.removeUserFromGroup(Alice.username, config.nonExistentGroup)
         .then(status => {
           expect(status).toBe(null)
         }).catch(error => {
@@ -1143,7 +1146,7 @@ describe('Main: Currently testing user management,', function () {
     await addUserToSubAdminGroupInteraction(
       provider,
       'existent user subadmin of non-existent group',
-      config.testUser,
+      Alice.username,
       config.nonExistentGroup,
       meta => {
         ocsMeta(meta, 'failure', 102, 'Group:' + config.nonExistentGroup + ' does not exist')
@@ -1153,7 +1156,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.addUserToSubadminGroup(config.testUser, config.nonExistentGroup)
+      return oc.users.addUserToSubadminGroup(Alice.username, config.nonExistentGroup)
         .then(status => {
           expect(status).toBe(null)
         }).catch(error => {
@@ -1227,7 +1230,7 @@ describe('Main: Currently testing user management,', function () {
     await getUsersSubAdminGroupsInteraction(
       provider,
       'existent user',
-      config.testUser,
+      Alice.username,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
           ocs.appendElement('meta', '', (meta) => {
@@ -1240,7 +1243,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.userIsInSubadminGroup(config.testUser, config.nonExistentGroup)
+      return oc.users.userIsInSubadminGroup(Alice.username, config.nonExistentGroup)
         .then(status => {
           expect(status).toBe(false)
         }).catch(error => {
@@ -1284,7 +1287,7 @@ describe('Main: Currently testing user management,', function () {
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)
     await provider
-      .uponReceiving(`as '${config.adminUsername}', a request to delete a non-existent user`)
+      .uponReceiving(`as '${adminUsername}', a request to delete a non-existent user`)
       .withRequest({
         method: 'DELETE',
         path: MatchersV3.regex(

--- a/tests/userTest.js
+++ b/tests/userTest.js
@@ -4,7 +4,7 @@ describe('Main: Currently testing user management,', function () {
   var config = require('./config/config.json')
   const {
     admin: { username: adminUsername, displayname: adminDisplayName },
-    Alice
+    testUser1: { username: testUser, password: testUserPassword }
   } = require('./config/users.json')
 
   // PACT setup
@@ -22,7 +22,7 @@ describe('Main: Currently testing user management,', function () {
   const getUserInformationInteraction = async function (provider, requestName, username, responseBody) {
     if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
-        .given('the user is recreated', { username: username, password: Alice.password })
+        .given('the user is recreated', { username: username, password: testUserPassword })
     }
     return provider
       .uponReceiving(`as '${adminUsername}', a GET request to ${requestName}`)
@@ -43,7 +43,7 @@ describe('Main: Currently testing user management,', function () {
 
   const getUsersInteraction = function (provider, requestName, query, bodyData) {
     return provider
-      .given('the user is recreated', { username: Alice.username, password: Alice.password })
+      .given('the user is recreated', { username: testUser, password: testUserPassword })
       .uponReceiving(`as '${adminUsername}', a GET request to ${requestName}`)
       .withRequest({
         method: 'GET',
@@ -69,7 +69,7 @@ describe('Main: Currently testing user management,', function () {
   const changeUserAttributeInteraction = async function (provider, requestName, username, requestBody, response) {
     if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
-        .given('the user is recreated', { username: username, password: Alice.password })
+        .given('the user is recreated', { username: username, password: testUserPassword })
     }
 
     return provider
@@ -105,7 +105,7 @@ describe('Main: Currently testing user management,', function () {
     }
     if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
-        .given('the user is recreated', { username: username, password: Alice.password })
+        .given('the user is recreated', { username: username, password: testUserPassword })
     }
     if (group !== config.nonExistentGroup) {
       await provider
@@ -149,7 +149,7 @@ describe('Main: Currently testing user management,', function () {
   const getGroupOfUserInteraction = async function (provider, requestName, username, responseBody) {
     if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
-        .given('the user is recreated', { username: username, password: Alice.password })
+        .given('the user is recreated', { username: username, password: testUserPassword })
         .given('group exists', { groupName: config.testGroup })
         .given('user is added to group', { username: username, groupName: config.testGroup })
     }
@@ -179,7 +179,7 @@ describe('Main: Currently testing user management,', function () {
     }
     if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
-        .given('the user is recreated', { username: username, password: Alice.password })
+        .given('the user is recreated', { username: username, password: testUserPassword })
     }
     if (group !== config.nonExistentGroup) {
       await provider
@@ -219,7 +219,7 @@ describe('Main: Currently testing user management,', function () {
   const addUserToSubAdminGroupInteraction = async function (provider, requestName, username, group, responseOcsMeta) {
     if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
-        .given('the user is recreated', { username: username, password: Alice.password })
+        .given('the user is recreated', { username: username, password: testUserPassword })
     }
     if (group !== config.nonExistentGroup) {
       await provider
@@ -252,7 +252,7 @@ describe('Main: Currently testing user management,', function () {
   const getUsersSubAdminGroupsInteraction = async function (provider, requestName, username, responseBody) {
     if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
-        .given('the user is recreated', { username: username, password: Alice.password })
+        .given('the user is recreated', { username: username, password: testUserPassword })
         .given('group exists', { groupName: config.testGroup })
         .given('user is made group subadmin', { username: username, groupName: config.testGroup })
     }
@@ -297,7 +297,7 @@ describe('Main: Currently testing user management,', function () {
       await getGroupOfUserInteraction(
         provider,
         'existent user',
-        Alice.username,
+        testUser,
         new XmlBuilder('1.0', '', 'ocs')
           .build(ocs => {
             ocs.appendElement('meta', '', (meta) => {
@@ -316,7 +316,7 @@ describe('Main: Currently testing user management,', function () {
       return provider.executeTest(async () => {
         const oc = createOwncloud()
         await oc.login()
-        return oc.users.getUserGroups(Alice.username).then(data => {
+        return oc.users.getUserGroups(testUser).then(data => {
           expect(typeof (data)).toEqual('object')
           expect(data.indexOf(config.testGroup)).toBeGreaterThan(-1)
         }).catch(error => {
@@ -333,7 +333,7 @@ describe('Main: Currently testing user management,', function () {
       await getGroupOfUserInteraction(
         provider,
         'existent user',
-        Alice.username,
+        testUser,
         new XmlBuilder('1.0', '', 'ocs')
           .build(ocs => {
             ocs.appendElement('meta', '', (meta) => {
@@ -349,7 +349,7 @@ describe('Main: Currently testing user management,', function () {
       return provider.executeTest(async () => {
         const oc = createOwncloud()
         await oc.login()
-        return oc.users.userIsInGroup(Alice.username, config.testGroup).then(status => {
+        return oc.users.userIsInGroup(testUser, config.testGroup).then(status => {
           expect(status).toBe(true)
         }).catch(error => {
           expect(error).toBe(null)
@@ -369,7 +369,7 @@ describe('Main: Currently testing user management,', function () {
       await getUsersSubAdminGroupsInteraction(
         provider,
         'an existent user',
-        Alice.username,
+        testUser,
         new XmlBuilder('1.0', '', 'ocs')
           .build(ocs => {
             ocs.appendElement('meta', '', (meta) => {
@@ -383,7 +383,7 @@ describe('Main: Currently testing user management,', function () {
       return provider.executeTest(async () => {
         const oc = createOwncloud()
         await oc.login()
-        return oc.users.getUserSubadminGroups(Alice.username).then(data => {
+        return oc.users.getUserSubadminGroups(testUser).then(data => {
           expect(typeof (data)).toEqual('object')
           expect(data.indexOf(config.testGroup)).toBeGreaterThan(-1)
         }).catch(error => {
@@ -473,9 +473,9 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.createUser(Alice.username, Alice.password).then(data => {
+      return oc.users.createUser(testUser, testUserPassword).then(data => {
         expect(data).toEqual(true)
-        return oc.users.deleteUser(Alice.username)
+        return oc.users.deleteUser(testUser)
       }).then(status => {
         expect(status).toBe(true)
       }).catch(error => {
@@ -488,7 +488,7 @@ describe('Main: Currently testing user management,', function () {
   // [oCIS] email is needed for oCIS to create users
   it('checking method : createUser with groups', async function () {
     const provider = createProvider(false, true)
-    await provider.given('user doesn\'t exist', { username: Alice.username })
+    await provider.given('user doesn\'t exist', { username: testUser })
 
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)
@@ -497,7 +497,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.createUser(Alice.username, Alice.password, [config.testGroup]).then((data) => {
+      return oc.users.createUser(testUser, testUserPassword, [config.testGroup]).then((data) => {
         expect(data).toEqual(true)
       }).catch((error) => {
         expect(error).toBe(null)
@@ -519,7 +519,7 @@ describe('Main: Currently testing user management,', function () {
         data.appendElement('users', '', users => {
           users.appendElement('element', '', MatchersV3.string(adminUsername))
             .eachLike('element', '', user => {
-              user.appendText(MatchersV3.string(Alice.username))
+              user.appendText(MatchersV3.string(testUser))
             })
         })
       }
@@ -531,7 +531,7 @@ describe('Main: Currently testing user management,', function () {
       return oc.users.searchUsers('').then(data => {
         expect(typeof (data)).toEqual('object')
         expect(data.indexOf(adminUsername)).toBeGreaterThan(-1)
-        expect(data.indexOf(Alice.username)).toBeGreaterThan(-1)
+        expect(data.indexOf(testUser)).toBeGreaterThan(-1)
       }).catch(error => {
         expect(error).toBe(null)
       })
@@ -618,15 +618,15 @@ describe('Main: Currently testing user management,', function () {
     await provider
       .given(
         'the user is recreated',
-        { username: Alice.username, password: Alice.password }
+        { username: testUser, password: testUserPassword }
       )
       .uponReceiving(`as '${adminUsername}' a PUT request to enable an existing user`)
       .withRequest({
         headers: validAdminAuthHeaders,
         method: 'PUT',
         path: MatchersV3.regex(
-          '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + Alice.username + '\\/enable',
-          '/ocs/v1.php/cloud/users/' + Alice.username + '/enable'
+          '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + testUser + '\\/enable',
+          '/ocs/v1.php/cloud/users/' + testUser + '/enable'
         )
       }).willRespondWith({
         status: 200,
@@ -642,7 +642,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.enableUser(Alice.username).then((status) => {
+      return oc.users.enableUser(testUser).then((status) => {
         expect(status).toBe(true)
       }).catch(error => {
         expect(error).toBe(null)
@@ -657,15 +657,15 @@ describe('Main: Currently testing user management,', function () {
     await provider
       .given(
         'the user is recreated',
-        { username: Alice.username, password: Alice.password }
+        { username: testUser, password: testUserPassword }
       )
       .uponReceiving(`as '${adminUsername}' a PUT request to disable an existing user`)
       .withRequest({
         headers: validAdminAuthHeaders,
         method: 'PUT',
         path: MatchersV3.regex(
-          '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + Alice.username + '\\/disable',
-          '/ocs/v1.php/cloud/users/' + Alice.username + '/disable'
+          '.*\\/ocs\\/v1\\.php\\/cloud\\/users\\/' + testUser + '\\/disable',
+          '/ocs/v1.php/cloud/users/' + testUser + '/disable'
         )
       }).willRespondWith({
         status: 200,
@@ -681,7 +681,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.disableUser(Alice.username).then((status) => {
+      return oc.users.disableUser(testUser).then((status) => {
         expect(status).toBe(true)
       }).catch(error => {
         expect(error).toBe(null)
@@ -766,7 +766,7 @@ describe('Main: Currently testing user management,', function () {
     await changeUserAttributeInteraction(
       provider,
       'an existent user, attribute is allowed',
-      Alice.username,
+      testUser,
       'key=email&value=asd%40a.com',
       meta => {
         ocsMeta(meta, 'ok', 100, MatchersV3.regex('(OK)?', ''))
@@ -776,7 +776,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.setUserAttribute(Alice.username, 'email', 'asd@a.com').then(data => {
+      return oc.users.setUserAttribute(testUser, 'email', 'asd@a.com').then(data => {
         expect(data).toEqual(true)
       }).catch(error => {
         expect(error).toBe(null)
@@ -792,7 +792,7 @@ describe('Main: Currently testing user management,', function () {
     await changeUserAttributeInteraction(
       provider,
       'an existent user, attribute is not allowed',
-      Alice.username,
+      testUser,
       'key=email&value=%C3%83%C2%A4%C3%83%C2%B6%C3%83%C2%BC%C3%83%C2%A4%C3%83%C2%A4_sfsdf%2B%24%25%2F)%25%26%3D',
       meta => {
         // [oCIS] Different ocs status-text and status-code in oCIS and oC10
@@ -809,7 +809,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.setUserAttribute(Alice.username, 'email', 'äöüää_sfsdf+$%/)%&=')
+      return oc.users.setUserAttribute(testUser, 'email', 'äöüää_sfsdf+$%/)%&=')
         .then(status => {
           expect(status).toBe(null)
         }).catch(error => {
@@ -862,14 +862,14 @@ describe('Main: Currently testing user management,', function () {
     await addUserToGroupInteraction(
       provider,
       'add existent user in a non existent group',
-      Alice.username,
+      testUser,
       config.nonExistentGroup
     )
 
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.addUserToGroup(Alice.username, config.nonExistentGroup)
+      return oc.users.addUserToGroup(testUser, config.nonExistentGroup)
         .then(status => {
           expect(status).toBe(null)
         }).catch(error => {
@@ -943,7 +943,7 @@ describe('Main: Currently testing user management,', function () {
     await getGroupOfUserInteraction(
       provider,
       'existent user and group that user isn\'t part of',
-      Alice.username,
+      testUser,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
           ocs.appendElement('meta', '', (meta) => {
@@ -962,7 +962,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.userIsInGroup(Alice.username, 'admin').then(status => {
+      return oc.users.userIsInGroup(testUser, 'admin').then(status => {
         expect(status).toEqual(false)
       }).catch(error => {
         expect(error).toBe(null)
@@ -977,7 +977,7 @@ describe('Main: Currently testing user management,', function () {
     await getGroupOfUserInteraction(
       provider,
       'existent user and nonexistant group',
-      Alice.username,
+      testUser,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
           ocs.appendElement('meta', '', (meta) => {
@@ -996,7 +996,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.userIsInGroup(Alice.username, config.nonExistentGroup)
+      return oc.users.userIsInGroup(testUser, config.nonExistentGroup)
         .then(status => {
           expect(status).toEqual(false)
         }).catch(error => {
@@ -1045,8 +1045,8 @@ describe('Main: Currently testing user management,', function () {
     await getCurrentUserInformationInteraction(provider)
     await getUserInformationInteraction(
       provider,
-      `get user attribute of an existent user '${Alice.username}'`,
-      Alice.username,
+      `get user attribute of an existent user '${testUser}'`,
+      testUser,
 
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
@@ -1057,16 +1057,16 @@ describe('Main: Currently testing user management,', function () {
               .appendElement('quota', '', quota => {
                 quota.appendElement('definition', '', MatchersV3.equal('default'))
               })
-              .appendElement('displayname', '', MatchersV3.equal(Alice.username))
+              .appendElement('displayname', '', MatchersV3.equal(testUser))
           })
         })
     )
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.getUser(Alice.username).then(data => {
+      return oc.users.getUser(testUser).then(data => {
         expect(typeof (data)).toEqual('object')
-        expect(data.displayname).toEqual(Alice.username)
+        expect(data.displayname).toEqual(testUser)
       }).catch(error => {
         expect(error).toBe(null)
       })
@@ -1097,13 +1097,13 @@ describe('Main: Currently testing user management,', function () {
     await removeUserFromGroupInteraction(
       provider,
       'existent user from a non-existent group',
-      Alice.username,
+      testUser,
       config.nonExistentGroup
     )
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.removeUserFromGroup(Alice.username, config.nonExistentGroup)
+      return oc.users.removeUserFromGroup(testUser, config.nonExistentGroup)
         .then(status => {
           expect(status).toBe(null)
         }).catch(error => {
@@ -1146,7 +1146,7 @@ describe('Main: Currently testing user management,', function () {
     await addUserToSubAdminGroupInteraction(
       provider,
       'existent user subadmin of non-existent group',
-      Alice.username,
+      testUser,
       config.nonExistentGroup,
       meta => {
         ocsMeta(meta, 'failure', 102, 'Group:' + config.nonExistentGroup + ' does not exist')
@@ -1156,7 +1156,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.addUserToSubadminGroup(Alice.username, config.nonExistentGroup)
+      return oc.users.addUserToSubadminGroup(testUser, config.nonExistentGroup)
         .then(status => {
           expect(status).toBe(null)
         }).catch(error => {
@@ -1230,7 +1230,7 @@ describe('Main: Currently testing user management,', function () {
     await getUsersSubAdminGroupsInteraction(
       provider,
       'existent user',
-      Alice.username,
+      testUser,
       new XmlBuilder('1.0', '', 'ocs')
         .build(ocs => {
           ocs.appendElement('meta', '', (meta) => {
@@ -1243,7 +1243,7 @@ describe('Main: Currently testing user management,', function () {
     return provider.executeTest(async () => {
       const oc = createOwncloud()
       await oc.login()
-      return oc.users.userIsInSubadminGroup(Alice.username, config.nonExistentGroup)
+      return oc.users.userIsInSubadminGroup(testUser, config.nonExistentGroup)
         .then(status => {
           expect(status).toBe(false)
         }).catch(error => {


### PR DESCRIPTION
The main goal of this PR is to use the single structured config file for users so that the user config can be used both for tests and helper files.

This PR seems large but all the files have very similar changes.
Users are imported from new user config file.

### Related issues
part of https://github.com/owncloud/owncloud-sdk/issues/1086