### PR TITLE
[full-ci][tests-only] use oCIS from the global long term cache

### DIFF
--- a/tests/drone/check-oCIS-cache.sh
+++ b/tests/drone/check-oCIS-cache.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+source .drone.env
+
+url="https://cache.owncloud.com/$CACHE_BUCKET/ocis-build/$OCIS_COMMITID/ocis"
+
+echo "Checking oCIS version - $OCIS_COMMITID in cache."
+echo "Downloading oCIS from '$url'."
+
+if curl --output /dev/null --silent --head --fail "$url"
+then
+	echo "oCIS binary for $OCIS_COMMITID already available in cache."
+	echo "Skipping the caching pipeline..."
+	# https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
+	# exit a Pipeline early without failing
+	exit 78
+else
+	echo "oCIS binary for $OCIS_COMMITID not available in cache."
+fi


### PR DESCRIPTION
**Description**
With this PR, the oCIS binary is cached inside the `cache_public_s3_bucket` as
```
s3/$CACHE_BUCKET/ocis-build/$OCIS_COMMITID
|__ ocis (binary)
``` 
The same setup is to be made on the owncloud/web CI, so that, if both repositories. uses the same commit id for oCIS, the binary can be shared.

**Related Issue:**
- Part of https://github.com/owncloud/QA/issues/756
- With https://github.com/owncloud/web/pull/7523

---
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>
