### PR TITLE
Replace provider states with helper functions (p1)

### DIFF
--- a/tests/fileTrashTest.js
+++ b/tests/fileTrashTest.js
@@ -24,6 +24,8 @@ describe('oc.fileTrash', function () {
     webdavExceptionResponseBody
   } = require('./helpers/pactHelper.js')
 
+  const { givenFolderExists } = require('./helpers/providerStateHelper')
+
   const mockServerBaseUrl = getMockServerBaseUrl()
 
   const deletedFolderId = '2147596415'
@@ -538,17 +540,14 @@ describe('oc.fileTrash', function () {
           ))
       }
 
-      const PropfindToARestoredFolderInNewLocation = provider => {
-        return provider
+      const PropfindToARestoredFolderInNewLocation = async (provider) => {
+        await provider
           .given('the user is recreated', {
             username: testUser,
             password: testUserPassword
           })
-          .given('folder exists', {
-            folderName: originalLocation,
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenFolderExists(provider, testUser, testUserPassword, originalLocation)
+        return provider
           .uponReceiving(`as '${testUser}', a PROPFIND request to a restored folder in new location`)
           .withRequest({
             method: 'PROPFIND',
@@ -616,17 +615,14 @@ describe('oc.fileTrash', function () {
 
   describe('when a file is deleted', function () {
     describe('and file is not restored', function () {
-      const propfindTrashItemsBeforeDeletingFile = provider => {
-        return provider
+      const propfindTrashItemsBeforeDeletingFile = async (provider) => {
+        await provider
           .given('the user is recreated', {
             username: testUser,
             password: testUserPassword
           })
-          .given('folder exists', {
-            folderName: testFolder,
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenFolderExists(provider, testUser, testUserPassword, testFolder)
+        return provider
           .given('file exists', {
             fileName: path.join(testFolder, testFile),
             username: testUser,

--- a/tests/fileTrashTest.js
+++ b/tests/fileTrashTest.js
@@ -24,7 +24,10 @@ describe('oc.fileTrash', function () {
     webdavExceptionResponseBody
   } = require('./helpers/pactHelper.js')
 
-  const { givenFolderExists } = require('./helpers/providerStateHelper')
+  const {
+    givenFolderExists,
+    givenFileExists
+  } = require('./helpers/providerStateHelper')
 
   const mockServerBaseUrl = getMockServerBaseUrl()
 
@@ -202,17 +205,14 @@ describe('oc.fileTrash', function () {
 
   describe('when a folder is deleted', function () {
     describe('and folder is not restored', function () {
-      const propfindForTrashbinWithItems = provider => {
-        return provider
+      const propfindForTrashbinWithItems = async (provider) => {
+        await provider
           .given('the user is recreated', {
             username: testUser,
             password: testUserPassword
           })
-          .given('file exists', {
-            fileName: path.join(testFolder, testFile),
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        return provider
           .given('resource is deleted', {
             resourcePath: testFolder,
             username: testUser,
@@ -233,17 +233,14 @@ describe('oc.fileTrash', function () {
             trashbinXmlResponseBody(false, deletedFolderId)
           ))
       }
-      const listItemWithinADeletedFolder = provider => {
-        return provider
+      const listItemWithinADeletedFolder = async (provider) => {
+        await provider
           .given('the user is recreated', {
             username: testUser,
             password: testUserPassword
           })
-          .given('file exists', {
-            fileName: path.join(testFolder, testFile),
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        return provider
           .given('resource is deleted', {
             resourcePath: testFolder,
             username: testUser,
@@ -357,17 +354,14 @@ describe('oc.fileTrash', function () {
 
     describe('and when this deleted folder is restored to its original location', function () {
       const originalLocation = testFolder
-      const moveFolderFromTrashbinToFilesList = provider => {
-        return provider
+      const moveFolderFromTrashbinToFilesList = async (provider) => {
+        await provider
           .given('the user is recreated', {
             username: testUser,
             password: testUserPassword
           })
-          .given('file exists', {
-            fileName: path.join(testFolder, testFile),
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        return provider
           .given('resource is deleted', {
             resourcePath: path.join(testFolder, testFile),
             username: testUser,
@@ -406,17 +400,14 @@ describe('oc.fileTrash', function () {
           ))
       }
 
-      const propfindToARestoredFolderInOriginalLocation = provider => {
-        return provider
+      const propfindToARestoredFolderInOriginalLocation = async (provider) => {
+        await provider
           .given('the user is recreated', {
             username: testUser,
             password: testUserPassword
           })
-          .given('file exists', {
-            fileName: path.join(testFolder, testFile),
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        return provider
           .uponReceiving(`as '${testUser}', a PROPFIND request to a restored folder in original location`)
           .withRequest({
             method: 'PROPFIND',
@@ -486,17 +477,14 @@ describe('oc.fileTrash', function () {
       const originalLocation = testFolder + ' (restored to a different location)'
       const urlEncodedFolder = encodeURIComponent(originalLocation)
 
-      const MoveFromTrashbinToDifferentLocation = provider => {
-        return provider
+      const MoveFromTrashbinToDifferentLocation = async (provider) => {
+        await provider
           .given('the user is recreated', {
             username: testUser,
             password: testUserPassword
           })
-          .given('file exists', {
-            fileName: path.join(testFolder, testFile),
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        return provider
           .given('resource is deleted', {
             resourcePath: path.join(testFolder, testFile),
             username: testUser,
@@ -622,12 +610,8 @@ describe('oc.fileTrash', function () {
             password: testUserPassword
           })
         await givenFolderExists(provider, testUser, testUserPassword, testFolder)
+        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
         return provider
-          .given('file exists', {
-            fileName: path.join(testFolder, testFile),
-            username: testUser,
-            password: testUserPassword
-          })
           .given('resource is deleted', {
             resourcePath: path.join(testFolder, testFile),
             username: testUser,
@@ -713,17 +697,14 @@ describe('oc.fileTrash', function () {
 
     describe('and when this deleted file is restored to its original location', function () {
       const originalLocation = testFile
-      const MoveFromTrashbinToDifferentLocation = provider => {
-        return provider
+      const MoveFromTrashbinToDifferentLocation = async (provider) => {
+        await provider
           .given('the user is recreated', {
             username: testUser,
             password: testUserPassword
           })
-          .given('file exists', {
-            fileName: path.join(testFolder, testFile),
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        return provider
           .given('resource is deleted', {
             resourcePath: path.join(testFolder, testFile),
             username: testUser,
@@ -759,17 +740,14 @@ describe('oc.fileTrash', function () {
           .willRespondWith(responseMethod(207, responseHeader('application/xml; charset=utf-8'), trashbinXmlResponseBody()))
       }
 
-      const propfindToARestoredFileInOriginalLocation = provider => {
-        return provider
+      const propfindToARestoredFileInOriginalLocation = async (provider) => {
+        await provider
           .given('the user is recreated', {
             username: testUser,
             password: testUserPassword
           })
-          .given('file exists', {
-            fileName: path.join(testFolder, testFile),
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        return provider
           .uponReceiving(`as '${testUser}', a PROPFIND request to a restored file in original location`)
           .withRequest({
             method: 'PROPFIND',
@@ -839,17 +817,14 @@ describe('oc.fileTrash', function () {
       const originalLocation = 'file (restored to a different location).txt'
       const urlEncodedFile = encodeURIComponent(originalLocation)
 
-      const MoveFromTrashbinToDifferentLocation = provider => {
-        return provider
+      const MoveFromTrashbinToDifferentLocation = async (provider) => {
+        await provider
           .given('the user is recreated', {
             username: testUser,
             password: testUserPassword
           })
-          .given('file exists', {
-            fileName: path.join(testFolder, testFile),
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        return provider
           .given('resource is deleted', {
             resourcePath: path.join(testFolder, testFile),
             username: testUser,
@@ -872,17 +847,14 @@ describe('oc.fileTrash', function () {
             headers: htmlResponseHeaders
           })
       }
-      const propfindToARestoredFileInNewLocationEmpty = provider => {
-        return provider
+      const propfindToARestoredFileInNewLocationEmpty = async (provider) => {
+        await provider
           .given('the user is recreated', {
             username: testUser,
             password: testUserPassword
           })
-          .given('file exists', {
-            fileName: '/file (restored to a different location).txt',
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenFileExists(provider, testUser, testUserPassword, '/file (restored to a different location).txt')
+        return provider
           .uponReceiving(`as '${testUser}', a PROPFIND request to trash items after restoring deleting file to new location`)
           .withRequest({
             method: 'PROPFIND',
@@ -897,17 +869,14 @@ describe('oc.fileTrash', function () {
           })
       }
 
-      const propfindToARestoredFileInNewLocation = provider => {
-        return provider
+      const propfindToARestoredFileInNewLocation = async (provider) => {
+        await provider
           .given('the user is recreated', {
             username: testUser,
             password: testUserPassword
           })
-          .given('file exists', {
-            fileName: '/file (restored to a different location).txt',
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenFileExists(provider, testUser, testUserPassword, '/file (restored to a different location).txt')
+        return provider
           .uponReceiving(`as '${testUser}', a PROPFIND request to a restored file in new location`)
           .withRequest({
             method: 'PROPFIND',
@@ -971,17 +940,14 @@ describe('oc.fileTrash', function () {
     // https://github.com/owncloud/ocis/issues/1122
     // Deleted file cannot be restored to different location
     describe('Trashbin errors should be handled correctly', function () {
-      const MoveFromTrashbinToNonExistingLocation = provider => {
-        return provider
+      const MoveFromTrashbinToNonExistingLocation = async (provider) => {
+        await provider
           .given('the user is recreated', {
             username: testUser,
             password: testUserPassword
           })
-          .given('file exists', {
-            fileName: path.join(testFolder, testFile),
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        return provider
           .given('resource is deleted', {
             resourcePath: path.join(testFolder, testFile),
             username: testUser,

--- a/tests/fileTrashTest.js
+++ b/tests/fileTrashTest.js
@@ -211,7 +211,7 @@ describe('oc.fileTrash', function () {
             username: testUser,
             password: testUserPassword
           })
-        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         return provider
           .given('resource is deleted', {
             resourcePath: testFolder,
@@ -239,7 +239,7 @@ describe('oc.fileTrash', function () {
             username: testUser,
             password: testUserPassword
           })
-        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         return provider
           .given('resource is deleted', {
             resourcePath: testFolder,
@@ -360,7 +360,7 @@ describe('oc.fileTrash', function () {
             username: testUser,
             password: testUserPassword
           })
-        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         return provider
           .given('resource is deleted', {
             resourcePath: path.join(testFolder, testFile),
@@ -406,7 +406,7 @@ describe('oc.fileTrash', function () {
             username: testUser,
             password: testUserPassword
           })
-        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         return provider
           .uponReceiving(`as '${testUser}', a PROPFIND request to a restored folder in original location`)
           .withRequest({
@@ -483,7 +483,7 @@ describe('oc.fileTrash', function () {
             username: testUser,
             password: testUserPassword
           })
-        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         return provider
           .given('resource is deleted', {
             resourcePath: path.join(testFolder, testFile),
@@ -534,7 +534,7 @@ describe('oc.fileTrash', function () {
             username: testUser,
             password: testUserPassword
           })
-        await givenFolderExists(provider, testUser, testUserPassword, originalLocation)
+        await givenFolderExists(provider, testUser, originalLocation)
         return provider
           .uponReceiving(`as '${testUser}', a PROPFIND request to a restored folder in new location`)
           .withRequest({
@@ -609,8 +609,8 @@ describe('oc.fileTrash', function () {
             username: testUser,
             password: testUserPassword
           })
-        await givenFolderExists(provider, testUser, testUserPassword, testFolder)
-        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        await givenFolderExists(provider, testUser, testFolder)
+        await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         return provider
           .given('resource is deleted', {
             resourcePath: path.join(testFolder, testFile),
@@ -703,7 +703,7 @@ describe('oc.fileTrash', function () {
             username: testUser,
             password: testUserPassword
           })
-        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         return provider
           .given('resource is deleted', {
             resourcePath: path.join(testFolder, testFile),
@@ -746,7 +746,7 @@ describe('oc.fileTrash', function () {
             username: testUser,
             password: testUserPassword
           })
-        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         return provider
           .uponReceiving(`as '${testUser}', a PROPFIND request to a restored file in original location`)
           .withRequest({
@@ -823,7 +823,7 @@ describe('oc.fileTrash', function () {
             username: testUser,
             password: testUserPassword
           })
-        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         return provider
           .given('resource is deleted', {
             resourcePath: path.join(testFolder, testFile),
@@ -853,7 +853,7 @@ describe('oc.fileTrash', function () {
             username: testUser,
             password: testUserPassword
           })
-        await givenFileExists(provider, testUser, testUserPassword, '/file (restored to a different location).txt')
+        await givenFileExists(provider, testUser, '/file (restored to a different location).txt')
         return provider
           .uponReceiving(`as '${testUser}', a PROPFIND request to trash items after restoring deleting file to new location`)
           .withRequest({
@@ -875,7 +875,7 @@ describe('oc.fileTrash', function () {
             username: testUser,
             password: testUserPassword
           })
-        await givenFileExists(provider, testUser, testUserPassword, '/file (restored to a different location).txt')
+        await givenFileExists(provider, testUser, '/file (restored to a different location).txt')
         return provider
           .uponReceiving(`as '${testUser}', a PROPFIND request to a restored file in new location`)
           .withRequest({
@@ -946,7 +946,7 @@ describe('oc.fileTrash', function () {
             username: testUser,
             password: testUserPassword
           })
-        await givenFileExists(provider, testUser, testUserPassword, path.join(testFolder, testFile))
+        await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         return provider
           .given('resource is deleted', {
             resourcePath: path.join(testFolder, testFile),

--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -122,14 +122,13 @@ describe('Main: Currently testing file versions management,', function () {
         username: testUser,
         password: testUserPassword
       })
-      await givenFileExists(provider, testUser, testUserPassword, versionedFile)
+      await givenFileExists(provider, testUser, versionedFile)
       await provider
         .given('the client waits', { delay: 2000 })
       // re-upload the same file to create a new version
       await givenFileExists(
         provider,
         testUser,
-        testUserPassword,
         versionedFile,
         fileInfo.versions[0].content
       )
@@ -137,7 +136,6 @@ describe('Main: Currently testing file versions management,', function () {
       await givenFileExists(
         provider,
         testUser,
-        testUserPassword,
         versionedFile,
         fileInfo.versions[1].content
       )
@@ -149,77 +147,43 @@ describe('Main: Currently testing file versions management,', function () {
           password: testUserPassword,
           number: 1
         })
-        .uponReceiving(
-          `as '${testUser}', a PROPFIND request to get file versions of existent file`
-        )
+        .uponReceiving(`as '${testUser}', a PROPFIND request to get file versions of existent file`)
         .withRequest({
           method: 'PROPFIND',
           path: MatchersV3.fromProviderState(
-            '/remote.php/dav/meta/${fileId}/v' /* eslint-disable-line no-template-curly-in-string */,
+            '/remote.php/dav/meta/${fileId}/v', /* eslint-disable-line no-template-curly-in-string */
             `/remote.php/dav/meta/${fileInfo.id}/v`
           ),
-          headers: {
-            authorization: getAuthHeaders(testUser, testUserPassword),
-            ...applicationXmlResponseHeaders
-          },
-          body: new XmlBuilder('1.0', '', 'd:propfind').build((dPropfind) => {
-            dPropfind.setAttributes({
-              'xmlns:d': 'DAV:',
-              'xmlns:oc': 'http://owncloud.org/ns'
-            })
+          headers: { authorization: getAuthHeaders(testUser, testUserPassword), ...applicationXmlResponseHeaders },
+          body: new XmlBuilder('1.0', '', 'd:propfind').build(dPropfind => {
+            dPropfind.setAttributes({ 'xmlns:d': 'DAV:', 'xmlns:oc': 'http://owncloud.org/ns' })
             dPropfind.appendElement('d:prop', '', '')
           })
         })
         .willRespondWith({
           status: 207,
           headers: applicationXmlResponseHeaders,
-          body: new XmlBuilder('1.0', '', 'd:multistatus').build(
-            (dMultistatus) => {
-              dMultistatus.setAttributes({
-                'xmlns:d': 'DAV:',
-                'xmlns:s': 'http://sabredav.org/ns',
-                'xmlns:oc': 'http://owncloud.org/ns'
-              })
-              const node = dMultistatus.appendElement(
-                'd:response',
-                '',
-                (dResponse) => {
-                  dResponse
-                    .appendElement(
-                      'd:href',
-                      '',
-                      MatchersV3.regex(
-                        '.*\\/remote\\.php\\/dav\\/meta\\/.*\\/v$',
-                        `/remote.php/dav/meta/${fileInfo.id}/v/`
-                      )
-                    )
-                    .appendElement('d:propstat', '', (dPropstat) => {
-                      dPropstat
-                        .appendElement('d:prop', '', (dProp) => {
-                          dProp.appendElement(
-                            'd:resourcetype',
-                            '',
-                            (dResourceType) => {
-                              dResourceType.appendElement(
-                                'd:collection',
-                                '',
-                                ''
-                              )
-                            }
-                          )
-                        })
-                        .appendElement(
-                          'd:status',
-                          '',
-                          MatchersV3.equal('HTTP/1.1 200 OK')
-                        )
-                    })
-                }
-              )
-              propfindFileVersionsResponse(node, 1, 14)
-              propfindFileVersionsResponse(node, 0, 6)
-            }
-          )
+          body: new XmlBuilder('1.0', '', 'd:multistatus').build(dMultistatus => {
+            dMultistatus.setAttributes({
+              'xmlns:d': 'DAV:',
+              'xmlns:s': 'http://sabredav.org/ns',
+              'xmlns:oc': 'http://owncloud.org/ns'
+            })
+            const node = dMultistatus.appendElement('d:response', '', dResponse => {
+              dResponse.appendElement('d:href', '', MatchersV3.regex('.*\\/remote\\.php\\/dav\\/meta\\/.*\\/v$', `/remote.php/dav/meta/${fileInfo.id}/v/`))
+                .appendElement('d:propstat', '', dPropstat => {
+                  dPropstat.appendElement('d:prop', '', dProp => {
+                    dProp
+                      .appendElement('d:resourcetype', '', dResourceType => {
+                        dResourceType.appendElement('d:collection', '', '')
+                      })
+                  })
+                    .appendElement('d:status', '', MatchersV3.equal('HTTP/1.1 200 OK'))
+                })
+            })
+            propfindFileVersionsResponse(node, 1, 14)
+            propfindFileVersionsResponse(node, 0, 6)
+          })
         })
     }
     const getFileVersionContents = async (provider, i) => {
@@ -227,12 +191,11 @@ describe('Main: Currently testing file versions management,', function () {
         username: testUser,
         password: testUserPassword
       })
-      await givenFileExists(provider, testUser, testUserPassword, versionedFile)
+      await givenFileExists(provider, testUser, versionedFile)
       await provider.given('the client waits', { delay: 2000 })
       await givenFileExists(
         provider,
         testUser,
-        testUserPassword,
         versionedFile,
         fileInfo.versions[0].content
       )
@@ -240,7 +203,6 @@ describe('Main: Currently testing file versions management,', function () {
       await givenFileExists(
         provider,
         testUser,
-        testUserPassword,
         versionedFile,
         fileInfo.versions[1].content
       )
@@ -309,9 +271,9 @@ describe('Main: Currently testing file versions management,', function () {
           username: testUser,
           password: testUserPassword
         })
-      await givenFileExists(provider, testUser, testUserPassword, versionedFile)
+      await givenFileExists(provider, testUser, versionedFile)
       // re-upload the same file to create a new version
-      await givenFileExists(provider, testUser, testUserPassword, versionedFile, 'new content')
+      await givenFileExists(provider, testUser, versionedFile, 'new content')
       await provider
         .given('file version link is returned', {
           fileName: versionedFile,

--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -643,16 +643,13 @@ describe('Main: Currently testing files management,', function () {
       const desFolder = 'testFolder2'
       const desFilePath = `${desFolder}/中文.txt`
       const destinationWebDavPath = `remote.php/dav/files/${testUser}/${encodeURI(desFilePath)}`
-      provider
+      await provider
         .given('the user is recreated', {
           username: testUser,
           password: testUserPassword
         })
-        .given('folder exists', {
-          folderName: desFolder,
-          username: testUser,
-          password: testUserPassword
-        })
+      await givenFolderExists(provider, testUser, testUserPassword, desFolder)
+      await provider
         .given('file exists', {
           fileName: srcFilePath,
           username: testUser,
@@ -1218,11 +1215,8 @@ describe('Main: Currently testing files management,', function () {
           username: testUser,
           password: testUserPassword
         })
-        .given('folder exists', {
-          folderName: `${testFolder}/subdir/`,
-          username: testUser,
-          password: testUserPassword
-        })
+      await givenFolderExists(provider, testUser, testUserPassword, `${testFolder}/subdir/`)
+      await provider
         .given('provider base url is returned')
         .uponReceiving(`as '${testUser}', a COPY request to copy existent file into different folder`)
         .withRequest({

--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -109,12 +109,12 @@ describe('Main: Currently testing files management,', function () {
     await givenUserExists(provider, testUser, testUserPassword)
     if (parentFolder !== nonExistentFile) {
       for (let i = 0; i < files.length; i++) {
-        await givenFileExists(provider, testUser, testUserPassword, parentFolder + '/' + files[i])
+        await givenFileExists(provider, testUser, parentFolder + '/' + files[i])
       }
     }
     if (parentFolder !== nonExistentFile) {
       for (let i = 0; i < folders.length; i++) {
-        await givenFolderExists(provider, testUser, testUserPassword, parentFolder + '/' + folders[i])
+        await givenFolderExists(provider, testUser, parentFolder + '/' + folders[i])
       }
     }
     return provider.uponReceiving(`as '${testUser}', a PROPFIND request to list content of folder, ${requestName}`)
@@ -185,7 +185,7 @@ describe('Main: Currently testing files management,', function () {
 
   const favoriteFileInteraction = async (provider, value, file) => {
     await givenUserExists(provider, testUser, testUserPassword)
-    await givenFileExists(provider, testUser, testUserPassword, file)
+    await givenFileExists(provider, testUser, file)
     return provider.uponReceiving(`as '${testUser}', a PROPPATCH request to ${value === true ? 'favorite' : 'unfavorite'} a file`)
       .withRequest({
         method: 'PROPPATCH',
@@ -599,7 +599,7 @@ describe('Main: Currently testing files management,', function () {
           username: testUser,
           password: testUserPassword
         })
-      await givenFileExists(provider, testUser, testUserPassword, encodedSrcFilePath)
+      await givenFileExists(provider, testUser, encodedSrcFilePath)
       provider.given('provider base url is returned')
       await moveFileInteraction(
         provider,
@@ -644,8 +644,8 @@ describe('Main: Currently testing files management,', function () {
           username: testUser,
           password: testUserPassword
         })
-      await givenFolderExists(provider, testUser, testUserPassword, desFolder)
-      await givenFileExists(provider, testUser, testUserPassword, srcFilePath)
+      await givenFolderExists(provider, testUser, desFolder)
+      await givenFileExists(provider, testUser, srcFilePath)
       await provider
         .given('provider base url is returned')
         .uponReceiving(`as '${testUser}', a MOVE request to move existent file into different folder`)
@@ -726,7 +726,7 @@ describe('Main: Currently testing files management,', function () {
         provider, testUser, testUserPassword
       )
       await givenUserExists(provider, testUser, testUserPassword)
-      await givenFileExists(provider, testUser, testUserPassword, file)
+      await givenFileExists(provider, testUser, file)
       await provider
         .given('provider base url is returned')
         .uponReceiving(`as '${testUser}', a COPY request to copy existent file into same folder, same name`)
@@ -808,7 +808,7 @@ describe('Main: Currently testing files management,', function () {
       )
       const file = `${testFolder}/${testFile}`
       await givenUserExists(provider, testUser, testUserPassword)
-      await givenFileExists(provider, testUser, testUserPassword, file)
+      await givenFileExists(provider, testUser, file)
       await provider
         .uponReceiving(`as '${testUser}', a PROPFIND request to path for fileId`)
         .withRequest({
@@ -874,7 +874,7 @@ describe('Main: Currently testing files management,', function () {
       )
       const file = `${testFolder}/${testFile}`
       await givenUserExists(provider, testUser, testUserPassword)
-      await givenFileExists(provider, testUser, testUserPassword, file)
+      await givenFileExists(provider, testUser, file)
       await provider
         .uponReceiving(`as '${testUser}', a PROPFIND request to file info, fileId`)
         .withRequest({
@@ -1020,7 +1020,7 @@ describe('Main: Currently testing files management,', function () {
         provider, testUser, testUserPassword
       )
       await givenUserExists(provider, testUser, testUserPassword)
-      await givenFileExists(provider, testUser, testUserPassword, testFile)
+      await givenFileExists(provider, testUser, testFile)
       await tusSupportRequest(provider)
 
       return provider.executeTest(async () => {
@@ -1047,8 +1047,8 @@ describe('Main: Currently testing files management,', function () {
       )
       const dir = 'somedir'
       await givenUserExists(provider, testUser, testUserPassword)
-      await givenFolderExists(provider, testUser, testUserPassword, dir)
-      await givenFileExists(provider, testUser, testUserPassword, dir + '/' + testFile)
+      await givenFolderExists(provider, testUser, dir)
+      await givenFileExists(provider, testUser, dir + '/' + testFile)
       await tusSupportRequest(provider, true, dir)
 
       return provider.executeTest(async () => {
@@ -1071,7 +1071,7 @@ describe('Main: Currently testing files management,', function () {
         provider, testUser, testUserPassword
       )
       await givenUserExists(provider, testUser, testUserPassword)
-      await givenFileExists(provider, testUser, testUserPassword, testFile)
+      await givenFileExists(provider, testUser, testFile)
       await tusSupportRequest(provider, false)
 
       return provider.executeTest(async () => {
@@ -1103,7 +1103,7 @@ describe('Main: Currently testing files management,', function () {
           username: testUser,
           password: testUserPassword
         })
-      await givenFileExists(provider, testUser, testUserPassword, srcFilePath)
+      await givenFileExists(provider, testUser, srcFilePath)
       provider.given('provider base url is returned')
       await moveFileInteraction(
         provider,
@@ -1148,7 +1148,7 @@ describe('Main: Currently testing files management,', function () {
           username: testUser,
           password: testUserPassword
         })
-      await givenFileExists(provider, testUser, testUserPassword, srcFilePath)
+      await givenFileExists(provider, testUser, srcFilePath)
       await provider
         .given('provider base url is returned')
         .uponReceiving(`as '${testUser}', a COPY request to copy existent file into same folder, different name`)
@@ -1195,8 +1195,8 @@ describe('Main: Currently testing files management,', function () {
           username: testUser,
           password: testUserPassword
         })
-      await givenFileExists(provider, testUser, testUserPassword, srcFilePath)
-      await givenFolderExists(provider, testUser, testUserPassword, `${testFolder}/subdir/`)
+      await givenFileExists(provider, testUser, srcFilePath)
+      await givenFolderExists(provider, testUser, `${testFolder}/subdir/`)
       await provider
         .given('provider base url is returned')
         .uponReceiving(`as '${testUser}', a COPY request to copy existent file into different folder`)
@@ -1289,7 +1289,7 @@ describe('Main: Currently testing files management,', function () {
         provider, testUser, testUserPassword
       )
       await givenUserExists(provider, testUser, testUserPassword)
-      await givenFileExists(provider, testUser, testUserPassword, file)
+      await givenFileExists(provider, testUser, file)
       await givenFileIsMarkedFavorite(provider, testUser, testUserPassword, file)
       await provider
         .uponReceiving(`as '${testUser}', a REPORT request to get favorite file`)
@@ -1359,7 +1359,7 @@ describe('Main: Currently testing files management,', function () {
         provider, testUser, testUserPassword
       )
       await givenUserExists(provider, testUser, testUserPassword)
-      await givenFileExists(provider, testUser, testUserPassword, file)
+      await givenFileExists(provider, testUser, file)
       await provider
         .uponReceiving(`as '${testUser}', a REPORT request to get favorite file when there are no favorites`)
         .withRequest({
@@ -1425,7 +1425,7 @@ describe('Main: Currently testing files management,', function () {
       const filename = 'abc.txt'
       const filePath = testFolder + '/' + filename
       await givenUserExists(provider, testUser, testUserPassword)
-      await givenFileExists(provider, testUser, testUserPassword, filePath)
+      await givenFileExists(provider, testUser, filePath)
       await provider
         .uponReceiving(`as '${testUser}', a REPORT request to search in the instance`)
         .withRequest({
@@ -1538,7 +1538,7 @@ describe('Main: Currently testing files management,', function () {
       )
 
       await givenUserExists(provider, testUser, testUserPassword)
-      await givenFileExists(provider, testUser, testUserPassword, testFile)
+      await givenFileExists(provider, testUser, testFile)
       await givenSystemTagExists(provider, testUser, testUserPassword, newTagName)
       await givenTagIsAssignedToFile(provider, testUser, testUserPassword, testFile, newTagName)
       await provider
@@ -1633,7 +1633,7 @@ describe('Main: Currently testing files management,', function () {
       )
 
       await givenUserExists(provider, testUser, testUserPassword)
-      await givenFileExists(provider, testUser, testUserPassword, testFile)
+      await givenFileExists(provider, testUser, testFile)
       await givenSystemTagExists(provider, testUser, testUserPassword, newTagName)
       await provider
         .uponReceiving(`as '${testUser}', a PUT request to tag file`)

--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -599,12 +599,8 @@ describe('Main: Currently testing files management,', function () {
           username: testUser,
           password: testUserPassword
         })
-        .given('file exists', {
-          fileName: encodedSrcFilePath,
-          username: testUser,
-          password: testUserPassword
-        })
-        .given('provider base url is returned')
+      await givenFileExists(provider, testUser, testUserPassword, encodedSrcFilePath)
+      provider.given('provider base url is returned')
       await moveFileInteraction(
         provider,
         'same name',
@@ -649,12 +645,8 @@ describe('Main: Currently testing files management,', function () {
           password: testUserPassword
         })
       await givenFolderExists(provider, testUser, testUserPassword, desFolder)
+      await givenFileExists(provider, testUser, testUserPassword, srcFilePath)
       await provider
-        .given('file exists', {
-          fileName: srcFilePath,
-          username: testUser,
-          password: testUserPassword
-        })
         .given('provider base url is returned')
         .uponReceiving(`as '${testUser}', a MOVE request to move existent file into different folder`)
         .withRequest({
@@ -1111,12 +1103,8 @@ describe('Main: Currently testing files management,', function () {
           username: testUser,
           password: testUserPassword
         })
-        .given('file exists', {
-          fileName: srcFilePath,
-          username: testUser,
-          password: testUserPassword
-        })
-        .given('provider base url is returned')
+      await givenFileExists(provider, testUser, testUserPassword, srcFilePath)
+      provider.given('provider base url is returned')
       await moveFileInteraction(
         provider,
         'different name',
@@ -1160,11 +1148,8 @@ describe('Main: Currently testing files management,', function () {
           username: testUser,
           password: testUserPassword
         })
-        .given('file exists', {
-          fileName: srcFilePath,
-          username: testUser,
-          password: testUserPassword
-        })
+      await givenFileExists(provider, testUser, testUserPassword, srcFilePath)
+      await provider
         .given('provider base url is returned')
         .uponReceiving(`as '${testUser}', a COPY request to copy existent file into same folder, different name`)
         .withRequest({
@@ -1210,11 +1195,7 @@ describe('Main: Currently testing files management,', function () {
           username: testUser,
           password: testUserPassword
         })
-        .given('file exists', {
-          fileName: srcFilePath,
-          username: testUser,
-          password: testUserPassword
-        })
+      await givenFileExists(provider, testUser, testUserPassword, srcFilePath)
       await givenFolderExists(provider, testUser, testUserPassword, `${testFolder}/subdir/`)
       await provider
         .given('provider base url is returned')

--- a/tests/groupTest.js
+++ b/tests/groupTest.js
@@ -18,7 +18,10 @@ describe('Main: Currently testing group management,', function () {
     createOwncloud
   } = require('./helpers/pactHelper.js')
 
-  const { givenGroupExists } = require('./helpers/providerStateHelper')
+  const {
+    givenGroupExists,
+    givenGroupDoesNotExist
+  } = require('./helpers/providerStateHelper')
 
   async function getGroupsInteraction (provider) {
     await givenGroupExists(provider, 'admin')
@@ -56,8 +59,7 @@ describe('Main: Currently testing group management,', function () {
 
   async function deleteGroupInteraction (provider, group, responseBody) {
     if (group === config.nonExistentGroup) {
-      await provider
-        .given('group does not exist', { groupName: group })
+      await givenGroupDoesNotExist(provider, group)
     } else {
       await givenGroupExists(provider, group)
     }
@@ -207,8 +209,9 @@ describe('Main: Currently testing group management,', function () {
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)
     const headers = { ...validAdminAuthHeaders, ...{ 'Content-Type': 'application/x-www-form-urlencoded' } }
+
+    await givenGroupDoesNotExist(provider, config.testGroup)
     await provider
-      .given('group does not exist', { groupName: config.testGroup })
       .uponReceiving(`as '${adminUsername}', a POST request to create a group`)
       .withRequest({
         method: 'POST',

--- a/tests/groupTest.js
+++ b/tests/groupTest.js
@@ -18,10 +18,12 @@ describe('Main: Currently testing group management,', function () {
     createOwncloud
   } = require('./helpers/pactHelper.js')
 
+  const { givenGroupExists } = require('./helpers/providerStateHelper')
+
   async function getGroupsInteraction (provider) {
+    await givenGroupExists(provider, 'admin')
+    await givenGroupExists(provider, config.testGroup)
     await provider
-      .given('group exists', { groupName: 'admin' })
-      .given('group exists', { groupName: config.testGroup })
       .uponReceiving(`as '${adminUsername}', a GET request to get all groups`)
       .withRequest({
         method: 'GET',
@@ -57,8 +59,7 @@ describe('Main: Currently testing group management,', function () {
       await provider
         .given('group does not exist', { groupName: group })
     } else {
-      await provider
-        .given('group exists', { groupName: group })
+      await givenGroupExists(provider, group)
     }
 
     await provider
@@ -135,8 +136,9 @@ describe('Main: Currently testing group management,', function () {
     provider = createProvider(false, true)
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)
+
+    await givenGroupExists(provider, config.testGroup)
     await provider
-      .given('group exists', { groupName: config.testGroup })
       .given('the user is recreated', { username: testUser, password: testUserPassword })
       .given('user is added to group', { username: testUser, groupName: config.testGroup })
       .uponReceiving(`as '${adminUsername}', a GET request to get all members of existing group`)

--- a/tests/helpers/pactHelper.js
+++ b/tests/helpers/pactHelper.js
@@ -193,7 +193,7 @@ const getContentsOfFileInteraction = async (
     provider.given('the user is recreated', { username: user, password: password })
   }
   if (file !== config.nonExistentFile) {
-    await givenFileExists(provider, user, password, file)
+    await givenFileExists(provider, user, file)
   }
   return provider
     .uponReceiving(`as '${user}', a GET request to get contents of a file '${file}'`)
@@ -227,7 +227,7 @@ const deleteResourceInteraction = async (
       body: webdavExceptionResponseBody('NotFound', resourceNotFoundExceptionMessage(config.nonExistentDir))
     }
   } else if (type === 'file') {
-    await givenFileExists(provider, user, password, resource)
+    await givenFileExists(provider, user, resource)
     response = {
       status: 200,
       headers: xmlResponseHeaders,
@@ -238,7 +238,7 @@ const deleteResourceInteraction = async (
       })
     }
   } else {
-    await givenFolderExists(provider, user, password, resource)
+    await givenFolderExists(provider, user, resource)
     response = {
       status: 204
     }
@@ -460,7 +460,7 @@ const createFolderInteraction = async function (
     recrusivePath += path.sep + folders[i]
   }
   if (recrusivePath !== '') {
-    await givenFolderExists(provider, user, password, recrusivePath)
+    await givenFolderExists(provider, user, recrusivePath)
   }
   const encodedFolderName = encodeURIPath(folderName)
   return provider
@@ -484,7 +484,7 @@ const updateFileInteraction = async function (provider, file, user = adminUserna
     provider.given('the user is recreated', { username: user, password: password })
   }
   if (!file.includes('nonExistent')) {
-    await givenFolderExists(provider, user, password, path.dirname(file))
+    await givenFolderExists(provider, user, path.dirname(file))
   }
 
   const etagMatcher = MatchersV3.regex(/^"[a-f0-9:.]{1,32}"$/, config.testFileEtag)

--- a/tests/helpers/pactHelper.js
+++ b/tests/helpers/pactHelper.js
@@ -13,6 +13,8 @@ const adminPasswordHash = Buffer.from(adminUsername + ':' + adminPassword, 'bina
 const path = require('path')
 const OwnCloud = require('../../src/owncloud')
 
+const { givenGroupExists } = require('./helpers/providerStateHelper')
+
 const accessControlAllowHeaders = 'OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With'
 const accessControlAllowMethods = 'GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT,COPY,MOVE,HEAD,LOCK,UNLOCK'
 const origin = 'http://localhost:9876'
@@ -402,9 +404,9 @@ const createUserInteraction = function (provider) {
     })
 }
 
-const createUserWithGroupMembershipInteraction = function (provider) {
+const createUserWithGroupMembershipInteraction = async function (provider) {
+  await givenGroupExists(provider, config.testGroup)
   return provider
-    .given('group exists', { groupName: config.testGroup })
     .uponReceiving(`as '${adminUsername}', a POST request to create a user with group membership`)
     .withRequest({
       method: 'POST',

--- a/tests/helpers/pactHelper.js
+++ b/tests/helpers/pactHelper.js
@@ -15,7 +15,8 @@ const OwnCloud = require('../../src/owncloud')
 
 const {
   givenGroupExists,
-  givenFolderExists
+  givenFolderExists,
+  givenFileExists
 } = require('../helpers/providerStateHelper')
 
 const accessControlAllowHeaders = 'OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With'
@@ -183,7 +184,7 @@ const createOwncloud = function (username = adminUsername, password = adminPassw
 }
 // [OCIS] Trying to access a non-existing resource returns an empty body
 // https://github.com/owncloud/ocis/issues/1282
-const getContentsOfFileInteraction = (
+const getContentsOfFileInteraction = async (
   provider, file,
   user = adminUsername,
   password = adminPassword
@@ -192,12 +193,7 @@ const getContentsOfFileInteraction = (
     provider.given('the user is recreated', { username: user, password: password })
   }
   if (file !== config.nonExistentFile) {
-    provider
-      .given('file exists', {
-        fileName: file,
-        username: user,
-        password: password
-      })
+    await givenFileExists(provider, user, password, file)
   }
   return provider
     .uponReceiving(`as '${user}', a GET request to get contents of a file '${file}'`)
@@ -231,11 +227,7 @@ const deleteResourceInteraction = async (
       body: webdavExceptionResponseBody('NotFound', resourceNotFoundExceptionMessage(config.nonExistentDir))
     }
   } else if (type === 'file') {
-    provider.given('file exists', {
-      fileName: resource,
-      username: user,
-      password: password
-    })
+    await givenFileExists(provider, user, password, resource)
     response = {
       status: 200,
       headers: xmlResponseHeaders,

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -42,13 +42,12 @@ const givenGroupDoesNotExist = (provider, group) => {
  *
  * @param {object} provider
  * @param {string} username
- * @param {string} password
  * @param {string} resource file name
  * @param {string} content
  */
-const givenFileExists = (provider, username, password, resource, content) => {
+const givenFileExists = (provider, username, resource, content) => {
   return provider
-    .given('file exists', { username, password, fileName: resource, content })
+    .given('file exists', { username, fileName: resource, content })
 }
 
 /**
@@ -56,12 +55,11 @@ const givenFileExists = (provider, username, password, resource, content) => {
  *
  * @param {object} provider
  * @param {string} username
- * @param {sring} password
- * @param {sring} resource folder name
+ * @param {string} resource folder name
  */
-const givenFolderExists = (provider, username, password, resource) => {
+const givenFolderExists = (provider, username, resource) => {
   return provider
-    .given('folder exists', { username, password, folderName: resource })
+    .given('folder exists', { username, folderName: resource })
 }
 
 /**
@@ -174,9 +172,9 @@ const givenPublicShareExists = (
  */
 const givenFileFolderIsCreated = (provider, username, password, resource, resourceType) => {
   if (resourceType === 'folder') {
-    return givenFolderExists(provider, username, password, resource)
+    return givenFolderExists(provider, username, resource)
   } else {
-    return givenFileExists(provider, username, password, resource)
+    return givenFileExists(provider, username, resource)
   }
 }
 

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -42,12 +42,13 @@ const givenGroupDoesNotExist = (provider, group) => {
  *
  * @param {object} provider
  * @param {string} username
- * @param {sring} password
- * @param {sring} resource file name
+ * @param {string} password
+ * @param {string} resource file name
+ * @param {string} content
  */
-const givenFileExists = (provider, username, password, resource) => {
+const givenFileExists = (provider, username, password, resource, content) => {
   return provider
-    .given('file exists', { username, password, fileName: resource })
+    .given('file exists', { username, password, fileName: resource, content })
 }
 
 /**

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -28,6 +28,16 @@ const givenGroupExists = (provider, group) => {
 }
 
 /**
+ * provider state: deletes a given group
+ *
+ * @param {object} provider
+ * @param {string} group
+ */
+const givenGroupDoesNotExist = (provider, group) => {
+  return provider.given('group does not exist', { groupName: group })
+}
+
+/**
  * provider state: creates given file
  *
  * @param {object} provider
@@ -287,6 +297,7 @@ const givenTagIsAssignedToFile = (provider, username, password, fileName, tagNam
 module.exports = {
   givenUserExists,
   givenGroupExists,
+  givenGroupDoesNotExist,
   givenFileExists,
   givenFolderExists,
   givenUserShareExists,

--- a/tests/helpers/webdavHelper.js
+++ b/tests/helpers/webdavHelper.js
@@ -25,11 +25,10 @@ const createDavPath = function (userId, element, type = 'files') {
  * Create a folder using webDAV api.
  *
  * @param {string} user
- * @param {string} password
  * @param {string} folderName
  * @returns {[]} all fetch results
  */
-const createFolderRecursive = function (user, password, folderName) {
+const createFolderRecursive = function (user, folderName) {
   const results = []
   folderName = folderName.replace(/\/$/, '')
   folderName = folderName.replace(/^\//, '')
@@ -53,12 +52,11 @@ const createFolderRecursive = function (user, password, folderName) {
  * Create a file using webDAV api.
  *
  * @param {string} user
- * @param {string} password
  * @param {string} fileName
  * @param {string} contents
  * @returns {*} result of the fetch request
  */
-const createFile = function (user, password, fileName, contents = '') {
+const createFile = function (user, fileName, contents = '') {
   return httpHelper.put(createDavPath(user, fileName), contents, null, user)
 }
 

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -125,7 +125,8 @@ describe('provider testing', () => {
     'folder exists': (setup, parameters) => {
       if (setup) {
         const results = createFolderRecursive(
-          parameters.username, parameters.password, parameters.folderName
+          parameters.username,
+          parameters.folderName
         )
         assertFoldersCreatedSuccessfully(results, parameters.folderName)
       }
@@ -136,13 +137,11 @@ describe('provider testing', () => {
       const content = parameters.content || testContent
       if (setup) {
         if (dirname !== '' && dirname !== '/' && dirname !== '.') {
-          const results = createFolderRecursive(
-            parameters.username, parameters.password, dirname
-          )
+          const results = createFolderRecursive(parameters.username, dirname)
           assertFoldersCreatedSuccessfully(results, dirname)
         }
         const result = createFile(
-          parameters.username, parameters.password, parameters.fileName, content
+          parameters.username, parameters.fileName, content
         )
         chai.assert.isBelow(
           result.status, 300, `creating file '${parameters.fileName}' failed`

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -57,7 +57,7 @@ describe('oc.publicFiles', function () {
     }
     await provider
       .given('the user is recreated', { username: testUser, password: testUserPassword })
-    await givenFolderExists(provider, testUser, testUserPassword, testFolder)
+    await givenFolderExists(provider, testUser, testFolder)
     return provider
       .given('resource is shared', {
         username: testUser,
@@ -105,7 +105,7 @@ describe('oc.publicFiles', function () {
     }
     await provider
       .given('the user is recreated', { username: testUser, password: testUserPassword })
-    await givenFolderExists(provider, testUser, testUserPassword, testFolder)
+    await givenFolderExists(provider, testUser, testFolder)
     await provider
       .given('resource is shared', {
         username: testUser,
@@ -236,7 +236,7 @@ describe('oc.publicFiles', function () {
 
             await givenUserExists(provider, testUser, testUserPassword)
             for (let fileNum = 0; fileNum < testFiles.length; fileNum++) {
-              await givenFileExists(provider, testUser, testUserPassword, testFolder + '/' + testFiles[fileNum])
+              await givenFileExists(provider, testUser, testFolder + '/' + testFiles[fileNum])
             }
             if (data.shareParams.password) {
               await givenPublicShareExists(provider, testUser, testUserPassword, testFolder, { password: data.shareParams.password })
@@ -365,7 +365,7 @@ describe('oc.publicFiles', function () {
             }
 
             await givenUserExists(provider, testUser, testUserPassword)
-            await givenFileExists(provider, testUser, testUserPassword, testFolder + '/' + testFiles[2])
+            await givenFileExists(provider, testUser, testFolder + '/' + testFiles[2])
             if (data.shareParams.password) {
               await givenPublicShareExists(provider, testUser, testUserPassword, testFolder, { password: data.shareParams.password })
             } else {
@@ -527,7 +527,7 @@ describe('oc.publicFiles', function () {
           await provider
             .given('provider base url is returned')
             .given('the user is recreated', { username: testUser, password: testUserPassword })
-          await givenFolderExists(provider, testUser, testUserPassword, testFolder)
+          await givenFolderExists(provider, testUser, testFolder)
           if (data.shareParams.password) {
             await givenPublicShareExists(
               provider,
@@ -579,7 +579,7 @@ describe('oc.publicFiles', function () {
           await provider
             .given('provider base url is returned')
             .given('the user is recreated', { username: testUser, password: testUserPassword })
-          await givenFolderExists(provider, testUser, testUserPassword, testFolder)
+          await givenFolderExists(provider, testUser, testFolder)
           if (data.shareParams.password) {
             await givenPublicShareExists(
               provider,
@@ -628,7 +628,7 @@ describe('oc.publicFiles', function () {
           await provider
             .given('provider base url is returned')
             .given('the user is recreated', { username: testUser, password: testUserPassword })
-          await givenFolderExists(provider, testUser, testUserPassword, testFolder)
+          await givenFolderExists(provider, testUser, testFolder)
           if (data.shareParams.password) {
             await givenPublicShareExists(
               provider,
@@ -679,7 +679,7 @@ describe('oc.publicFiles', function () {
           await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
 
           await givenUserExists(provider, testUser, testUserPassword)
-          await givenFolderExists(provider, testUser, testUserPassword, testFolder)
+          await givenFolderExists(provider, testUser, testFolder)
           if (data.shareParams.password) {
             await givenPublicShareExists(
               provider,

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -50,18 +50,15 @@ describe('oc.publicFiles', function () {
     }
   }
 
-  const folderInPublicShareInteraction = (provider, description, method, statusCode, password = null) => {
+  const folderInPublicShareInteraction = async (provider, description, method, statusCode, password = null) => {
     let headers = {}
     if (password) {
       headers = getPublicLinkAuthHeader(password)
     }
-    return provider
+    await provider
       .given('the user is recreated', { username: testUser, password: testUserPassword })
-      .given('folder exists', {
-        username: testUser,
-        password: testUserPassword,
-        folderName: testFolder
-      })
+    await givenFolderExists(provider, testUser, testUserPassword, testFolder)
+    return provider
       .given('resource is shared', {
         username: testUser,
         userPassword: testUserPassword,
@@ -108,11 +105,8 @@ describe('oc.publicFiles', function () {
     }
     await provider
       .given('the user is recreated', { username: testUser, password: testUserPassword })
-      .given('folder exists', {
-        username: testUser,
-        password: testUserPassword,
-        folderName: testFolder
-      })
+    await givenFolderExists(provider, testUser, testUserPassword, testFolder)
+    await provider
       .given('resource is shared', {
         username: testUser,
         userPassword: testUserPassword,
@@ -533,7 +527,7 @@ describe('oc.publicFiles', function () {
           await provider
             .given('provider base url is returned')
             .given('the user is recreated', { username: testUser, password: testUserPassword })
-            .given('folder exists', { username: testUser, password: testUserPassword, folderName: testFolder })
+          await givenFolderExists(provider, testUser, testUserPassword, testFolder)
           if (data.shareParams.password) {
             await givenPublicShareExists(
               provider,
@@ -585,7 +579,7 @@ describe('oc.publicFiles', function () {
           await provider
             .given('provider base url is returned')
             .given('the user is recreated', { username: testUser, password: testUserPassword })
-            .given('folder exists', { username: testUser, password: testUserPassword, folderName: testFolder })
+          await givenFolderExists(provider, testUser, testUserPassword, testFolder)
           if (data.shareParams.password) {
             await givenPublicShareExists(
               provider,
@@ -634,7 +628,7 @@ describe('oc.publicFiles', function () {
           await provider
             .given('provider base url is returned')
             .given('the user is recreated', { username: testUser, password: testUserPassword })
-            .given('folder exists', { username: testUser, password: testUserPassword, folderName: testFolder })
+          await givenFolderExists(provider, testUser, testUserPassword, testFolder)
           if (data.shareParams.password) {
             await givenPublicShareExists(
               provider,

--- a/tests/shareRecipientTest.js
+++ b/tests/shareRecipientTest.js
@@ -15,11 +15,14 @@ describe('Main: Currently testing share recipient,', function () {
     createProvider
   } = require('./helpers/pactHelper.js')
 
-  const getShareesInteraction = (provider, folder = config.testFolder) => {
+  const { givenGroupExists } = require('./helpers/providerStateHelper')
+
+  const getShareesInteraction = async (provider, folder = config.testFolder) => {
     provider
       .given('the user is recreated', { username: sharer, password: sharerPassword })
       .given('the user is recreated', { username: receiver, password: receiverPassword })
-      .given('group exists', { groupName: config.testGroup })
+    await givenGroupExists(provider, config.testGroup)
+
     return provider
       .uponReceiving(`as '${sharer}', a GET request to get share recipients (both users and groups)`)
       .withRequest({

--- a/tests/sharingWithAttributesTest.js
+++ b/tests/sharingWithAttributesTest.js
@@ -41,7 +41,7 @@ describe('oc.shares', function () {
     await provider
       .given('the user is recreated', { username: sharer, password: sharerPassword })
       .given('the user is recreated', { username: receiver, password: receiverPassword })
-    await givenFileExists(provider, sharer, sharerPassword, testFile, 'a test file')
+    await givenFileExists(provider, sharer, testFile, 'a test file')
     return provider
       .uponReceiving(`as '${sharer}', a POST request to share a file with permissions in attributes`)
       .withRequest({

--- a/tests/sharingWithAttributesTest.js
+++ b/tests/sharingWithAttributesTest.js
@@ -19,6 +19,8 @@ describe('oc.shares', function () {
     getAuthHeaders
   } = require('./helpers/pactHelper.js')
 
+  const { givenFileExists } = require('./helpers/providerStateHelper')
+
   const shareAttributes = {
     attributes: [
       { scope: 'ownCloud', key: 'read', value: 'true' },
@@ -35,11 +37,12 @@ describe('oc.shares', function () {
     return `[${response}]`
   }
 
-  const sharingWithAttributes = (provider) => {
-    return provider
+  const sharingWithAttributes = async (provider) => {
+    await provider
       .given('the user is recreated', { username: sharer, password: sharerPassword })
       .given('the user is recreated', { username: receiver, password: receiverPassword })
-      .given('file exists', { username: sharer, password: sharerPassword, fileName: testFile, testContent: 'a test file' })
+    await givenFileExists(provider, sharer, sharerPassword, testFile, 'a test file')
+    return provider
       .uponReceiving(`as '${sharer}', a POST request to share a file with permissions in attributes`)
       .withRequest({
         method: 'POST',

--- a/tests/signedUrlIntegrationTest.js
+++ b/tests/signedUrlIntegrationTest.js
@@ -18,6 +18,8 @@ describe('Signed urls', function () {
     createProvider
   } = require('./helpers/pactHelper.js')
 
+  const { givenFileExists } = require('./helpers/providerStateHelper')
+
   const getSigningKeyInteraction = (provider, username, password) => {
     return provider
       .given('the user is recreated', { username: username, password: password })
@@ -49,12 +51,8 @@ describe('Signed urls', function () {
   }
 
   const downloadWithSignedURLInteraction = async (provider, username, password) => {
+    await givenFileExists(provider, username, password, `${config.testFolder}/${config.testFile}`)
     await provider
-      .given('file exists', {
-        fileName: `${config.testFolder}/${config.testFile}`,
-        username: username,
-        password: password
-      })
       .given('signed-key is returned', {
         username: username,
         password: password,

--- a/tests/signedUrlIntegrationTest.js
+++ b/tests/signedUrlIntegrationTest.js
@@ -51,7 +51,7 @@ describe('Signed urls', function () {
   }
 
   const downloadWithSignedURLInteraction = async (provider, username, password) => {
-    await givenFileExists(provider, username, password, `${config.testFolder}/${config.testFile}`)
+    await givenFileExists(provider, username, `${config.testFolder}/${config.testFile}`)
     await provider
       .given('signed-key is returned', {
         username: username,

--- a/tests/userTest.js
+++ b/tests/userTest.js
@@ -18,7 +18,14 @@ describe('Main: Currently testing user management,', function () {
     createOwncloud,
     createProvider
   } = require('./helpers/pactHelper.js')
-  const { validAdminAuthHeaders, xmlResponseHeaders, applicationFormUrlEncoded } = require('./helpers/pactHelper.js')
+  const {
+    validAdminAuthHeaders,
+    xmlResponseHeaders,
+    applicationFormUrlEncoded
+  } = require('./helpers/pactHelper.js')
+
+  const { givenGroupExists } = require('./helpers/providerStateHelper')
+
   const getUserInformationInteraction = async function (provider, requestName, username, responseBody) {
     if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
@@ -108,8 +115,7 @@ describe('Main: Currently testing user management,', function () {
         .given('the user is recreated', { username: username, password: testUserPassword })
     }
     if (group !== config.nonExistentGroup) {
-      await provider
-        .given('group exists', { groupName: group })
+      await givenGroupExists(provider, group)
     }
 
     return provider
@@ -150,8 +156,8 @@ describe('Main: Currently testing user management,', function () {
     if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
         .given('the user is recreated', { username: username, password: testUserPassword })
-        .given('group exists', { groupName: config.testGroup })
-        .given('user is added to group', { username: username, groupName: config.testGroup })
+      await givenGroupExists(provider, config.testGroup)
+      await provider.given('user is added to group', { username: username, groupName: config.testGroup })
     }
     return provider
       .uponReceiving(`as '${adminUsername}', a GET request to get groups of ${requestName}`)
@@ -182,8 +188,7 @@ describe('Main: Currently testing user management,', function () {
         .given('the user is recreated', { username: username, password: testUserPassword })
     }
     if (group !== config.nonExistentGroup) {
-      await provider
-        .given('group exists', { groupName: group })
+      await givenGroupExists(provider, group)
     }
     return provider
       .uponReceiving(`as '${adminUsername}', a DELETE request to remove ${requestName}`)
@@ -222,8 +227,7 @@ describe('Main: Currently testing user management,', function () {
         .given('the user is recreated', { username: username, password: testUserPassword })
     }
     if (group !== config.nonExistentGroup) {
-      await provider
-        .given('group exists', { groupName: group })
+      await givenGroupExists(provider, group)
     }
     return provider
       .uponReceiving(`as '${adminUsername}', a POST request to make ${requestName}`)
@@ -253,8 +257,8 @@ describe('Main: Currently testing user management,', function () {
     if (username !== adminUsername && username !== config.nonExistentUser) {
       await provider
         .given('the user is recreated', { username: username, password: testUserPassword })
-        .given('group exists', { groupName: config.testGroup })
-        .given('user is made group subadmin', { username: username, groupName: config.testGroup })
+      await givenGroupExists(provider, config.testGroup)
+      await provider.given('user is made group subadmin', { username: username, groupName: config.testGroup })
     }
     return provider
       .uponReceiving(`as '${adminUsername}', a GET request to get subadmin groups of ${requestName}`)


### PR DESCRIPTION
For the Provider side tests, we have stateHandlers for pre-conditions. We have used state handlers directly in most of the tests but we also have state helper functions exactly for that.
State handler:
https://github.com/owncloud/owncloud-sdk/blob/4116766b9f90e6283d34bbb8eda2baae2ffaf02b/tests/providerTest.js#L112-L120

helper function:
https://github.com/owncloud/owncloud-sdk/blob/4116766b9f90e6283d34bbb8eda2baae2ffaf02b/tests/helpers/providerStateHelper.js#L25-L28

In this PR, I have refactored the tests to use state helper functions.

### Related issues
part of #1086