### PR TITLE
Using httphelper in sharing and webdav helpers

### DIFF
--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -304,7 +304,7 @@ describe('Main: Currently testing file versions management,', function () {
           headers: {
             authorization: getAuthHeaders(testUser, testUserPassword),
             Destination: MatchersV3.fromProviderState(
-              `\${providerBaseURL}${destinationWebDavPath}`,
+              `\${providerBaseURL}/remote.php/dav/${destinationWebDavPath}`,
               `${mockServerBaseUrl}${destinationWebDavPath}`
             )
           }

--- a/tests/helpers/httpHelper.js
+++ b/tests/helpers/httpHelper.js
@@ -59,6 +59,8 @@ module.exports = {
   // dav request methods
   get: (url, body, header, userId) =>
     requestEndpoint(url, { body, method: 'GET' }, userId, header),
+  post: (url, body, header, userId) =>
+    requestEndpoint(url, { body, method: 'POST' }, userId, header),
   put: (url, body, header, userId) =>
     requestEndpoint(url, { body, method: 'PUT' }, userId, header),
   delete: (url, body, header, userId) =>
@@ -69,6 +71,8 @@ module.exports = {
     requestEndpoint(url, { body, method: 'MKCOL' }, userId, header),
   propfind: (url, body, header, userId) =>
     requestEndpoint(url, { body, method: 'PROPFIND' }, userId, header),
+  proppatch: (url, body, header, userId) =>
+    requestEndpoint(url, { body, method: 'PROPPATCH' }, userId, header),
   // graph Api requests
   postGraph: (url, body, header, userId) =>
     requestGraphEndpoint(url, { body, method: 'POST' }, userId, header),

--- a/tests/helpers/httpHelper.js
+++ b/tests/helpers/httpHelper.js
@@ -11,7 +11,11 @@ const createAuthHeader = function (userId) {
 }
 
 const requestEndpoint = function (path, params, userId = 'admin', header = {}) {
-  const headers = { ...createAuthHeader(userId), ...header }
+  let headers = { ...createAuthHeader(userId), ...header }
+  // do not add default auth header for public-files paths
+  if (path.includes('public-files')) {
+    headers = { ...header }
+  }
   const options = { ...params, headers }
   const url = join(getProviderBaseUrl(), 'remote.php/dav', path)
   return fetch(url, options)

--- a/tests/helpers/pactHelper.js
+++ b/tests/helpers/pactHelper.js
@@ -97,6 +97,13 @@ const getAuthHeaders = (username, password) => {
   return 'Basic ' + buff.toString('base64')
 }
 
+const getPublicLinkAuthHeader = (password) => {
+  if (!password) {
+    return {}
+  }
+  return { Authorization: 'Basic ' + Buffer.from('public:' + password, 'binary').toString('base64') }
+}
+
 const invalidAuthHeader = 'Basic YWRtaW46bm90QVZhbGlkUGFzc3dvcmQ='
 
 const unauthorizedXmlResponseBody = new XmlBuilder('1.0', '', 'ocs').build(ocs => {
@@ -551,6 +558,7 @@ const getMockServerBaseUrl = function () {
 
 module.exports = {
   getAuthHeaders,
+  getPublicLinkAuthHeader,
   getContentsOfFileInteraction,
   deleteResourceInteraction,
   ocsMeta,

--- a/tests/helpers/sharingHelper.js
+++ b/tests/helpers/sharingHelper.js
@@ -1,7 +1,8 @@
 const httpHelper = require('./httpHelper')
 const {
   applicationFormUrlEncoded,
-  encodeURIPath
+  encodeURIPath,
+  getPublicLinkAuthHeader
 } = require('./pactHelper.js')
 const config = require('../config/config.json')
 
@@ -74,10 +75,11 @@ const validateParams = function (data) {
  *
  * @param {string} token
  * @param {string} folderName
+ * @param {string} password
  * @returns {*} result of the fetch request
  */
-const createFolderInLastPublicShare = function (token, folderName) {
-  return httpHelper.mkcol(`${publicFilesEndPoint}/${token}/${folderName}`)
+const createFolderInLastPublicShare = function (token, folderName, password) {
+  return httpHelper.mkcol(`${publicFilesEndPoint}/${token}/${folderName}`, null, getPublicLinkAuthHeader(password))
 }
 
 /**
@@ -85,10 +87,12 @@ const createFolderInLastPublicShare = function (token, folderName) {
  *
  * @param {string} token
  * @param {string} fileName
+ * @param {string} password
+ * @param {string} content
  * @returns {*} result of the fetch request
  */
-const createFileInLastPublicShare = function (token, fileName, content = 'a file') {
-  return httpHelper.put(`${publicFilesEndPoint}/${token}/${fileName}`, content)
+const createFileInLastPublicShare = function (token, fileName, password, content = 'a file') {
+  return httpHelper.put(`${publicFilesEndPoint}/${token}/${fileName}`, content, getPublicLinkAuthHeader(password))
 }
 
 /**

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -259,8 +259,8 @@ describe('provider testing', () => {
     },
     'folder exists in last shared public share': (setup, parameters) => {
       if (setup) {
-        const { folderName } = parameters
-        const response = createFolderInLastPublicShare(lastSharedToken, folderName)
+        const { folderName, password } = parameters
+        const response = createFolderInLastPublicShare(lastSharedToken, folderName, password)
 
         const { status } = response
         // 405 means that the folder already exists
@@ -274,9 +274,10 @@ describe('provider testing', () => {
       if (setup) {
         const {
           fileName,
+          password,
           content
         } = parameters
-        const response = createFileInLastPublicShare(lastSharedToken, fileName, content)
+        const response = createFileInLastPublicShare(lastSharedToken, fileName, password, content)
 
         const { status } = response
         if (status !== 201 && status !== 204) {


### PR DESCRIPTION
We have a `httpHelper` file. In this PR, I have refactored `sharingHelper` and `webdavHelper` files to use httpHelper for requests.

### Related issues
part of #1086