### PR TITLE
[tests-only][full-ci]Bump ocis commit id for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=b905e305491f5925afeffbed456be2154d6ba8fa
+OCIS_COMMITID=4cba6028f6aab1958d08c48f64a1f9e6b69516d3
 OCIS_BRANCH=master


### PR DESCRIPTION
This PR bumps `ocis/master` commit id for tests
Part of: https://github.com/owncloud/QA/issues/792