### PR TITLE
[full-ci][tests-only]Bump PHP version to 7.4 for CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2,7 +2,7 @@
 OC_CI_ALPINE = "owncloudci/alpine:latest"
 OC_CI_GOLANG = "owncloudci/golang:1.19"
 OC_CI_NODEJS = "owncloudci/nodejs:%s"
-OC_CI_PHP = "owncloudci/php:7.3"
+OC_CI_PHP = "owncloudci/php:7.4"
 OC_UBUNTU = "owncloud/ubuntu:20.04"
 OC_CI_DRONE_CANCEL_PREVIOUS_BUILDS = "owncloudci/drone-cancel-previous-builds"
 OC_CI_WAIT_FOR = "owncloudci/wait-for:latest"


### PR DESCRIPTION
Currently CI is failing because of

```
+ cd /var/www/owncloud/server/
+ php occ config:system:set trusted_domains 1 --value=owncloud
This version of ownCloud requires at least PHP 7.4.0
You are currently running PHP 7.3.33-10+ubuntu18.04.1+deb.sury.org+1. Please update your PHP version.
```
So, this PR bumps the PHP version to 7.4, which is the required version
fixes: https://github.com/owncloud/owncloud-sdk/issues/1222
