### PR TITLE
Replace provider states with helper functions (p2)

### DIFF
--- a/tests/fileTrashTest.js
+++ b/tests/fileTrashTest.js
@@ -26,7 +26,8 @@ describe('oc.fileTrash', function () {
 
   const {
     givenFolderExists,
-    givenFileExists
+    givenFileExists,
+    givenResourceIsDeleted
   } = require('./helpers/providerStateHelper')
 
   const mockServerBaseUrl = getMockServerBaseUrl()
@@ -212,12 +213,8 @@ describe('oc.fileTrash', function () {
             password: testUserPassword
           })
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
+        await givenResourceIsDeleted(provider, testUser, testFolder)
         return provider
-          .given('resource is deleted', {
-            resourcePath: testFolder,
-            username: testUser,
-            password: testUserPassword
-          })
           .uponReceiving(`as '${testUser}', a PROPFIND request to list trashbin items`)
           .withRequest(requestMethod(
             'PROPFIND',
@@ -240,12 +237,8 @@ describe('oc.fileTrash', function () {
             password: testUserPassword
           })
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
+        await givenResourceIsDeleted(provider, testUser, testFolder)
         return provider
-          .given('resource is deleted', {
-            resourcePath: testFolder,
-            username: testUser,
-            password: testUserPassword
-          })
           .uponReceiving(`as '${testUser}', a PROPFIND request to list item within a deleted folder`)
           .withRequest(requestMethod(
             'PROPFIND',
@@ -361,12 +354,8 @@ describe('oc.fileTrash', function () {
             password: testUserPassword
           })
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
+        await givenResourceIsDeleted(provider, testUser, path.join(testFolder, testFile))
         return provider
-          .given('resource is deleted', {
-            resourcePath: path.join(testFolder, testFile),
-            username: testUser,
-            password: testUserPassword
-          })
           .uponReceiving(`as '${testUser}', a MOVE request to restore folder from trashbin to fileslist to original location`)
           .withRequest({
             method: 'MOVE',
@@ -484,12 +473,8 @@ describe('oc.fileTrash', function () {
             password: testUserPassword
           })
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
+        await givenResourceIsDeleted(provider, testUser, path.join(testFolder, testFile))
         return provider
-          .given('resource is deleted', {
-            resourcePath: path.join(testFolder, testFile),
-            username: testUser,
-            password: testUserPassword
-          })
           .uponReceiving(`as '${testUser}', a MOVE request to restore folder from trashbin to fileslist to a different location`)
           .withRequest({
             method: 'MOVE',
@@ -611,12 +596,8 @@ describe('oc.fileTrash', function () {
           })
         await givenFolderExists(provider, testUser, testFolder)
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
+        await givenResourceIsDeleted(provider, testUser, path.join(testFolder, testFile))
         return provider
-          .given('resource is deleted', {
-            resourcePath: path.join(testFolder, testFile),
-            username: testUser,
-            password: testUserPassword
-          })
           .uponReceiving(`as '${testUser}', a PROPFIND request to trash items before deleting file`)
           .withRequest(requestMethod(
             'PROPFIND',
@@ -704,12 +685,8 @@ describe('oc.fileTrash', function () {
             password: testUserPassword
           })
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
+        await givenResourceIsDeleted(provider, testUser, path.join(testFolder, testFile))
         return provider
-          .given('resource is deleted', {
-            resourcePath: path.join(testFolder, testFile),
-            username: testUser,
-            password: testUserPassword
-          })
           .uponReceiving(`as '${testUser}', a MOVE request to restore file from trashbin to fileslist to a different location`)
           .withRequest({
             method: 'MOVE',
@@ -824,12 +801,8 @@ describe('oc.fileTrash', function () {
             password: testUserPassword
           })
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
+        await givenResourceIsDeleted(provider, testUser, path.join(testFolder, testFile))
         return provider
-          .given('resource is deleted', {
-            resourcePath: path.join(testFolder, testFile),
-            username: testUser,
-            password: testUserPassword
-          })
           .uponReceiving(`as '${testUser}', a MOVE request to restore file from trashbin to a new location`)
           .withRequest({
             method: 'MOVE',
@@ -947,12 +920,8 @@ describe('oc.fileTrash', function () {
             password: testUserPassword
           })
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
+        await givenResourceIsDeleted(provider, testUser, path.join(testFolder, testFile))
         return provider
-          .given('resource is deleted', {
-            resourcePath: path.join(testFolder, testFile),
-            username: testUser,
-            password: testUserPassword
-          })
           .uponReceiving(`as '${testUser}', a MOVE request to restore file from trashbin to a non existing location`)
           .withRequest({
             method: 'MOVE',

--- a/tests/fileTrashTest.js
+++ b/tests/fileTrashTest.js
@@ -27,7 +27,8 @@ describe('oc.fileTrash', function () {
   const {
     givenFolderExists,
     givenFileExists,
-    givenResourceIsDeleted
+    givenResourceIsDeleted,
+    givenUserExists
   } = require('./helpers/providerStateHelper')
 
   const mockServerBaseUrl = getMockServerBaseUrl()
@@ -174,11 +175,9 @@ describe('oc.fileTrash', function () {
       const provider = createProvider(false, true)
       await getCapabilitiesInteraction(provider, testUser, testUserPassword)
       await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
+
+      await givenUserExists(provider, testUser)
       await provider
-        .given('the user is recreated', {
-          username: testUser,
-          password: testUserPassword
-        })
         .uponReceiving(`as '${testUser}', a PROPFIND request to list empty trash`)
         .withRequest(requestMethod(
           'PROPFIND',
@@ -207,11 +206,7 @@ describe('oc.fileTrash', function () {
   describe('when a folder is deleted', function () {
     describe('and folder is not restored', function () {
       const propfindForTrashbinWithItems = async (provider) => {
-        await provider
-          .given('the user is recreated', {
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenUserExists(provider, testUser)
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         await givenResourceIsDeleted(provider, testUser, testFolder)
         return provider
@@ -231,11 +226,7 @@ describe('oc.fileTrash', function () {
           ))
       }
       const listItemWithinADeletedFolder = async (provider) => {
-        await provider
-          .given('the user is recreated', {
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenUserExists(provider, testUser)
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         await givenResourceIsDeleted(provider, testUser, testFolder)
         return provider
@@ -348,11 +339,7 @@ describe('oc.fileTrash', function () {
     describe('and when this deleted folder is restored to its original location', function () {
       const originalLocation = testFolder
       const moveFolderFromTrashbinToFilesList = async (provider) => {
-        await provider
-          .given('the user is recreated', {
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenUserExists(provider, testUser)
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         await givenResourceIsDeleted(provider, testUser, path.join(testFolder, testFile))
         return provider
@@ -390,11 +377,7 @@ describe('oc.fileTrash', function () {
       }
 
       const propfindToARestoredFolderInOriginalLocation = async (provider) => {
-        await provider
-          .given('the user is recreated', {
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenUserExists(provider, testUser)
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         return provider
           .uponReceiving(`as '${testUser}', a PROPFIND request to a restored folder in original location`)
@@ -467,11 +450,7 @@ describe('oc.fileTrash', function () {
       const urlEncodedFolder = encodeURIComponent(originalLocation)
 
       const MoveFromTrashbinToDifferentLocation = async (provider) => {
-        await provider
-          .given('the user is recreated', {
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenUserExists(provider, testUser)
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         await givenResourceIsDeleted(provider, testUser, path.join(testFolder, testFile))
         return provider
@@ -493,12 +472,9 @@ describe('oc.fileTrash', function () {
           ))
       }
 
-      const PropfindToAnEmptytrashbinAfterRestoring = provider => {
+      const PropfindToAnEmptytrashbinAfterRestoring = async (provider) => {
+        await givenUserExists(provider, testUser)
         return provider
-          .given('the user is recreated', {
-            username: testUser,
-            password: testUserPassword
-          })
           .uponReceiving(`as '${testUser}', a PROPFIND request to an empty trashbin after restoring`)
           .withRequest(requestMethod(
             'PROPFIND',
@@ -514,11 +490,7 @@ describe('oc.fileTrash', function () {
       }
 
       const PropfindToARestoredFolderInNewLocation = async (provider) => {
-        await provider
-          .given('the user is recreated', {
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenUserExists(provider, testUser)
         await givenFolderExists(provider, testUser, originalLocation)
         return provider
           .uponReceiving(`as '${testUser}', a PROPFIND request to a restored folder in new location`)
@@ -589,11 +561,7 @@ describe('oc.fileTrash', function () {
   describe('when a file is deleted', function () {
     describe('and file is not restored', function () {
       const propfindTrashItemsBeforeDeletingFile = async (provider) => {
-        await provider
-          .given('the user is recreated', {
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenUserExists(provider, testUser)
         await givenFolderExists(provider, testUser, testFolder)
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         await givenResourceIsDeleted(provider, testUser, path.join(testFolder, testFile))
@@ -679,11 +647,7 @@ describe('oc.fileTrash', function () {
     describe('and when this deleted file is restored to its original location', function () {
       const originalLocation = testFile
       const MoveFromTrashbinToDifferentLocation = async (provider) => {
-        await provider
-          .given('the user is recreated', {
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenUserExists(provider, testUser)
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         await givenResourceIsDeleted(provider, testUser, path.join(testFolder, testFile))
         return provider
@@ -718,11 +682,7 @@ describe('oc.fileTrash', function () {
       }
 
       const propfindToARestoredFileInOriginalLocation = async (provider) => {
-        await provider
-          .given('the user is recreated', {
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenUserExists(provider, testUser)
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         return provider
           .uponReceiving(`as '${testUser}', a PROPFIND request to a restored file in original location`)
@@ -795,11 +755,7 @@ describe('oc.fileTrash', function () {
       const urlEncodedFile = encodeURIComponent(originalLocation)
 
       const MoveFromTrashbinToDifferentLocation = async (provider) => {
-        await provider
-          .given('the user is recreated', {
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenUserExists(provider, testUser)
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         await givenResourceIsDeleted(provider, testUser, path.join(testFolder, testFile))
         return provider
@@ -821,11 +777,7 @@ describe('oc.fileTrash', function () {
           })
       }
       const propfindToARestoredFileInNewLocationEmpty = async (provider) => {
-        await provider
-          .given('the user is recreated', {
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenUserExists(provider, testUser)
         await givenFileExists(provider, testUser, '/file (restored to a different location).txt')
         return provider
           .uponReceiving(`as '${testUser}', a PROPFIND request to trash items after restoring deleting file to new location`)
@@ -843,11 +795,7 @@ describe('oc.fileTrash', function () {
       }
 
       const propfindToARestoredFileInNewLocation = async (provider) => {
-        await provider
-          .given('the user is recreated', {
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenUserExists(provider, testUser)
         await givenFileExists(provider, testUser, '/file (restored to a different location).txt')
         return provider
           .uponReceiving(`as '${testUser}', a PROPFIND request to a restored file in new location`)
@@ -914,11 +862,7 @@ describe('oc.fileTrash', function () {
     // Deleted file cannot be restored to different location
     describe('Trashbin errors should be handled correctly', function () {
       const MoveFromTrashbinToNonExistingLocation = async (provider) => {
-        await provider
-          .given('the user is recreated', {
-            username: testUser,
-            password: testUserPassword
-          })
+        await givenUserExists(provider, testUser)
         await givenFileExists(provider, testUser, path.join(testFolder, testFile))
         await givenResourceIsDeleted(provider, testUser, path.join(testFolder, testFile))
         return provider

--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -23,7 +23,8 @@ describe('Main: Currently testing file versions management,', function () {
 
   const {
     givenFileExists,
-    givenUserExists
+    givenUserExists,
+    givenProviderBaseUrlIsReturned
   } = require('./helpers/providerStateHelper')
 
   const mockServerBaseUrl = getMockServerBaseUrl()
@@ -273,8 +274,7 @@ describe('Main: Currently testing file versions management,', function () {
           password: testUserPassword,
           number: 1
         })
-        .given('provider base url is returned')
-
+      await givenProviderBaseUrlIsReturned(provider)
       await provider
         .uponReceiving(`as '${testUser}', a COPY request to restore file versions`)
         .withRequest({

--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -21,7 +21,10 @@ describe('Main: Currently testing file versions management,', function () {
     getMockServerBaseUrl
   } = require('./helpers/pactHelper.js')
 
-  const { givenFileExists } = require('./helpers/providerStateHelper')
+  const {
+    givenFileExists,
+    givenUserExists
+  } = require('./helpers/providerStateHelper')
 
   const mockServerBaseUrl = getMockServerBaseUrl()
   const { createDavPath } = require('./helpers/webdavHelper.js')
@@ -76,11 +79,9 @@ describe('Main: Currently testing file versions management,', function () {
       const provider = createProvider(false, true)
       await getCapabilitiesInteraction(provider, testUser, testUserPassword)
       await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
+
+      await givenUserExists(provider, testUser)
       await provider
-        .given('the user is recreated', {
-          username: testUser,
-          password: testUserPassword
-        })
         .uponReceiving(`as '${testUser}', a PROPFIND request to get file versions of non existent file`)
         .withRequest({
           method: 'PROPFIND',
@@ -118,10 +119,7 @@ describe('Main: Currently testing file versions management,', function () {
 
   describe('file versions for existing files', () => {
     const PropfindFileVersionOfExistentFiles = async (provider) => {
-      await provider.given('the user is recreated', {
-        username: testUser,
-        password: testUserPassword
-      })
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, versionedFile)
       await provider
         .given('the client waits', { delay: 2000 })
@@ -187,10 +185,7 @@ describe('Main: Currently testing file versions management,', function () {
         })
     }
     const getFileVersionContents = async (provider, i) => {
-      await provider.given('the user is recreated', {
-        username: testUser,
-        password: testUserPassword
-      })
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, versionedFile)
       await provider.given('the client waits', { delay: 2000 })
       await givenFileExists(
@@ -266,11 +261,8 @@ describe('Main: Currently testing file versions management,', function () {
       const provider = createProvider()
       await getCapabilitiesInteraction(provider, testUser, testUserPassword)
       await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
-      await provider
-        .given('the user is recreated', {
-          username: testUser,
-          password: testUserPassword
-        })
+
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, versionedFile)
       // re-upload the same file to create a new version
       await givenFileExists(provider, testUser, versionedFile, 'new content')

--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -39,7 +39,8 @@ describe('Main: Currently testing files management,', function () {
     givenFileIsMarkedFavorite,
     givenSystemTagExists,
     givenTagIsAssignedToFile,
-    givenFolderExists
+    givenFolderExists,
+    givenProviderBaseUrlIsReturned
   } = require('./helpers/providerStateHelper')
   const validAuthHeaders = { authorization: getAuthHeaders(testUser, testUserPassword) }
 
@@ -597,7 +598,7 @@ describe('Main: Currently testing files management,', function () {
 
       await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, encodedSrcFilePath)
-      provider.given('provider base url is returned')
+      await givenProviderBaseUrlIsReturned(provider)
       await moveFileInteraction(
         provider,
         'same name',
@@ -640,8 +641,8 @@ describe('Main: Currently testing files management,', function () {
       await givenUserExists(provider, testUser)
       await givenFolderExists(provider, testUser, desFolder)
       await givenFileExists(provider, testUser, srcFilePath)
+      await givenProviderBaseUrlIsReturned(provider)
       await provider
-        .given('provider base url is returned')
         .uponReceiving(`as '${testUser}', a MOVE request to move existent file into different folder`)
         .withRequest({
           method: 'MOVE',
@@ -678,8 +679,8 @@ describe('Main: Currently testing files management,', function () {
         provider, testUser, testUserPassword
       )
       await givenUserExists(provider, testUser, testUserPassword)
+      await givenProviderBaseUrlIsReturned(provider)
       await provider
-        .given('provider base url is returned')
         .uponReceiving(`as '${testUser}', a MOVE request to move non existent file`)
         .withRequest({
           method: 'MOVE',
@@ -721,8 +722,8 @@ describe('Main: Currently testing files management,', function () {
       )
       await givenUserExists(provider, testUser, testUserPassword)
       await givenFileExists(provider, testUser, file)
+      await givenProviderBaseUrlIsReturned(provider)
       await provider
-        .given('provider base url is returned')
         .uponReceiving(`as '${testUser}', a COPY request to copy existent file into same folder, same name`)
         .withRequest({
           method: 'COPY',
@@ -761,9 +762,10 @@ describe('Main: Currently testing files management,', function () {
       await getCurrentUserInformationInteraction(
         provider, testUser, testUserPassword
       )
+
       await givenUserExists(provider, testUser, testUserPassword)
+      await givenProviderBaseUrlIsReturned(provider)
       await provider
-        .given('provider base url is returned')
         .uponReceiving(`as '${testUser}', a COPY request to copy non existent file`)
         .withRequest({
           method: 'COPY',
@@ -1095,7 +1097,7 @@ describe('Main: Currently testing files management,', function () {
 
       await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, srcFilePath)
-      provider.given('provider base url is returned')
+      await givenProviderBaseUrlIsReturned(provider)
       await moveFileInteraction(
         provider,
         'different name',
@@ -1137,8 +1139,8 @@ describe('Main: Currently testing files management,', function () {
 
       await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, srcFilePath)
+      await givenProviderBaseUrlIsReturned(provider)
       await provider
-        .given('provider base url is returned')
         .uponReceiving(`as '${testUser}', a COPY request to copy existent file into same folder, different name`)
         .withRequest({
           method: 'COPY',
@@ -1182,8 +1184,8 @@ describe('Main: Currently testing files management,', function () {
       await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, srcFilePath)
       await givenFolderExists(provider, testUser, `${testFolder}/subdir/`)
+      await givenProviderBaseUrlIsReturned(provider)
       await provider
-        .given('provider base url is returned')
         .uponReceiving(`as '${testUser}', a COPY request to copy existent file into different folder`)
         .withRequest({
           method: 'COPY',

--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -107,7 +107,7 @@ describe('Main: Currently testing files management,', function () {
       }
     }
 
-    await givenUserExists(provider, testUser, testUserPassword)
+    await givenUserExists(provider, testUser)
     if (parentFolder !== nonExistentFile) {
       for (let i = 0; i < files.length; i++) {
         await givenFileExists(provider, testUser, parentFolder + '/' + files[i])
@@ -185,7 +185,7 @@ describe('Main: Currently testing files management,', function () {
   }
 
   const favoriteFileInteraction = async (provider, value, file) => {
-    await givenUserExists(provider, testUser, testUserPassword)
+    await givenUserExists(provider, testUser)
     await givenFileExists(provider, testUser, file)
     return provider.uponReceiving(`as '${testUser}', a PROPPATCH request to ${value === true ? 'favorite' : 'unfavorite'} a file`)
       .withRequest({
@@ -678,7 +678,7 @@ describe('Main: Currently testing files management,', function () {
       await getCurrentUserInformationInteraction(
         provider, testUser, testUserPassword
       )
-      await givenUserExists(provider, testUser, testUserPassword)
+      await givenUserExists(provider, testUser)
       await givenProviderBaseUrlIsReturned(provider)
       await provider
         .uponReceiving(`as '${testUser}', a MOVE request to move non existent file`)
@@ -720,7 +720,7 @@ describe('Main: Currently testing files management,', function () {
       await getCurrentUserInformationInteraction(
         provider, testUser, testUserPassword
       )
-      await givenUserExists(provider, testUser, testUserPassword)
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, file)
       await givenProviderBaseUrlIsReturned(provider)
       await provider
@@ -763,7 +763,7 @@ describe('Main: Currently testing files management,', function () {
         provider, testUser, testUserPassword
       )
 
-      await givenUserExists(provider, testUser, testUserPassword)
+      await givenUserExists(provider, testUser)
       await givenProviderBaseUrlIsReturned(provider)
       await provider
         .uponReceiving(`as '${testUser}', a COPY request to copy non existent file`)
@@ -803,7 +803,7 @@ describe('Main: Currently testing files management,', function () {
         provider, testUser, testUserPassword
       )
       const file = `${testFolder}/${testFile}`
-      await givenUserExists(provider, testUser, testUserPassword)
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, file)
       await provider
         .uponReceiving(`as '${testUser}', a PROPFIND request to path for fileId`)
@@ -869,7 +869,7 @@ describe('Main: Currently testing files management,', function () {
         provider, testUser, testUserPassword
       )
       const file = `${testFolder}/${testFile}`
-      await givenUserExists(provider, testUser, testUserPassword)
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, file)
       await provider
         .uponReceiving(`as '${testUser}', a PROPFIND request to file info, fileId`)
@@ -1015,7 +1015,7 @@ describe('Main: Currently testing files management,', function () {
       await getCurrentUserInformationInteraction(
         provider, testUser, testUserPassword
       )
-      await givenUserExists(provider, testUser, testUserPassword)
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, testFile)
       await tusSupportRequest(provider)
 
@@ -1042,7 +1042,7 @@ describe('Main: Currently testing files management,', function () {
         provider, testUser, testUserPassword
       )
       const dir = 'somedir'
-      await givenUserExists(provider, testUser, testUserPassword)
+      await givenUserExists(provider, testUser)
       await givenFolderExists(provider, testUser, dir)
       await givenFileExists(provider, testUser, dir + '/' + testFile)
       await tusSupportRequest(provider, true, dir)
@@ -1066,7 +1066,7 @@ describe('Main: Currently testing files management,', function () {
       await getCurrentUserInformationInteraction(
         provider, testUser, testUserPassword
       )
-      await givenUserExists(provider, testUser, testUserPassword)
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, testFile)
       await tusSupportRequest(provider, false)
 
@@ -1275,7 +1275,7 @@ describe('Main: Currently testing files management,', function () {
       await getCurrentUserInformationInteraction(
         provider, testUser, testUserPassword
       )
-      await givenUserExists(provider, testUser, testUserPassword)
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, file)
       await givenFileIsMarkedFavorite(provider, testUser, testUserPassword, file)
       await provider
@@ -1345,7 +1345,7 @@ describe('Main: Currently testing files management,', function () {
       await getCurrentUserInformationInteraction(
         provider, testUser, testUserPassword
       )
-      await givenUserExists(provider, testUser, testUserPassword)
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, file)
       await provider
         .uponReceiving(`as '${testUser}', a REPORT request to get favorite file when there are no favorites`)
@@ -1411,7 +1411,7 @@ describe('Main: Currently testing files management,', function () {
 
       const filename = 'abc.txt'
       const filePath = testFolder + '/' + filename
-      await givenUserExists(provider, testUser, testUserPassword)
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, filePath)
       await provider
         .uponReceiving(`as '${testUser}', a REPORT request to search in the instance`)
@@ -1524,7 +1524,7 @@ describe('Main: Currently testing files management,', function () {
         provider, testUser, testUserPassword
       )
 
-      await givenUserExists(provider, testUser, testUserPassword)
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, testFile)
       await givenSystemTagExists(provider, testUser, testUserPassword, newTagName)
       await givenTagIsAssignedToFile(provider, testUser, testUserPassword, testFile, newTagName)
@@ -1575,7 +1575,7 @@ describe('Main: Currently testing files management,', function () {
       )
 
       const tagToCreate = newTagName + Date.now()
-      await givenUserExists(provider, testUser, testUserPassword)
+      await givenUserExists(provider, testUser)
       await provider
         .uponReceiving(`as '${testUser}', a POST request to create tag`)
         .withRequest({
@@ -1619,7 +1619,7 @@ describe('Main: Currently testing files management,', function () {
         provider, testUser, testUserPassword
       )
 
-      await givenUserExists(provider, testUser, testUserPassword)
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, testFile)
       await givenSystemTagExists(provider, testUser, testUserPassword, newTagName)
       await provider

--- a/tests/filesTest.js
+++ b/tests/filesTest.js
@@ -594,11 +594,8 @@ describe('Main: Currently testing files management,', function () {
       await getCurrentUserInformationInteraction(
         provider, testUser, testUserPassword
       )
-      provider
-        .given('the user is recreated', {
-          username: testUser,
-          password: testUserPassword
-        })
+
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, encodedSrcFilePath)
       provider.given('provider base url is returned')
       await moveFileInteraction(
@@ -639,11 +636,8 @@ describe('Main: Currently testing files management,', function () {
       const desFolder = 'testFolder2'
       const desFilePath = `${desFolder}/中文.txt`
       const destinationWebDavPath = `remote.php/dav/files/${testUser}/${encodeURI(desFilePath)}`
-      await provider
-        .given('the user is recreated', {
-          username: testUser,
-          password: testUserPassword
-        })
+
+      await givenUserExists(provider, testUser)
       await givenFolderExists(provider, testUser, desFolder)
       await givenFileExists(provider, testUser, srcFilePath)
       await provider
@@ -1098,11 +1092,8 @@ describe('Main: Currently testing files management,', function () {
       const srcFilePath = `${testFolder}/中文.txt`
       const desFilePath = `${testFolder}/中文123.txt`
       const destinationWebDavPath = `remote.php/dav/files/${testUser}/${testFolder}/${encodeURI('中文123.txt')}`
-      provider
-        .given('the user is recreated', {
-          username: testUser,
-          password: testUserPassword
-        })
+
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, srcFilePath)
       provider.given('provider base url is returned')
       await moveFileInteraction(
@@ -1143,11 +1134,8 @@ describe('Main: Currently testing files management,', function () {
       const srcFilePath = `${testFolder}/中文.txt`
       const desFilePath = `${testFolder}/中文123.txt`
       const destinationWebDavPath = `remote.php/dav/files/${testUser}/${testFolder}/${encodeURI('中文123.txt')}`
-      await provider
-        .given('the user is recreated', {
-          username: testUser,
-          password: testUserPassword
-        })
+
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, srcFilePath)
       await provider
         .given('provider base url is returned')
@@ -1190,11 +1178,8 @@ describe('Main: Currently testing files management,', function () {
       const srcFilePath = `${testFolder}/中文.txt`
       const desFilePath = `${testFolder}/subdir/中文123.txt`
       const destinationWebDavPath = `remote.php/dav/files/${testUser}/${testFolder}/subdir/${encodeURI('中文123.txt')}`
-      await provider
-        .given('the user is recreated', {
-          username: testUser,
-          password: testUserPassword
-        })
+
+      await givenUserExists(provider, testUser)
       await givenFileExists(provider, testUser, srcFilePath)
       await givenFolderExists(provider, testUser, `${testFolder}/subdir/`)
       await provider

--- a/tests/groupTest.js
+++ b/tests/groupTest.js
@@ -4,7 +4,7 @@ describe('Main: Currently testing group management,', function () {
   const config = require('./config/config.json')
   const {
     admin: { username: adminUsername },
-    testUser1: { username: testUser, password: testUserPassword }
+    testUser1: { username: testUser }
   } = require('./config/users.json')
   let provider = null
 
@@ -20,7 +20,8 @@ describe('Main: Currently testing group management,', function () {
 
   const {
     givenGroupExists,
-    givenGroupDoesNotExist
+    givenGroupDoesNotExist,
+    givenUserExists
   } = require('./helpers/providerStateHelper')
 
   async function getGroupsInteraction (provider) {
@@ -140,8 +141,8 @@ describe('Main: Currently testing group management,', function () {
     await getCurrentUserInformationInteraction(provider)
 
     await givenGroupExists(provider, config.testGroup)
+    await givenUserExists(provider, testUser)
     await provider
-      .given('the user is recreated', { username: testUser, password: testUserPassword })
       .given('user is added to group', { username: testUser, groupName: config.testGroup })
       .uponReceiving(`as '${adminUsername}', a GET request to get all members of existing group`)
       .withRequest({

--- a/tests/helpers/pactHelper.js
+++ b/tests/helpers/pactHelper.js
@@ -16,7 +16,8 @@ const OwnCloud = require('../../src/owncloud')
 const {
   givenGroupExists,
   givenFolderExists,
-  givenFileExists
+  givenFileExists,
+  givenUserExists
 } = require('../helpers/providerStateHelper')
 
 const accessControlAllowHeaders = 'OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With'
@@ -190,7 +191,7 @@ const getContentsOfFileInteraction = async (
   password = adminPassword
 ) => {
   if (user !== adminUsername) {
-    provider.given('the user is recreated', { username: user, password: password })
+    await givenUserExists(provider, user)
   }
   if (file !== config.nonExistentFile) {
     await givenFileExists(provider, user, file)
@@ -218,7 +219,7 @@ const deleteResourceInteraction = async (
 ) => {
   let response
   if (user !== adminUsername) {
-    provider.given('the user is recreated', { username: user, password: password })
+    await givenUserExists(provider, user)
   }
   if (resource.includes('nonExistent')) {
     response = {
@@ -256,7 +257,7 @@ async function getCurrentUserInformationInteraction (
 ) {
   const displayName = getDisplayNameForUser(user)
   if (user !== adminUsername) {
-    provider.given('the user is recreated', { username: user, password: password })
+    await givenUserExists(provider, user)
   }
   await provider
     .uponReceiving(`as '${user}', a GET to get current user information`)
@@ -289,7 +290,7 @@ async function getCapabilitiesInteraction (
   provider, user = adminUsername, password = adminPassword
 ) {
   if (user !== adminUsername) {
-    provider.given('the user is recreated', { username: user, password: password })
+    await givenUserExists(provider, user)
   }
   await provider
     .uponReceiving(`as '${user}', a GET request to get capabilities with valid authentication`)
@@ -450,7 +451,7 @@ const createFolderInteraction = async function (
   provider, folderName, user = adminUsername, password = adminPassword
 ) {
   if (user !== adminUsername) {
-    provider.given('the user is recreated', { username: user, password: password })
+    await givenUserExists(provider, user)
   }
 
   // if a subfolder is to be created the higher level folder needs to be created in the provider state
@@ -481,7 +482,7 @@ const createFolderInteraction = async function (
 const updateFileInteraction = async function (provider, file, user = adminUsername, password = adminPassword
 ) {
   if (user !== adminUsername) {
-    provider.given('the user is recreated', { username: user, password: password })
+    await givenUserExists(provider, user)
   }
   if (!file.includes('nonExistent')) {
     await givenFolderExists(provider, user, path.dirname(file))

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -313,6 +313,14 @@ const givenTagIsAssignedToFile = (provider, username, password, fileName, tagNam
     .given('a tag is assigned to a file', { username, password, fileName, tagName })
 }
 
+/**
+ *
+ * @param {object} provider
+ */
+const givenProviderBaseUrlIsReturned = (provider) => {
+  return provider.given('provider base url is returned')
+}
+
 module.exports = {
   givenUserExists,
   givenUserDoesNotExist,
@@ -328,5 +336,6 @@ module.exports = {
   givenResourceIsShared,
   givenFileIsMarkedFavorite,
   givenSystemTagExists,
-  givenTagIsAssignedToFile
+  givenTagIsAssignedToFile,
+  givenProviderBaseUrlIsReturned
 }

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -16,6 +16,16 @@ const givenUserExists = (provider, username) => {
 }
 
 /**
+ * provider state: deletes a given user
+ *
+ * @param {object} provider
+ * @param {string} username
+ */
+const givenUserDoesNotExist = (provider, username) => {
+  return provider.given('user doesn\'t exist', { username })
+}
+
+/**
  * provider state: creates a given group
  *
  * @param {object} provider
@@ -305,6 +315,7 @@ const givenTagIsAssignedToFile = (provider, username, password, fileName, tagNam
 
 module.exports = {
   givenUserExists,
+  givenUserDoesNotExist,
   givenGroupExists,
   givenGroupDoesNotExist,
   givenFileExists,

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -9,11 +9,10 @@ const SHARE_TYPE = Object.freeze({
  *
  * @param {object} provider
  * @param {string} username user to create
- * @param {sring} password
  */
-const givenUserExists = (provider, username, password) => {
+const givenUserExists = (provider, username) => {
   return provider
-    .given('the user is recreated', { username, password })
+    .given('the user is recreated', { username })
 }
 
 /**

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -63,6 +63,17 @@ const givenFolderExists = (provider, username, resource) => {
 }
 
 /**
+ * provider state: delete a given resource
+ *
+ * @param {object} provider
+ * @param {string} username
+ * @param {string} resource
+ */
+const givenResourceIsDeleted = (provider, username, resource) => {
+  return provider.given('resource is deleted', { username, resourcePath: resource })
+}
+
+/**
  * provider state: creates a user share
  *
  * @param {object} provider
@@ -299,6 +310,7 @@ module.exports = {
   givenGroupDoesNotExist,
   givenFileExists,
   givenFolderExists,
+  givenResourceIsDeleted,
   givenUserShareExists,
   givenGroupShareExists,
   givenPublicShareExists,

--- a/tests/helpers/webdavHelper.js
+++ b/tests/helpers/webdavHelper.js
@@ -64,11 +64,10 @@ const createFile = function (user, fileName, contents = '') {
  * Delete a file or folder using webDAV api.
  *
  * @param {string} user
- * @param {string} password
  * @param {string} itemName
  * @returns {*} result of the fetch request
  */
-const deleteItem = function (user, password, itemName) {
+const deleteItem = function (user, itemName) {
   return httpHelper.delete(createDavPath(user, itemName), null, null, user)
 }
 
@@ -123,7 +122,7 @@ const getSignKey = function (username, password) {
  * @param {string} type
  * @param {number} folderDepth
  */
-const propfind = function (path, userId, password, properties, type = 'files', folderDepth = '1') {
+const propfind = function (path, userId, properties, type = 'files', folderDepth = '1') {
   let propertyBody = ''
   properties.map(prop => {
     propertyBody += `<${prop}/>`
@@ -160,14 +159,12 @@ const propfind = function (path, userId, password, properties, type = 'files', f
  * },...]
  *
  * @param {string} user
- * @param {string} password
  * @param {number|string} depth
  */
-const getTrashBinElements = function (user, password, depth = '1') {
+const getTrashBinElements = function (user, depth = '1') {
   const str = propfind(
     '/',
     user,
-    password,
     [
       'oc:trashbin-original-filename',
       'oc:trashbin-original-location',

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -153,16 +153,16 @@ describe('provider testing', () => {
       if (!setup) {
         return
       }
-      const dirname = parameters.resourcePath
-      const result = deleteItem(parameters.username, parameters.password, dirname)
+      const resourcePath = parameters.resourcePath
+      const result = deleteItem(parameters.username, resourcePath)
       chai.assert.isBelow(
-        result.status, 300, `Deleting path '${dirname}' failed`
+        result.status, 300, `Deleting path '${resourcePath}' failed`
       )
-      const items = getTrashBinElements(parameters.username, parameters.password)
+      const items = getTrashBinElements(parameters.username)
       let found = false
       let id
       for (const item of items) {
-        if (item.originalLocation === parameters.resourcePath) {
+        if (item.originalLocation === resourcePath) {
           found = true
           const parts = item.href.split('/').filter(el => el !== '')
           id = parts[parts.length - 1]

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -55,8 +55,8 @@ describe('oc.publicFiles', function () {
     if (password) {
       headers = getPublicLinkAuthHeader(password)
     }
-    await provider
-      .given('the user is recreated', { username: testUser, password: testUserPassword })
+
+    await givenUserExists(provider, testUser)
     await givenFolderExists(provider, testUser, testFolder)
     return provider
       .given('resource is shared', {
@@ -103,8 +103,8 @@ describe('oc.publicFiles', function () {
         ...getPublicLinkAuthHeader(password)
       }
     }
-    await provider
-      .given('the user is recreated', { username: testUser, password: testUserPassword })
+
+    await givenUserExists(provider, testUser)
     await givenFolderExists(provider, testUser, testFolder)
     await provider
       .given('resource is shared', {
@@ -524,9 +524,10 @@ describe('oc.publicFiles', function () {
           const provider = createProvider()
           await getCapabilitiesInteraction(provider, testUser, testUserPassword)
           await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
+
           await provider
             .given('provider base url is returned')
-            .given('the user is recreated', { username: testUser, password: testUserPassword })
+          await givenUserExists(provider, testUser)
           await givenFolderExists(provider, testUser, testFolder)
           if (data.shareParams.password) {
             await givenPublicShareExists(
@@ -576,9 +577,10 @@ describe('oc.publicFiles', function () {
           const provider = createProvider()
           await getCapabilitiesInteraction(provider, testUser, testUserPassword)
           await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
+
           await provider
             .given('provider base url is returned')
-            .given('the user is recreated', { username: testUser, password: testUserPassword })
+          await givenUserExists(provider, testUser)
           await givenFolderExists(provider, testUser, testFolder)
           if (data.shareParams.password) {
             await givenPublicShareExists(
@@ -625,9 +627,10 @@ describe('oc.publicFiles', function () {
           const provider = createProvider()
           await getCapabilitiesInteraction(provider, testUser, testUserPassword)
           await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
+
           await provider
             .given('provider base url is returned')
-            .given('the user is recreated', { username: testUser, password: testUserPassword })
+          await givenUserExists(provider, testUser)
           await givenFolderExists(provider, testUser, testFolder)
           if (data.shareParams.password) {
             await givenPublicShareExists(

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -35,7 +35,8 @@ describe('oc.publicFiles', function () {
     givenUserExists,
     givenPublicShareExists,
     givenFolderExists,
-    givenFileExists
+    givenFileExists,
+    givenProviderBaseUrlIsReturned
   } = require('./helpers/providerStateHelper')
 
   const publicLinkShareTokenPath = MatchersV3.fromProviderState(
@@ -525,8 +526,7 @@ describe('oc.publicFiles', function () {
           await getCapabilitiesInteraction(provider, testUser, testUserPassword)
           await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
 
-          await provider
-            .given('provider base url is returned')
+          await givenProviderBaseUrlIsReturned(provider)
           await givenUserExists(provider, testUser)
           await givenFolderExists(provider, testUser, testFolder)
           if (data.shareParams.password) {
@@ -578,8 +578,7 @@ describe('oc.publicFiles', function () {
           await getCapabilitiesInteraction(provider, testUser, testUserPassword)
           await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
 
-          await provider
-            .given('provider base url is returned')
+          await givenProviderBaseUrlIsReturned(provider)
           await givenUserExists(provider, testUser)
           await givenFolderExists(provider, testUser, testFolder)
           if (data.shareParams.password) {
@@ -628,8 +627,7 @@ describe('oc.publicFiles', function () {
           await getCapabilitiesInteraction(provider, testUser, testUserPassword)
           await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
 
-          await provider
-            .given('provider base url is returned')
+          await givenProviderBaseUrlIsReturned(provider)
           await givenUserExists(provider, testUser)
           await givenFolderExists(provider, testUser, testFolder)
           if (data.shareParams.password) {

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -235,7 +235,7 @@ describe('oc.publicFiles', function () {
             }
             const status = shallGrantAccess ? 207 : 401
 
-            await givenUserExists(provider, testUser, testUserPassword)
+            await givenUserExists(provider, testUser)
             for (let fileNum = 0; fileNum < testFiles.length; fileNum++) {
               await givenFileExists(provider, testUser, testFolder + '/' + testFiles[fileNum])
             }
@@ -365,7 +365,7 @@ describe('oc.publicFiles', function () {
               }
             }
 
-            await givenUserExists(provider, testUser, testUserPassword)
+            await givenUserExists(provider, testUser)
             await givenFileExists(provider, testUser, testFolder + '/' + testFiles[2])
             if (data.shareParams.password) {
               await givenPublicShareExists(provider, testUser, testUserPassword, testFolder, { password: data.shareParams.password })
@@ -679,7 +679,7 @@ describe('oc.publicFiles', function () {
           await getCapabilitiesInteraction(provider, testUser, testUserPassword)
           await getCurrentUserInformationInteraction(provider, testUser, testUserPassword)
 
-          await givenUserExists(provider, testUser, testUserPassword)
+          await givenUserExists(provider, testUser)
           await givenFolderExists(provider, testUser, testFolder)
           if (data.shareParams.password) {
             await givenPublicShareExists(

--- a/tests/requestsOcsTest.js
+++ b/tests/requestsOcsTest.js
@@ -3,7 +3,7 @@ import { MatchersV3 } from '@pact-foundation/pact/v3'
 describe('Main: Currently testing low level OCS', function () {
   const {
     admin: { username: adminUsername },
-    testUser1: { username: testUser, password: testUserPassword }
+    testUser1: { username: testUser }
   } = require('./config/users.json')
 
   const {
@@ -13,6 +13,8 @@ describe('Main: Currently testing low level OCS', function () {
     createOwncloud,
     createProvider
   } = require('./helpers/pactHelper.js')
+
+  const { givenUserExists } = require('./helpers/providerStateHelper')
 
   it('checking : capabilities', async function () {
     const provider = createProvider()
@@ -105,8 +107,9 @@ describe('Main: Currently testing low level OCS', function () {
     const provider = createProvider(false, true)
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)
+
+    await givenUserExists(provider, testUser)
     await provider
-      .given('the user is recreated', { username: testUser, password: testUserPassword })
       .uponReceiving(`as '${adminUsername}', a PUT request to update a user using OCS`)
       .withRequest({
         method: 'PUT',

--- a/tests/shareRecipientTest.js
+++ b/tests/shareRecipientTest.js
@@ -4,7 +4,7 @@ describe('Main: Currently testing share recipient,', function () {
   var config = require('./config/config.json')
   const {
     testUser1: { username: sharer, password: sharerPassword, displayname: sharerDisplayname },
-    testUser2: { username: receiver, password: receiverPassword, displayname: receiverDisplayname }
+    testUser2: { username: receiver, displayname: receiverDisplayname }
   } = require('./config/users.json')
 
   const {
@@ -15,14 +15,15 @@ describe('Main: Currently testing share recipient,', function () {
     createProvider
   } = require('./helpers/pactHelper.js')
 
-  const { givenGroupExists } = require('./helpers/providerStateHelper')
+  const {
+    givenGroupExists,
+    givenUserExists
+  } = require('./helpers/providerStateHelper')
 
   const getShareesInteraction = async (provider, folder = config.testFolder) => {
-    provider
-      .given('the user is recreated', { username: sharer, password: sharerPassword })
-      .given('the user is recreated', { username: receiver, password: receiverPassword })
+    await givenUserExists(provider, sharer)
+    await givenUserExists(provider, receiver)
     await givenGroupExists(provider, config.testGroup)
-
     return provider
       .uponReceiving(`as '${sharer}', a GET request to get share recipients (both users and groups)`)
       .withRequest({

--- a/tests/sharingTest.js
+++ b/tests/sharingTest.js
@@ -29,7 +29,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
   } = require('./config/config.json')
   const {
     testUser1: { username: sharer, password: sharerPassword },
-    testUser2: { username: sharee, password: shareePassword }
+    testUser2: { username: sharee }
   } = require('./config/users.json')
 
   const {
@@ -72,7 +72,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
     resourceType = 'file'
   ) {
     const { shareId, shareToken } = getShareIdToken(resource, resourceType)
-    await givenUserExists(provider, sharer, sharerPassword)
+    await givenUserExists(provider, sharer)
     await givenFileFolderIsCreated(provider, sharer, sharerPassword, resource, resourceType)
     await givenResourceIsShared(provider, sharer, sharerPassword, resource, shareType, shareWith)
 
@@ -108,10 +108,10 @@ describe('Main: Currently testing file/folder sharing,', function () {
   }
 
   const getSharesInteraction = async function (provider, resource, resourceType = 'file') {
-    await givenUserExists(provider, sharer, sharerPassword)
+    await givenUserExists(provider, sharer)
     await givenFileFolderIsCreated(provider, sharer, sharerPassword, resource, resourceType)
 
-    await givenUserExists(provider, sharee, shareePassword)
+    await givenUserExists(provider, sharee)
     await givenGroupExists(provider, testGroup)
     // shares file/folder with user, group and public link
     await givenPublicShareExists(provider, sharer, sharerPassword, resource)
@@ -168,7 +168,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
     resourceType
   ) => {
     const { shareId, shareToken } = getShareIdToken(resource, resourceType)
-    await givenUserExists(provider, sharer, sharerPassword)
+    await givenUserExists(provider, sharer)
     await givenFileFolderIsCreated(provider, sharer, sharerPassword, resource, resourceType)
     await givenResourceIsShared(provider, sharer, sharerPassword, resource, shareType, shareWith)
     resource = '/' + resource
@@ -212,7 +212,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
   ) => {
     const { shareId, shareToken } = getShareIdToken(resource, resourceType)
     let permissions = 1
-    await givenUserExists(provider, sharer, sharerPassword)
+    await givenUserExists(provider, sharer)
     await givenFileFolderIsCreated(provider, sharer, sharerPassword, resource, resourceType)
     await givenResourceIsShared(provider, sharer, sharerPassword, resource, shareType, shareWith)
 
@@ -742,7 +742,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
       // [oCIS] Trying to share non-existing file responds with empty body
       // https://github.com/owncloud/ocis/issues/1799
       async function linkSharePOSTNonExistentFile (provider) {
-        await givenUserExists(provider, sharer, sharerPassword)
+        await givenUserExists(provider, sharer)
         return provider.uponReceiving(`as '${sharer}', a POST request to create a public link share with non-existent file`)
           .withRequest({
             method: 'POST',
@@ -770,7 +770,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
       // [oCIS] Trying to share non-existing file responds with empty body
       // https://github.com/owncloud/ocis/issues/1799
       async function groupSharePOSTNonExistentFile (provider) {
-        await givenUserExists(provider, sharer, sharerPassword)
+        await givenUserExists(provider, sharer)
         await givenGroupExists(provider, testGroup)
         return provider.uponReceiving(`as '${sharer}', a POST request to share non-existent file with existing group`)
           .withRequest({
@@ -797,7 +797,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
       // [oCIS] Different responses in oCIS and oC10
       // https://github.com/owncloud/ocis/issues/1777
       async function shareGETNonExistentFile (provider, name = '') {
-        await givenUserExists(provider, sharer, sharerPassword)
+        await givenUserExists(provider, sharer)
         return provider.uponReceiving(`as '${sharer}', a GET request to get share information of non-existent file '${name}'`)
           .withRequest({
             method: 'GET',
@@ -820,7 +820,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
           })
       }
       async function shareGETExistingNonSharedFile (provider, name, fileName) {
-        await givenUserExists(provider, sharer, sharerPassword)
+        await givenUserExists(provider, sharer)
         await givenFileFolderIsCreated(provider, sharer, sharerPassword, fileName)
         return provider
           .uponReceiving(`as '${sharer}', a GET request to get share information of existent but non-shared file '${name}'`)
@@ -868,8 +868,8 @@ describe('Main: Currently testing file/folder sharing,', function () {
           })
       }
       async function sharePOSTRequestWithExpirationDateSet (provider, fileEncoded, file) {
-        await givenUserExists(provider, sharer, sharerPassword)
-        await givenUserExists(provider, sharee, shareePassword)
+        await givenUserExists(provider, sharer)
+        await givenUserExists(provider, sharee)
         await givenFileFolderIsCreated(provider, sharer, sharerPassword, file)
         return provider
           .uponReceiving(`as '${sharer}', a POST request to share a file '${file}' to user with expiration date set`)

--- a/tests/sharingWithAttributesTest.js
+++ b/tests/sharingWithAttributesTest.js
@@ -4,7 +4,7 @@ describe('oc.shares', function () {
   const { testFile } = require('./config/config.json')
   const {
     testUser1: { username: sharer, password: sharerPassword },
-    testUser2: { username: receiver, password: receiverPassword }
+    testUser2: { username: receiver }
   } = require('./config/users.json')
 
   const {
@@ -19,7 +19,10 @@ describe('oc.shares', function () {
     getAuthHeaders
   } = require('./helpers/pactHelper.js')
 
-  const { givenFileExists } = require('./helpers/providerStateHelper')
+  const {
+    givenFileExists,
+    givenUserExists
+  } = require('./helpers/providerStateHelper')
 
   const shareAttributes = {
     attributes: [
@@ -38,9 +41,8 @@ describe('oc.shares', function () {
   }
 
   const sharingWithAttributes = async (provider) => {
-    await provider
-      .given('the user is recreated', { username: sharer, password: sharerPassword })
-      .given('the user is recreated', { username: receiver, password: receiverPassword })
+    await givenUserExists(provider, sharer)
+    await givenUserExists(provider, receiver)
     await givenFileExists(provider, sharer, testFile, 'a test file')
     return provider
       .uponReceiving(`as '${sharer}', a POST request to share a file with permissions in attributes`)

--- a/tests/signedUrlIntegrationTest.js
+++ b/tests/signedUrlIntegrationTest.js
@@ -18,11 +18,11 @@ describe('Signed urls', function () {
     createProvider
   } = require('./helpers/pactHelper.js')
 
-  const { givenFileExists } = require('./helpers/providerStateHelper')
+  const { givenFileExists, givenUserExists } = require('./helpers/providerStateHelper')
 
-  const getSigningKeyInteraction = (provider, username, password) => {
+  const getSigningKeyInteraction = async (provider, username, password) => {
+    await givenUserExists(provider, username)
     return provider
-      .given('the user is recreated', { username: username, password: password })
       .uponReceiving(`as '${username}', a GET request to get a signing key`)
       .withRequest({
         method: 'GET',

--- a/tests/userTest.js
+++ b/tests/userTest.js
@@ -16,20 +16,20 @@ describe('Main: Currently testing user management,', function () {
     deleteUserInteraction,
     createUserWithGroupMembershipInteraction,
     createOwncloud,
-    createProvider
-  } = require('./helpers/pactHelper.js')
-  const {
+    createProvider,
     validAdminAuthHeaders,
     xmlResponseHeaders,
     applicationFormUrlEncoded
   } = require('./helpers/pactHelper.js')
 
-  const { givenGroupExists } = require('./helpers/providerStateHelper')
+  const {
+    givenGroupExists,
+    givenUserExists
+  } = require('./helpers/providerStateHelper')
 
   const getUserInformationInteraction = async function (provider, requestName, username, responseBody) {
     if (username !== adminUsername && username !== config.nonExistentUser) {
-      await provider
-        .given('the user is recreated', { username: username, password: testUserPassword })
+      await givenUserExists(provider, username)
     }
     return provider
       .uponReceiving(`as '${adminUsername}', a GET request to ${requestName}`)
@@ -48,9 +48,9 @@ describe('Main: Currently testing user management,', function () {
       })
   }
 
-  const getUsersInteraction = function (provider, requestName, query, bodyData) {
+  const getUsersInteraction = async function (provider, requestName, query, bodyData) {
+    await givenUserExists(provider, testUser)
     return provider
-      .given('the user is recreated', { username: testUser, password: testUserPassword })
       .uponReceiving(`as '${adminUsername}', a GET request to ${requestName}`)
       .withRequest({
         method: 'GET',
@@ -75,8 +75,7 @@ describe('Main: Currently testing user management,', function () {
 
   const changeUserAttributeInteraction = async function (provider, requestName, username, requestBody, response) {
     if (username !== adminUsername && username !== config.nonExistentUser) {
-      await provider
-        .given('the user is recreated', { username: username, password: testUserPassword })
+      await givenUserExists(provider, username)
     }
 
     return provider
@@ -111,8 +110,7 @@ describe('Main: Currently testing user management,', function () {
       message = 'The requested user could not be found'
     }
     if (username !== adminUsername && username !== config.nonExistentUser) {
-      await provider
-        .given('the user is recreated', { username: username, password: testUserPassword })
+      await givenUserExists(provider, username)
     }
     if (group !== config.nonExistentGroup) {
       await givenGroupExists(provider, group)
@@ -154,8 +152,7 @@ describe('Main: Currently testing user management,', function () {
 
   const getGroupOfUserInteraction = async function (provider, requestName, username, responseBody) {
     if (username !== adminUsername && username !== config.nonExistentUser) {
-      await provider
-        .given('the user is recreated', { username: username, password: testUserPassword })
+      await givenUserExists(provider, username)
       await givenGroupExists(provider, config.testGroup)
       await provider.given('user is added to group', { username: username, groupName: config.testGroup })
     }
@@ -184,8 +181,7 @@ describe('Main: Currently testing user management,', function () {
       message = 'The requested user could not be found'
     }
     if (username !== adminUsername && username !== config.nonExistentUser) {
-      await provider
-        .given('the user is recreated', { username: username, password: testUserPassword })
+      await givenUserExists(provider, username)
     }
     if (group !== config.nonExistentGroup) {
       await givenGroupExists(provider, group)
@@ -223,8 +219,7 @@ describe('Main: Currently testing user management,', function () {
 
   const addUserToSubAdminGroupInteraction = async function (provider, requestName, username, group, responseOcsMeta) {
     if (username !== adminUsername && username !== config.nonExistentUser) {
-      await provider
-        .given('the user is recreated', { username: username, password: testUserPassword })
+      await givenUserExists(provider, username)
     }
     if (group !== config.nonExistentGroup) {
       await givenGroupExists(provider, group)
@@ -255,8 +250,7 @@ describe('Main: Currently testing user management,', function () {
 
   const getUsersSubAdminGroupsInteraction = async function (provider, requestName, username, responseBody) {
     if (username !== adminUsername && username !== config.nonExistentUser) {
-      await provider
-        .given('the user is recreated', { username: username, password: testUserPassword })
+      await givenUserExists(provider, username)
       await givenGroupExists(provider, config.testGroup)
       await provider.given('user is made group subadmin', { username: username, groupName: config.testGroup })
     }
@@ -619,11 +613,9 @@ describe('Main: Currently testing user management,', function () {
     const provider = createProvider(false, true)
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)
+
+    await givenUserExists(provider, testUser)
     await provider
-      .given(
-        'the user is recreated',
-        { username: testUser, password: testUserPassword }
-      )
       .uponReceiving(`as '${adminUsername}' a PUT request to enable an existing user`)
       .withRequest({
         headers: validAdminAuthHeaders,
@@ -658,11 +650,9 @@ describe('Main: Currently testing user management,', function () {
     const provider = createProvider(false, true)
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)
+
+    await givenUserExists(provider, testUser)
     await provider
-      .given(
-        'the user is recreated',
-        { username: testUser, password: testUserPassword }
-      )
       .uponReceiving(`as '${adminUsername}' a PUT request to disable an existing user`)
       .withRequest({
         headers: validAdminAuthHeaders,

--- a/tests/userTest.js
+++ b/tests/userTest.js
@@ -24,7 +24,8 @@ describe('Main: Currently testing user management,', function () {
 
   const {
     givenGroupExists,
-    givenUserExists
+    givenUserExists,
+    givenUserDoesNotExist
   } = require('./helpers/providerStateHelper')
 
   const getUserInformationInteraction = async function (provider, requestName, username, responseBody) {
@@ -486,7 +487,7 @@ describe('Main: Currently testing user management,', function () {
   // [oCIS] email is needed for oCIS to create users
   it('checking method : createUser with groups', async function () {
     const provider = createProvider(false, true)
-    await provider.given('user doesn\'t exist', { username: testUser })
+    await givenUserDoesNotExist(provider, testUser)
 
     await getCapabilitiesInteraction(provider)
     await getCurrentUserInformationInteraction(provider)


### PR DESCRIPTION
For the Provider side tests, we have stateHandlers for pre-conditions. We have used state handlers directly in most of the tests but we also have state helper functions exactly for that.
State handler:
https://github.com/owncloud/owncloud-sdk/blob/4116766b9f90e6283d34bbb8eda2baae2ffaf02b/tests/providerTest.js#L112-L120

helper function:
https://github.com/owncloud/owncloud-sdk/blob/4116766b9f90e6283d34bbb8eda2baae2ffaf02b/tests/helpers/providerStateHelper.js#L25-L28

In this PR, I have refactored the tests to use state helper functions.

### Related issues
part of #1086