### PR TITLE
Add notifications features

### DIFF
--- a/changelog/unreleased/enhancement-add-notifications
+++ b/changelog/unreleased/enhancement-add-notifications
@@ -1,0 +1,7 @@
+Enhancement: Add notifications fields
+
+This enhancement adds extra fields on the update share method to accommodate the
+changes in CS3APIs (https://cs3org.github.io/cs3apis/#cs3.sharing.link.v1beta1.CreatePublicShareRequest),
+as well as the method to send a reminder notification about a share.
+
+https://github.com/owncloud/owncloud-sdk/pull/1234

--- a/src/shareManagement.js
+++ b/src/shareManagement.js
@@ -444,6 +444,15 @@ class Shares {
       if (optionalParams.attributes) {
         postData.attributes = optionalParams.attributes
       }
+      if (optionalParams.notifyUploads !== undefined) {
+        postData.notifyUploads = optionalParams.notifyUploads
+      }
+      if (optionalParams.notifyUploadsExtraRecipients !== undefined) {
+        postData.notifyUploadsExtraRecipients = optionalParams.notifyUploadsExtraRecipients
+      }
+      if (optionalParams.notifyAddresses !== undefined) {
+        postData.notifyAddresses = optionalParams.notifyAddresses
+      }
     }
 
     /* jshint unused: false */
@@ -476,6 +485,27 @@ class Shares {
         'shares/' + encodeURIComponent(shareId.toString()) + urlParamString
       ).then(() => {
         resolve(true)
+      }).catch(error => {
+        reject(error)
+      })
+    })
+  }
+
+  /**
+   * Send a share reminder notification
+   * @param   {number}   shareId   ID of the share to delete
+   * @returns {Promise.<status>}   string: Array of emails where notification was sent.
+   * @returns {Promise.<error>}    string: error message, if any.
+   */
+  notifyShare (shareId) {
+    return new Promise((resolve, reject) => {
+      this.helpers._makeOCSrequest('GET', this.helpers.OCS_SERVICE_SHARE,
+        'shares/' + encodeURIComponent(shareId.toString()) + '/notify', []
+      ).then(data => {
+        if (data.response.ok) {
+          resolve(data.data.recipients)
+        }
+        throw new Error(data.response.status + '/' + data.response.statusText)
       }).catch(error => {
         reject(error)
       })
@@ -598,6 +628,10 @@ class Shares {
 
     if (optionalParams.remoteUser) {
       data.shareType = this.helpers.OCS_SHARE_TYPE_REMOTE
+    }
+
+    if (optionalParams.notify) {
+      data.notify = optionalParams.notify
     }
 
     return data


### PR DESCRIPTION
Hi ownClouders :wave: 

This PR adds notification features to the SDK, to meet the changes in the [CS3APIs spec regarding notifications](https://cs3org.github.io/cs3apis/#cs3/sharing/link/v1beta1/link_api.proto), namely:

* The optional fields `notify_uploads` and `notify_uploads_extra_recipients`.

* A `notify` field to signal the backend to send a notification on a share creation.

It also includes a a `notifyShare` method to `shareManagement` that is used by web to send a notification reminder for a share.

These changes are already being used by the [CERNBox web](https://github.com/cernbox/web/commit/a2be88fa0510c36a63e419df2e08c72b37640992).
