### PR TITLE
[tests-only][full-ci]Bump commit id for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=ef37f668723dd475f23e2308bec442ff6e9c607f
+OCIS_COMMITID=5ad8e283b669a7270e6925bf653a636610e022ed
 OCIS_BRANCH=master


### PR DESCRIPTION
This PR bumps `ocis` commit id for tests
Part of: https://github.com/owncloud/QA/issues/799