### PR TITLE
Replace provider states with helper functions (p3)

### DIFF
--- a/tests/fileVersionTest.js
+++ b/tests/fileVersionTest.js
@@ -24,7 +24,8 @@ describe('Main: Currently testing file versions management,', function () {
   const {
     givenFileExists,
     givenUserExists,
-    givenProviderBaseUrlIsReturned
+    givenProviderBaseUrlIsReturned,
+    givenFileVersionLinkIsReturned
   } = require('./helpers/providerStateHelper')
 
   const mockServerBaseUrl = getMockServerBaseUrl()
@@ -138,14 +139,10 @@ describe('Main: Currently testing file versions management,', function () {
         versionedFile,
         fileInfo.versions[1].content
       )
-      return provider
+      await provider
         .given('the client waits', { delay: 2000 })
-        .given('file version link is returned', {
-          fileName: versionedFile,
-          username: testUser,
-          password: testUserPassword,
-          number: 1
-        })
+      await givenFileVersionLinkIsReturned(provider, testUser, versionedFile, 1)
+      return provider
         .uponReceiving(`as '${testUser}', a PROPFIND request to get file versions of existent file`)
         .withRequest({
           method: 'PROPFIND',
@@ -203,12 +200,7 @@ describe('Main: Currently testing file versions management,', function () {
         fileInfo.versions[1].content
       )
       await provider.given('the client waits', { delay: 2000 })
-        .given('file version link is returned', {
-          fileName: versionedFile,
-          username: testUser,
-          password: testUserPassword,
-          number: i + 1
-        })
+      await givenFileVersionLinkIsReturned(provider, testUser, versionedFile, i + 1)
       await provider
         .uponReceiving(`as '${testUser}', a GET request to get file version ${i} contents`)
         .withRequest({
@@ -267,13 +259,7 @@ describe('Main: Currently testing file versions management,', function () {
       await givenFileExists(provider, testUser, versionedFile)
       // re-upload the same file to create a new version
       await givenFileExists(provider, testUser, versionedFile, 'new content')
-      await provider
-        .given('file version link is returned', {
-          fileName: versionedFile,
-          username: testUser,
-          password: testUserPassword,
-          number: 1
-        })
+      await givenFileVersionLinkIsReturned(provider, testUser, versionedFile, 1)
       await givenProviderBaseUrlIsReturned(provider)
       await provider
         .uponReceiving(`as '${testUser}', a COPY request to restore file versions`)

--- a/tests/groupTest.js
+++ b/tests/groupTest.js
@@ -21,7 +21,8 @@ describe('Main: Currently testing group management,', function () {
   const {
     givenGroupExists,
     givenGroupDoesNotExist,
-    givenUserExists
+    givenUserExists,
+    givenUserIsAddedToGroup
   } = require('./helpers/providerStateHelper')
 
   async function getGroupsInteraction (provider) {
@@ -142,8 +143,8 @@ describe('Main: Currently testing group management,', function () {
 
     await givenGroupExists(provider, config.testGroup)
     await givenUserExists(provider, testUser)
+    await givenUserIsAddedToGroup(provider, testUser, config.testGroup)
     await provider
-      .given('user is added to group', { username: testUser, groupName: config.testGroup })
       .uponReceiving(`as '${adminUsername}', a GET request to get all members of existing group`)
       .withRequest({
         method: 'GET',

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -347,6 +347,18 @@ const givenUserIsMadeGroupSubadmin = (provider, username, groupName) => {
   })
 }
 
+/**
+ * @param {object} provider
+ * @param {string} username
+ * @param {string} groupName
+ */
+const givenUserIsAddedToGroup = (provider, username, groupName) => {
+  return provider.given('user is added to group', {
+    username,
+    groupName
+  })
+}
+
 module.exports = {
   givenUserExists,
   givenUserDoesNotExist,
@@ -365,5 +377,6 @@ module.exports = {
   givenTagIsAssignedToFile,
   givenProviderBaseUrlIsReturned,
   givenFileVersionLinkIsReturned,
-  givenUserIsMadeGroupSubadmin
+  givenUserIsMadeGroupSubadmin,
+  givenUserIsAddedToGroup
 }

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -345,6 +345,18 @@ const givenUserIsAddedToGroup = (provider, username, groupName) => {
   })
 }
 
+/**
+ * @param {object} provider
+ * @param {string} folderName
+ * @param {string} password
+ */
+const givenFolderExistsInLastPublicShare = (provider, folderName, password) => {
+  return provider.given('folder exists in last shared public share', {
+    folderName,
+    password
+  })
+}
+
 module.exports = {
   givenUserExists,
   givenUserDoesNotExist,
@@ -364,5 +376,6 @@ module.exports = {
   givenProviderBaseUrlIsReturned,
   givenFileVersionLinkIsReturned,
   givenUserIsMadeGroupSubadmin,
-  givenUserIsAddedToGroup
+  givenUserIsAddedToGroup,
+  givenFolderExistsInLastPublicShare
 }

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -177,11 +177,10 @@ const givenPublicShareExists = (
  *
  * @param {object} provider
  * @param {string} username
- * @param {string} password
  * @param {string} resource
  * @param {string} resourceType
  */
-const givenFileFolderIsCreated = (provider, username, password, resource, resourceType) => {
+const givenFileFolderIsCreated = (provider, username, resource, resourceType) => {
   if (resourceType === 'folder') {
     return givenFolderExists(provider, username, resource)
   } else {

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -335,6 +335,18 @@ const givenFileVersionLinkIsReturned = (provider, username, fileName, number) =>
   })
 }
 
+/**
+ * @param {object} provider
+ * @param {string} username
+ * @param {string} groupName
+ */
+const givenUserIsMadeGroupSubadmin = (provider, username, groupName) => {
+  return provider.given('user is made group subadmin', {
+    username,
+    groupName
+  })
+}
+
 module.exports = {
   givenUserExists,
   givenUserDoesNotExist,
@@ -352,5 +364,6 @@ module.exports = {
   givenSystemTagExists,
   givenTagIsAssignedToFile,
   givenProviderBaseUrlIsReturned,
-  givenFileVersionLinkIsReturned
+  givenFileVersionLinkIsReturned,
+  givenUserIsMadeGroupSubadmin
 }

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -357,6 +357,25 @@ const givenFolderExistsInLastPublicShare = (provider, folderName, password) => {
   })
 }
 
+/**
+ * @param {object} provider
+ * @param {string} fileName
+ * @param {string} password
+ * @param {string} content
+ */
+const givenFileExistsInLastPublicShare = (
+  provider,
+  fileName,
+  password,
+  content
+) => {
+  return provider.given('file exists in last shared public share', {
+    fileName,
+    password,
+    content
+  })
+}
+
 module.exports = {
   givenUserExists,
   givenUserDoesNotExist,
@@ -377,5 +396,6 @@ module.exports = {
   givenFileVersionLinkIsReturned,
   givenUserIsMadeGroupSubadmin,
   givenUserIsAddedToGroup,
-  givenFolderExistsInLastPublicShare
+  givenFolderExistsInLastPublicShare,
+  givenFileExistsInLastPublicShare
 }

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -87,8 +87,7 @@ const givenResourceIsDeleted = (provider, username, resource) => {
  *
  * @param {object} provider
  * @param {string} username
- * @param {sring} userPassword
- * @param {sring} path
+ * @param {string} path
  * @param {string} shareWith
  * @param {object} optionalParams
  * available optional parameters
@@ -99,7 +98,6 @@ const givenResourceIsDeleted = (provider, username, resource) => {
 const givenUserShareExists = (
   provider,
   username,
-  userPassword,
   path,
   shareWith,
   optionalParams
@@ -107,7 +105,6 @@ const givenUserShareExists = (
   return provider
     .given('resource is shared', {
       username,
-      userPassword,
       path,
       shareType: SHARE_TYPE.user,
       shareWith,
@@ -120,8 +117,7 @@ const givenUserShareExists = (
  *
  * @param {object} provider
  * @param {string} username
- * @param {sring} userPassword
- * @param {sring} path
+ * @param {string} path
  * @param {string} shareWith
  * @param {object} optionalParams
  * available optional parameters
@@ -132,7 +128,6 @@ const givenUserShareExists = (
 const givenGroupShareExists = (
   provider,
   username,
-  userPassword,
   path,
   shareWith,
   optionalParams
@@ -140,7 +135,6 @@ const givenGroupShareExists = (
   return provider
     .given('resource is shared', {
       username,
-      userPassword,
       path,
       shareType: SHARE_TYPE.group,
       shareWith,
@@ -153,8 +147,7 @@ const givenGroupShareExists = (
  *
  * @param {object} provider
  * @param {string} username
- * @param {sring} userPassword
- * @param {sring} path
+ * @param {string} path
  * @param {object} optionalParams
  * available optional parameters
  * - name
@@ -167,14 +160,12 @@ const givenGroupShareExists = (
 const givenPublicShareExists = (
   provider,
   username,
-  userPassword,
   path,
   optionalParams
 ) => {
   return provider
     .given('resource is shared', {
       username,
-      userPassword,
       path,
       shareType: SHARE_TYPE.public,
       ...optionalParams
@@ -186,9 +177,9 @@ const givenPublicShareExists = (
  *
  * @param {object} provider
  * @param {string} username
- * @param {sring} password
- * @param {sring} resource
- * @param {sring} resourceType
+ * @param {string} password
+ * @param {string} resource
+ * @param {string} resourceType
  */
 const givenFileFolderIsCreated = (provider, username, password, resource, resourceType) => {
   if (resourceType === 'folder') {
@@ -203,10 +194,9 @@ const givenFileFolderIsCreated = (provider, username, password, resource, resour
  *
  * @param {object} provider
  * @param {string} username
- * @param {sring} userPassword
- * @param {sring} resource
+ * @param {string} resource
  * @param {number} shareType
- * @param {sring} shareWith
+ * @param {string} shareWith
  * @param {number} permissions
  * @param {string} expireDate
  * @param {object} attributes
@@ -216,7 +206,6 @@ const givenFileFolderIsCreated = (provider, username, password, resource, resour
 const givenResourceIsShared = async (
   provider,
   username,
-  userPassword,
   resource,
   shareType,
   shareWith,
@@ -230,7 +219,6 @@ const givenResourceIsShared = async (
     return givenPublicShareExists(
       provider,
       username,
-      userPassword,
       resource,
       {
         permissions,
@@ -245,7 +233,6 @@ const givenResourceIsShared = async (
     return givenUserShareExists(
       provider,
       username,
-      userPassword,
       resource,
       shareWith,
       {
@@ -259,7 +246,6 @@ const givenResourceIsShared = async (
     return givenGroupShareExists(
       provider,
       username,
-      userPassword,
       resource,
       shareWith,
       {
@@ -278,8 +264,8 @@ const givenResourceIsShared = async (
  *
  * @param {object} provider
  * @param {string} username
- * @param {sring} password
- * @param {sring} path
+ * @param {string} password
+ * @param {string} path
  */
 const givenFileIsMarkedFavorite = (provider, username, password, path) => {
   return provider
@@ -291,8 +277,8 @@ const givenFileIsMarkedFavorite = (provider, username, password, path) => {
  *
  * @param {object} provider
  * @param {string} username
- * @param {sring} password
- * @param {sring} tag tag name
+ * @param {string} password
+ * @param {string} tag tag name
  */
 const givenSystemTagExists = (provider, username, password, tag) => {
   return provider
@@ -304,9 +290,9 @@ const givenSystemTagExists = (provider, username, password, tag) => {
  *
  * @param {object} provider
  * @param {string} username
- * @param {sring} password
- * @param {sring} fileName
- * @param {sring} tagName
+ * @param {string} password
+ * @param {string} fileName
+ * @param {string} tagName
  */
 const givenTagIsAssignedToFile = (provider, username, password, fileName, tagName) => {
   return provider

--- a/tests/helpers/providerStateHelper.js
+++ b/tests/helpers/providerStateHelper.js
@@ -321,6 +321,20 @@ const givenProviderBaseUrlIsReturned = (provider) => {
   return provider.given('provider base url is returned')
 }
 
+/**
+ * @param {object} provider
+ * @param {string} username
+ * @param {string} fileName
+ * @param {string} number
+ */
+const givenFileVersionLinkIsReturned = (provider, username, fileName, number) => {
+  return provider.given('file version link is returned', {
+    username,
+    fileName,
+    number
+  })
+}
+
 module.exports = {
   givenUserExists,
   givenUserDoesNotExist,
@@ -337,5 +351,6 @@ module.exports = {
   givenFileIsMarkedFavorite,
   givenSystemTagExists,
   givenTagIsAssignedToFile,
-  givenProviderBaseUrlIsReturned
+  givenProviderBaseUrlIsReturned,
+  givenFileVersionLinkIsReturned
 }

--- a/tests/helpers/sharingHelper.js
+++ b/tests/helpers/sharingHelper.js
@@ -13,11 +13,10 @@ const publicFilesEndPoint = '/public-files'
  * share a file or folder using webDAV api.
  *
  * @param {string} username
- * @param {string} password
  * @param {object} shareParams
  * @returns {*} result of the fetch request
  */
-const shareResource = function (username, password, shareParams) {
+const shareResource = function (username, shareParams) {
   const params = validateParams(shareParams)
   return httpHelper.postOCS(
     sharesEndPoint,

--- a/tests/helpers/webdavHelper.js
+++ b/tests/helpers/webdavHelper.js
@@ -71,7 +71,7 @@ const deleteItem = function (user, itemName) {
   return httpHelper.delete(createDavPath(user, itemName), null, null, user)
 }
 
-const getFileId = function (user, password, itemName) {
+const getFileId = function (user, itemName) {
   const fileIdResult = httpHelper.propfind(
     createDavPath(user, itemName),
     '<?xml version="1.0"?>' +
@@ -88,7 +88,7 @@ const getFileId = function (user, password, itemName) {
   return fileIdResult.text().match(/<oc:fileid>([^<]*)<\/oc:fileid>/)[1]
 }
 
-const listVersionsFolder = function (user, password, fileId) {
+const listVersionsFolder = function (user, fileId) {
   const listResult = httpHelper.propfind(
     createDavPath(user, fileId, 'versions'),
     null,

--- a/tests/helpers/webdavHelper.js
+++ b/tests/helpers/webdavHelper.js
@@ -250,7 +250,7 @@ const createASystemTag = function (username, password, tag) {
  * @returns {*} result of the fetch request
  */
 const assignTagToFile = function (username, password, fileName, tagName) {
-  const fileId = getFileId(username, password, fileName)
+  const fileId = getFileId(username, fileName)
   const tagId = getTagId(username, password, tagName)
   return httpHelper.put(
     `/systemtags-relations/files/${fileId}/${tagId}`,

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -243,8 +243,8 @@ describe('provider testing', () => {
     },
     'resource is shared': (setup, parameters) => {
       if (setup) {
-        const { username, userPassword, ...shareParams } = parameters
-        const response = shareResource(username, userPassword, shareParams)
+        const { username, ...shareParams } = parameters
+        const response = shareResource(username, shareParams)
         const { status } = getOCSMeta(response)
 
         chai.assert.strictEqual(status, 'ok', `Sharing file/folder '${parameters.path}' failed`)

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -198,8 +198,8 @@ describe('provider testing', () => {
     },
     'file version link is returned': (setup, parameters) => {
       if (setup) {
-        const fileId = getFileId(parameters.username, parameters.password, parameters.fileName)
-        const versionsResult = listVersionsFolder(parameters.username, parameters.password, fileId)
+        const fileId = getFileId(parameters.username, parameters.fileName)
+        const versionsResult = listVersionsFolder(parameters.username, fileId)
         let nodeValue = ''
         parseString(versionsResult, function (err, result) {
           if (

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -36,7 +36,8 @@ describe('oc.publicFiles', function () {
     givenPublicShareExists,
     givenFolderExists,
     givenFileExists,
-    givenProviderBaseUrlIsReturned
+    givenProviderBaseUrlIsReturned,
+    givenFolderExistsInLastPublicShare
   } = require('./helpers/providerStateHelper')
 
   const publicLinkShareTokenPath = MatchersV3.fromProviderState(
@@ -562,7 +563,8 @@ describe('oc.publicFiles', function () {
               permissions: data.shareParams.permissions
             }
           )
-          await provider.given('folder exists in last shared public share', { folderName: 'foo', password: data.shareParams.password })
+          await givenFolderExistsInLastPublicShare(provider, 'foo', data.shareParams.password)
+          await provider
             .given('file exists in last shared public share', { fileName: testFile, password: data.shareParams.password })
             .uponReceiving(`as '${testUser}', a MOVE request to move a file to subfolder in public share ${data.description}`)
             .withRequest({
@@ -606,7 +608,8 @@ describe('oc.publicFiles', function () {
               permissions: data.shareParams.permissions
             }
           )
-          await provider.given('folder exists in last shared public share', { folderName: 'foo', password: data.shareParams.password })
+          await givenFolderExistsInLastPublicShare(provider, 'foo', data.shareParams.password)
+          await provider
             .uponReceiving(`as '${testUser}', a MOVE request to move a folder to different name in public share ${data.description}`)
             .withRequest({
               method: 'MOVE',

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -59,15 +59,8 @@ describe('oc.publicFiles', function () {
 
     await givenUserExists(provider, testUser)
     await givenFolderExists(provider, testUser, testFolder)
+    await givenPublicShareExists(provider, testUser, testFolder, { password, permissions: 15 })
     return provider
-      .given('resource is shared', {
-        username: testUser,
-        userPassword: testUserPassword,
-        path: testFolder,
-        shareType: 3,
-        permissions: 15,
-        password
-      })
       .uponReceiving(`as '${testUser}', a ${method} request to ${description}`)
       .withRequest({
         method: method,
@@ -107,15 +100,7 @@ describe('oc.publicFiles', function () {
 
     await givenUserExists(provider, testUser)
     await givenFolderExists(provider, testUser, testFolder)
-    await provider
-      .given('resource is shared', {
-        username: testUser,
-        userPassword: testUserPassword,
-        path: testFolder,
-        shareType: 3,
-        permissions: 15,
-        password
-      })
+    await givenPublicShareExists(provider, testUser, testFolder, { password, permissions: 15 })
 
     if (method === 'GET' || statusCode === 204) {
       await provider.given('file exists in last shared public share', { fileName: testFile, content: responseBody, password })
@@ -239,11 +224,7 @@ describe('oc.publicFiles', function () {
             for (let fileNum = 0; fileNum < testFiles.length; fileNum++) {
               await givenFileExists(provider, testUser, testFolder + '/' + testFiles[fileNum])
             }
-            if (data.shareParams.password) {
-              await givenPublicShareExists(provider, testUser, testUserPassword, testFolder, { password: data.shareParams.password })
-            } else {
-              await givenPublicShareExists(provider, testUser, testUserPassword, testFolder)
-            }
+            await givenPublicShareExists(provider, testUser, testFolder, { password: data.shareParams.password })
             return provider
               .uponReceiving(description)
               .withRequest({
@@ -367,11 +348,7 @@ describe('oc.publicFiles', function () {
 
             await givenUserExists(provider, testUser)
             await givenFileExists(provider, testUser, testFolder + '/' + testFiles[2])
-            if (data.shareParams.password) {
-              await givenPublicShareExists(provider, testUser, testUserPassword, testFolder, { password: data.shareParams.password })
-            } else {
-              await givenPublicShareExists(provider, testUser, testUserPassword, testFolder)
-            }
+            await givenPublicShareExists(provider, testUser, testFolder, { password: data.shareParams.password })
             return provider
               .uponReceiving(description)
               .withRequest({ method, path, headers })
@@ -529,20 +506,15 @@ describe('oc.publicFiles', function () {
           await givenProviderBaseUrlIsReturned(provider)
           await givenUserExists(provider, testUser)
           await givenFolderExists(provider, testUser, testFolder)
-          if (data.shareParams.password) {
-            await givenPublicShareExists(
-              provider,
-              testUser,
-              testUserPassword,
-              testFolder,
-              {
-                password: data.shareParams.password,
-                permissions: data.shareParams.permissions
-              }
-            )
-          } else {
-            await givenPublicShareExists(provider, testUser, testUserPassword, testFolder, { permissions: data.shareParams.permissions })
-          }
+          await givenPublicShareExists(
+            provider,
+            testUser,
+            testFolder,
+            {
+              password: data.shareParams.password,
+              permissions: data.shareParams.permissions
+            }
+          )
           await provider.given('file exists in last shared public share', { fileName: testFile, password: data.shareParams.password })
             .uponReceiving(`as '${testUser}', a MOVE request to move a file in public share ${data.description}`)
             .withRequest({
@@ -581,20 +553,15 @@ describe('oc.publicFiles', function () {
           await givenProviderBaseUrlIsReturned(provider)
           await givenUserExists(provider, testUser)
           await givenFolderExists(provider, testUser, testFolder)
-          if (data.shareParams.password) {
-            await givenPublicShareExists(
-              provider,
-              testUser,
-              testUserPassword,
-              testFolder,
-              {
-                password: data.shareParams.password,
-                permissions: data.shareParams.permissions
-              }
-            )
-          } else {
-            await givenPublicShareExists(provider, testUser, testUserPassword, testFolder, { permissions: data.shareParams.permissions })
-          }
+          await givenPublicShareExists(
+            provider,
+            testUser,
+            testFolder,
+            {
+              password: data.shareParams.password,
+              permissions: data.shareParams.permissions
+            }
+          )
           await provider.given('folder exists in last shared public share', { folderName: 'foo', password: data.shareParams.password })
             .given('file exists in last shared public share', { fileName: testFile, password: data.shareParams.password })
             .uponReceiving(`as '${testUser}', a MOVE request to move a file to subfolder in public share ${data.description}`)
@@ -630,20 +597,15 @@ describe('oc.publicFiles', function () {
           await givenProviderBaseUrlIsReturned(provider)
           await givenUserExists(provider, testUser)
           await givenFolderExists(provider, testUser, testFolder)
-          if (data.shareParams.password) {
-            await givenPublicShareExists(
-              provider,
-              testUser,
-              testUserPassword,
-              testFolder,
-              {
-                password: data.shareParams.password,
-                permissions: data.shareParams.permissions
-              }
-            )
-          } else {
-            await givenPublicShareExists(provider, testUser, testUserPassword, testFolder, { permissions: data.shareParams.permissions })
-          }
+          await givenPublicShareExists(
+            provider,
+            testUser,
+            testFolder,
+            {
+              password: data.shareParams.password,
+              permissions: data.shareParams.permissions
+            }
+          )
           await provider.given('folder exists in last shared public share', { folderName: 'foo', password: data.shareParams.password })
             .uponReceiving(`as '${testUser}', a MOVE request to move a folder to different name in public share ${data.description}`)
             .withRequest({
@@ -681,20 +643,15 @@ describe('oc.publicFiles', function () {
 
           await givenUserExists(provider, testUser)
           await givenFolderExists(provider, testUser, testFolder)
-          if (data.shareParams.password) {
-            await givenPublicShareExists(
-              provider,
-              testUser,
-              testUserPassword,
-              testFolder,
-              {
-                password: data.shareParams.password,
-                permissions: data.shareParams.permissions
-              }
-            )
-          } else {
-            await givenPublicShareExists(provider, testUser, testUserPassword, testFolder, { permissions: data.shareParams.permissions })
-          }
+          await givenPublicShareExists(
+            provider,
+            testUser,
+            testFolder,
+            {
+              password: data.shareParams.password,
+              permissions: data.shareParams.permissions
+            }
+          )
           await provider
             .uponReceiving(`as '${testUser}', a PROPFIND request to get file info of public share ${data.description}`)
             .withRequest({

--- a/tests/publicLinkTest.js
+++ b/tests/publicLinkTest.js
@@ -37,7 +37,8 @@ describe('oc.publicFiles', function () {
     givenFolderExists,
     givenFileExists,
     givenProviderBaseUrlIsReturned,
-    givenFolderExistsInLastPublicShare
+    givenFolderExistsInLastPublicShare,
+    givenFileExistsInLastPublicShare
   } = require('./helpers/providerStateHelper')
 
   const publicLinkShareTokenPath = MatchersV3.fromProviderState(
@@ -104,7 +105,7 @@ describe('oc.publicFiles', function () {
     await givenPublicShareExists(provider, testUser, testFolder, { password, permissions: 15 })
 
     if (method === 'GET' || statusCode === 204) {
-      await provider.given('file exists in last shared public share', { fileName: testFile, content: responseBody, password })
+      await givenFileExistsInLastPublicShare(provider, testFile, password, responseBody)
     }
 
     return provider
@@ -516,7 +517,8 @@ describe('oc.publicFiles', function () {
               permissions: data.shareParams.permissions
             }
           )
-          await provider.given('file exists in last shared public share', { fileName: testFile, password: data.shareParams.password })
+          await givenFileExistsInLastPublicShare(provider, testFile, data.shareParams.password)
+          await provider
             .uponReceiving(`as '${testUser}', a MOVE request to move a file in public share ${data.description}`)
             .withRequest({
               method: 'MOVE',
@@ -564,8 +566,8 @@ describe('oc.publicFiles', function () {
             }
           )
           await givenFolderExistsInLastPublicShare(provider, 'foo', data.shareParams.password)
+          await givenFileExistsInLastPublicShare(provider, testFile, data.shareParams.password)
           await provider
-            .given('file exists in last shared public share', { fileName: testFile, password: data.shareParams.password })
             .uponReceiving(`as '${testUser}', a MOVE request to move a file to subfolder in public share ${data.description}`)
             .withRequest({
               method: 'MOVE',

--- a/tests/sharingTest.js
+++ b/tests/sharingTest.js
@@ -73,8 +73,8 @@ describe('Main: Currently testing file/folder sharing,', function () {
   ) {
     const { shareId, shareToken } = getShareIdToken(resource, resourceType)
     await givenUserExists(provider, sharer)
-    await givenFileFolderIsCreated(provider, sharer, sharerPassword, resource, resourceType)
-    await givenResourceIsShared(provider, sharer, sharerPassword, resource, shareType, shareWith)
+    await givenFileFolderIsCreated(provider, sharer, resource, resourceType)
+    await givenResourceIsShared(provider, sharer, resource, shareType, shareWith)
 
     resource = '/' + resource
     const body = new XmlBuilder('1.0', '', 'ocs').build(ocs => {
@@ -109,7 +109,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
 
   const getSharesInteraction = async function (provider, resource, resourceType = 'file') {
     await givenUserExists(provider, sharer)
-    await givenFileFolderIsCreated(provider, sharer, sharerPassword, resource, resourceType)
+    await givenFileFolderIsCreated(provider, sharer, resource, resourceType)
 
     await givenUserExists(provider, sharee)
     await givenGroupExists(provider, testGroup)
@@ -169,8 +169,8 @@ describe('Main: Currently testing file/folder sharing,', function () {
   ) => {
     const { shareId, shareToken } = getShareIdToken(resource, resourceType)
     await givenUserExists(provider, sharer)
-    await givenFileFolderIsCreated(provider, sharer, sharerPassword, resource, resourceType)
-    await givenResourceIsShared(provider, sharer, sharerPassword, resource, shareType, shareWith)
+    await givenFileFolderIsCreated(provider, sharer, resource, resourceType)
+    await givenResourceIsShared(provider, sharer, resource, shareType, shareWith)
     resource = '/' + resource
 
     const body = new XmlBuilder('1.0', '', 'ocs').build(ocs => {
@@ -213,8 +213,8 @@ describe('Main: Currently testing file/folder sharing,', function () {
     const { shareId, shareToken } = getShareIdToken(resource, resourceType)
     let permissions = 1
     await givenUserExists(provider, sharer)
-    await givenFileFolderIsCreated(provider, sharer, sharerPassword, resource, resourceType)
-    await givenResourceIsShared(provider, sharer, sharerPassword, resource, shareType, shareWith)
+    await givenFileFolderIsCreated(provider, sharer, resource, resourceType)
+    await givenResourceIsShared(provider, sharer, resource, shareType, shareWith)
 
     if (formData.permissions) {
       permissions = formData.permissions
@@ -821,7 +821,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
       }
       async function shareGETExistingNonSharedFile (provider, name, fileName) {
         await givenUserExists(provider, sharer)
-        await givenFileFolderIsCreated(provider, sharer, sharerPassword, fileName)
+        await givenFileFolderIsCreated(provider, sharer, fileName)
         return provider
           .uponReceiving(`as '${sharer}', a GET request to get share information of existent but non-shared file '${name}'`)
           .withRequest({
@@ -870,7 +870,7 @@ describe('Main: Currently testing file/folder sharing,', function () {
       async function sharePOSTRequestWithExpirationDateSet (provider, fileEncoded, file) {
         await givenUserExists(provider, sharer)
         await givenUserExists(provider, sharee)
-        await givenFileFolderIsCreated(provider, sharer, sharerPassword, file)
+        await givenFileFolderIsCreated(provider, sharer, file)
         return provider
           .uponReceiving(`as '${sharer}', a POST request to share a file '${file}' to user with expiration date set`)
           .withRequest({

--- a/tests/sharingTest.js
+++ b/tests/sharingTest.js
@@ -114,9 +114,9 @@ describe('Main: Currently testing file/folder sharing,', function () {
     await givenUserExists(provider, sharee)
     await givenGroupExists(provider, testGroup)
     // shares file/folder with user, group and public link
-    await givenPublicShareExists(provider, sharer, sharerPassword, resource)
-    await givenUserShareExists(provider, sharer, sharerPassword, resource, sharee)
-    await givenGroupShareExists(provider, sharer, sharerPassword, resource, testGroup)
+    await givenPublicShareExists(provider, sharer, resource)
+    await givenUserShareExists(provider, sharer, resource, sharee)
+    await givenGroupShareExists(provider, sharer, resource, testGroup)
 
     resource = '/' + resource
     const body = new XmlBuilder('1.0', '', 'ocs').build(ocs => {

--- a/tests/userTest.js
+++ b/tests/userTest.js
@@ -26,7 +26,8 @@ describe('Main: Currently testing user management,', function () {
     givenGroupExists,
     givenUserExists,
     givenUserDoesNotExist,
-    givenUserIsMadeGroupSubadmin
+    givenUserIsMadeGroupSubadmin,
+    givenUserIsAddedToGroup
   } = require('./helpers/providerStateHelper')
 
   const getUserInformationInteraction = async function (provider, requestName, username, responseBody) {
@@ -156,7 +157,7 @@ describe('Main: Currently testing user management,', function () {
     if (username !== adminUsername && username !== config.nonExistentUser) {
       await givenUserExists(provider, username)
       await givenGroupExists(provider, config.testGroup)
-      await provider.given('user is added to group', { username: username, groupName: config.testGroup })
+      await givenUserIsAddedToGroup(provider, username, config.testGroup)
     }
     return provider
       .uponReceiving(`as '${adminUsername}', a GET request to get groups of ${requestName}`)

--- a/tests/userTest.js
+++ b/tests/userTest.js
@@ -25,7 +25,8 @@ describe('Main: Currently testing user management,', function () {
   const {
     givenGroupExists,
     givenUserExists,
-    givenUserDoesNotExist
+    givenUserDoesNotExist,
+    givenUserIsMadeGroupSubadmin
   } = require('./helpers/providerStateHelper')
 
   const getUserInformationInteraction = async function (provider, requestName, username, responseBody) {
@@ -253,7 +254,7 @@ describe('Main: Currently testing user management,', function () {
     if (username !== adminUsername && username !== config.nonExistentUser) {
       await givenUserExists(provider, username)
       await givenGroupExists(provider, config.testGroup)
-      await provider.given('user is made group subadmin', { username: username, groupName: config.testGroup })
+      await givenUserIsMadeGroupSubadmin(provider, username, config.testGroup)
     }
     return provider
       .uponReceiving(`as '${adminUsername}', a GET request to get subadmin groups of ${requestName}`)


### PR DESCRIPTION
For the Provider side tests, we have stateHandlers for pre-conditions. We have used state handlers directly in most of the tests but we also have state helper functions exactly for that.
State handler:
https://github.com/owncloud/owncloud-sdk/blob/4116766b9f90e6283d34bbb8eda2baae2ffaf02b/tests/providerTest.js#L112-L120

helper function:
https://github.com/owncloud/owncloud-sdk/blob/4116766b9f90e6283d34bbb8eda2baae2ffaf02b/tests/helpers/providerStateHelper.js#L25-L28

In this PR, I have refactored the tests to use state helper functions.

### Related issues
part of #1086