### PR TITLE
[tests-only][full-ci] bumps ocis latest commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=db098fa4f5b98052987eb09736cc8a6c11d52631
+OCIS_COMMITID=9c3511d2b08de25b16be3d309d0a7710b6848747
 OCIS_BRANCH=master


### PR DESCRIPTION
This PR bumps latest ocis commit id.
Part of https://github.com/owncloud/QA/issues/824