### PR TITLE
[tests-only][full-ci]Bump ocis commit id for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=754cc767a5427525a8b5a6ce0c2e67aa240fe50d
+OCIS_COMMITID=7cb622f4b2342f5531dff2dec1a3c27f8ceed02f
 OCIS_BRANCH=master


### PR DESCRIPTION
This PR bumps commit id of ocis for tests.
Part of: https://github.com/owncloud/QA/issues/806