### PR TITLE
[tests-only]Bump ocis latest commit-id on sdk

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=b44b33e9f821fec2f08e34d1516660759ee6d44b
+OCIS_COMMITID=45644912b0e12986f1545ecf1d102f319a8757ae
 OCIS_BRANCH=master


### PR DESCRIPTION
### Description

Bump latest `oCIS` commit-id to `owncloud-sdk`

### Related Issue
https://github.com/owncloud/QA/issues/772