### PR TITLE
[tests-only][full-ci]Added function to get expiration date instead of constant expiration date

### DIFF
--- a/tests/config/config.sample.json
+++ b/tests/config/config.sample.json
@@ -34,7 +34,6 @@
       "JbdgMGkt3Cq6B0u"
     ],
     "testContent": "123456",
-    "expirationDate": "2022-10-01",
     "invalidPassword": "notAValidPassword",
     "testFileOcFileId": "00011689ocbmtsldwk1v",
     "testFileEtag": "5da4a95b395231cb3d82cdfb70ce1b45"

--- a/tests/helpers/sharingHelper.js
+++ b/tests/helpers/sharingHelper.js
@@ -130,11 +130,26 @@ const getShareIdToken = (resource, resourceType) => {
   return { shareId, shareToken }
 }
 
+/**
+ *
+ *
+ * @returns {String} expiration date (10+ days from current Date)
+ */
+const generateExpirationDate = () => {
+  const currentDate = new Date()
+  const additionalDaysToAdd = 10
+  // adding +10 days to the current data
+  currentDate.setDate(currentDate.getDate() + additionalDaysToAdd)
+  // extracting date in string like '2022-10-10' from currentDate which is in format like '2022-10-10T07:20:33.287Z'
+  return currentDate.toISOString().slice(0, 10)
+}
+
 module.exports = {
   shareResource,
   getShareInfoByPath,
   createFolderInLastPublicShare,
   createFileInLastPublicShare,
   toFormUrlEncoded,
-  getShareIdToken
+  getShareIdToken,
+  generateExpirationDate
 }

--- a/tests/sharingTest.js
+++ b/tests/sharingTest.js
@@ -3,7 +3,8 @@ import { MatchersV3, XmlBuilder } from '@pact-foundation/pact/v3'
 const { fromProviderState } = MatchersV3
 const {
   toFormUrlEncoded,
-  getShareIdToken
+  getShareIdToken,
+  generateExpirationDate
 } = require('./helpers/sharingHelper')
 
 const {
@@ -21,7 +22,6 @@ describe('Main: Currently testing file/folder sharing,', function () {
     testGroup,
     testFolder,
     nonExistentFile,
-    expirationDate,
     testFiles,
     testFilesId,
     testFilesPath,
@@ -46,6 +46,9 @@ describe('Main: Currently testing file/folder sharing,', function () {
 
   // TESTING CONFIGS
   const publicLinkPassword = '1234'
+
+  // Expiration Date
+  const expirationDate = generateExpirationDate()
 
   const validAuthHeaders = {
     authorization: getAuthHeaders(sharer, sharerPassword)


### PR DESCRIPTION
### Description
Previously a constant expiration date was used and the nightly was failing since the expiration date is gone date than the current date. This PR adds a function to that gets the expiration date (+10 days with current date).

### Related NIghtly Failed Issue
https://github.com/owncloud/owncloud-sdk/issues/1159