### PR TITLE
Use custom env  PACT_CONSUMER_VERSION_TAG for storing pact version tag

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -659,7 +659,7 @@ def changelog(ctx):
     }]
 
 def setPactConsumerTagEnv(ctx):
-    consumer_tag = ctx.build.source if ctx.build.event == "pull_request" else ctx.repo.name
+    consumer_tag = ctx.build.source if ctx.build.event == "pull_request" else ctx.repo.branch
 
     # replaces reserved and unsafe url characters with '-'
     # reserved: & $ + , / : ; = ? @ #

--- a/.drone.star
+++ b/.drone.star
@@ -394,16 +394,13 @@ def pactConsumerTests(ctx, uploadPact):
         },
         "commands": [
             setPactConsumerTagEnv(ctx),
-            "echo %s" % ctx.repo.name,
-            "echo %s" % ctx.build.source,
-            "echo %s" % ctx.build.event,
             "yarn test-consumer",
         ] + ([
             'curl -XPUT -H"Content-Type: application/json" -H"Authorization: Bearer $${PACTFLOW_TOKEN}" https://jankaritech.pactflow.io/pacts/provider/oc-server/consumer/owncloud-sdk/version/$${DRONE_COMMIT_SHA} -d @tests/pacts/owncloud-sdk-oc-server.json',
             'curl -XPUT -H"Content-Type: application/json" -H"Authorization: Bearer $${PACTFLOW_TOKEN}" https://jankaritech.pactflow.io/pacts/provider/oc-server-pendingOn-oc10/consumer/owncloud-sdk/version/$${DRONE_COMMIT_SHA} -d @tests/pacts/owncloud-sdk-oc-server-pendingOn-oc10.json',
             'curl -XPUT -H"Content-Type: application/json" -H"Authorization: Bearer $${PACTFLOW_TOKEN}" https://jankaritech.pactflow.io/pacts/provider/oc-server-pendingOn-ocis/consumer/owncloud-sdk/version/$${DRONE_COMMIT_SHA} -d @tests/pacts/owncloud-sdk-oc-server-pendingOn-ocis.json',
             'curl -XPUT -H"Content-Type: application/json" -H"Authorization: Bearer $${PACTFLOW_TOKEN}" https://jankaritech.pactflow.io/pacts/provider/oc-server-pendingOn-oc10-ocis/consumer/owncloud-sdk/version/$${DRONE_COMMIT_SHA} -d @tests/pacts/owncloud-sdk-oc-server-pendingOn-oc10-ocis.json',
-            'curl -XPUT -H"Content-Type: application/json" -H"Authorization: Bearer $${PACTFLOW_TOKEN}" https://jankaritech.pactflow.io/pacticipants/owncloud-sdk/versions/$${DRONE_COMMIT_SHA}/tags/$${PACT_CONSUMER_TAG}',
+            'curl -XPUT -H"Content-Type: application/json" -H"Authorization: Bearer $${PACTFLOW_TOKEN}" https://jankaritech.pactflow.io/pacticipants/owncloud-sdk/versions/$${DRONE_COMMIT_SHA}/tags/$${PACT_CONSUMER_VERSION_TAG}',
         ] if uploadPact else []),
     }]
 
@@ -668,7 +665,7 @@ def setPactConsumerTagEnv(ctx):
     # reserved: & $ + , / : ; = ? @ #
     # unsafe: <space> < > [ ] { } | \ ^ %
     REGEX = "[][&$+,/:;=?@#[:space:]<>{}|^%\\\\]"
-    return 'PACT_CONSUMER_TAG=`echo "%s" | sed -e "s/%s/-/g"`' % (consumer_tag, REGEX)
+    return 'export PACT_CONSUMER_VERSION_TAG=$(echo "%s" | sed -e "s/%s/-/g")' % (consumer_tag, REGEX)
 
 def checkStarlark():
     return [{

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -18,7 +18,10 @@ const TEST_TIMEOUT = 600000
 
 // environment variables
 const PACTFLOW_TOKEN = process.env.PACTFLOW_TOKEN
-const DRONE_SOURCE_BRANCH = process.env.DRONE_SOURCE_BRANCH
+const PACT_CONSUMER_TAG = process.env.PACT_CONSUMER_TAG
+console.log(`--------------\n
+\n${PACT_CONSUMER_TAG}
+\n--------------`)
 const PROVIDER_VERSION = process.env.PROVIDER_VERSION
 
 let lastSharedToken = ''
@@ -104,7 +107,7 @@ describe('provider testing', () => {
     defaultOpts.pactBrokerUrl = 'https://jankaritech.pactflow.io'
     defaultOpts.publishVerificationResult = true
     defaultOpts.pactBrokerToken = PACTFLOW_TOKEN
-    defaultOpts.consumerVersionTags = DRONE_SOURCE_BRANCH
+    defaultOpts.consumerVersionTags = PACT_CONSUMER_TAG
     defaultOpts.providerVersion = PROVIDER_VERSION
     defaultOpts.providerVersionTags = PROVIDER_VERSION
   }

--- a/tests/providerTest.js
+++ b/tests/providerTest.js
@@ -18,10 +18,7 @@ const TEST_TIMEOUT = 600000
 
 // environment variables
 const PACTFLOW_TOKEN = process.env.PACTFLOW_TOKEN
-const PACT_CONSUMER_TAG = process.env.PACT_CONSUMER_TAG
-console.log(`--------------\n
-\n${PACT_CONSUMER_TAG}
-\n--------------`)
+const PACT_CONSUMER_VERSION_TAG = process.env.PACT_CONSUMER_VERSION_TAG
 const PROVIDER_VERSION = process.env.PROVIDER_VERSION
 
 let lastSharedToken = ''
@@ -107,7 +104,7 @@ describe('provider testing', () => {
     defaultOpts.pactBrokerUrl = 'https://jankaritech.pactflow.io'
     defaultOpts.publishVerificationResult = true
     defaultOpts.pactBrokerToken = PACTFLOW_TOKEN
-    defaultOpts.consumerVersionTags = PACT_CONSUMER_TAG
+    defaultOpts.consumerVersionTags = PACT_CONSUMER_VERSION_TAG
     defaultOpts.providerVersion = PROVIDER_VERSION
     defaultOpts.providerVersionTags = PROVIDER_VERSION
   }


### PR DESCRIPTION
The nightly failure was due to the failure in downloading the correct consumer pact file using the tag. We are currently using `DRONE_SOURCE_BRANCH` to create a tag for the pact version and also to download the correct pact version using this tag. But in cron builds, this env will be `undefined` thus causing the failure to download the latest expected pact version using `DRONE_SOURCE_BRANCH` as a tag.

In this PR, I have created a custom env `PACT_CONSUMER_VERSION_TAG` to store the tag name for the pact files. The tag name will be the branch name like before but with some conditions. For PRs, the tag name will be the PR branch name and for push/tags events the tag name will be the repo default branch name (`master`). 

Fixes https://github.com/owncloud/owncloud-sdk/issues/1159