### PR TITLE
update the drone.star in config rocketchat

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -754,7 +754,7 @@ def notify():
                 "image": PLUGINS_SLACK,
                 "settings": {
                     "webhook": {
-                        "from_secret": "rocketchat_chat_webhook",
+                        "from_secret": "rocketchat_talk_webhook",
                     },
                     "channel": ROCKETCHAT_CHANNEL,
                 },


### PR DESCRIPTION
This PR change the rocketchat notification server `chat` to `talk`.

Part of https://github.com/owncloud/QA/issues/846