### PR TITLE
Use default workspace - make workspace consistent in all pipelines

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -17,18 +17,9 @@ DEFAULT_NODEJS_VERSION = "14"
 
 # directory dictionary
 dirs = {
-    "base": "/var/www/owncloud",
-    "ocis": "/var/www/owncloud/ocis-build",
-}
-
-# config dictionary
-config = {
-    "app": "owncloud-sdk",
-}
-
-sdk_workspace = {
-    "base": dirs["base"],
-    "path": config["app"],
+    "base": "/drone/src",
+    "oc10": "/var/www/owncloud",
+    "ocis": "/drone/src/ocis-build",
 }
 
 # minio mc environment variables
@@ -166,7 +157,6 @@ def cacheOcisPipeline(ctx):
         "kind": "pipeline",
         "type": "docker",
         "name": "cache-ocis",
-        "workspace": sdk_workspace,
         "clone": {
             "disable": True,
         },
@@ -466,7 +456,6 @@ def consumerTestPipeline(ctx, subFolderPath = "/"):
             "os": "linux",
             "arch": "amd64",
         },
-        "workspace": sdk_workspace,
         "steps": restoreBuildArtifactCache(ctx, "yarn", ".yarn") +
                  installYarn() +
                  prepareTestConfig(subFolderPath) +
@@ -494,7 +483,6 @@ def ocisProviderTestPipeline(ctx):
             "os": "linux",
             "arch": "amd64",
         },
-        "workspace": sdk_workspace,
         "steps": restoreBuildArtifactCache(ctx, "yarn", ".yarn") +
                  installYarn() +
                  prepareTestConfig() +
@@ -527,7 +515,9 @@ def oc10ProviderTestPipeline(ctx):
             "os": "linux",
             "arch": "amd64",
         },
-        "workspace": sdk_workspace,
+        "workspace": {
+            "base": dirs["oc10"],
+        },
         "steps": restoreBuildArtifactCache(ctx, "yarn", ".yarn") +
                  installYarn() +
                  prepareTestConfig() +
@@ -555,7 +545,6 @@ def publish(ctx):
             "os": "linux",
             "arch": "amd64",
         },
-        "workspace": sdk_workspace,
         "steps": buildDocs() +
                  restoreBuildArtifactCache(ctx, "dist", "dist") +
                  publishDocs() +


### PR DESCRIPTION
Use the default workspace and only use the custom workspace for the oc10 pipeline.

The problem is caused due to the inconsistency in the paths. We build cache using `/drone/src` as a workspace and in some other pipelines, we use `/var/www/owncloud` as the workspace dir. This difference in paths was causing the caches to not be in the desired location.
Pipelines using `/var/www/owncloud` as workspace dir weren't getting the caches actually.

Explained by these images:
1. Pipelines using `/var/www/owncloud` dir
```bash
➤ YN0013: │ 3 packages were already cached, 1227 had to be fetched
```
![Screenshot from 2022-12-06 10-10-43](https://user-images.githubusercontent.com/52366632/205814141-8826d5bc-0c64-478e-b46b-db0b698a3bda.png)

2. Pipelines using `/drone/src` dir
```bash
➤ YN0013: │ 1229 packages were already cached
```
![Screenshot from 2022-12-06 10-10-53](https://user-images.githubusercontent.com/52366632/205814795-a9831e68-f84a-4088-a29f-15f02e98c587.png)


`dist` is available now: https://drone.owncloud.com/owncloud/owncloud-sdk/4007/4/4

Fixes https://github.com/owncloud/owncloud-sdk/issues/1183