### PR TITLE
Allow removing expiration dates from space shares

### DIFF
--- a/changelog/unreleased/bugfix-allow-removing-space-expiration-date
+++ b/changelog/unreleased/bugfix-allow-removing-space-expiration-date
@@ -1,0 +1,6 @@
+Bugfix: Allow removing expiration dates from space shares
+
+We've fixed a bug where removing expiration dates from space shares was not possible.
+
+https://github.com/owncloud/owncloud-sdk/pull/1204
+https://github.com/owncloud/web/pull/8320

--- a/src/shareManagement.js
+++ b/src/shareManagement.js
@@ -155,6 +155,10 @@ class Shares {
 
     if (optionalParams) {
       postData = { ...postData, ...this._getOptionalParams(optionalParams) }
+
+      if (optionalParams.expireDate !== undefined) {
+        postData.expireDate = optionalParams.expireDate
+      }
     }
 
     return this.helpers._makeOCSrequest('POST', this.helpers.OCS_SERVICE_SHARE, 'shares', postData)


### PR DESCRIPTION
`optionalParams.expireDate` is empty when it's being removed from a share. Hence we need to check for `undefined` explicitly.

Needed for https://github.com/owncloud/web/pull/8320. 